### PR TITLE
feat(sdk): add single-room mode to SDK MCP bridge [INT-292]

### DIFF
--- a/packages/sdk/src/mcp/backends.ts
+++ b/packages/sdk/src/mcp/backends.ts
@@ -1,7 +1,11 @@
 import type { AdapterToolsProtocol } from "../contracts/protocols";
 import { mcpToolNames } from "../runtime/tools/schemas";
 import type { McpToolRegistration } from "./registrations";
-import { buildRoomScopedRegistrations } from "./registrations";
+import {
+  buildRoomScopedRegistrations,
+  buildSingleContextRegistrations,
+  resolveSingleRoomTools,
+} from "./registrations";
 import { ThenvoiMcpStdioServer } from "./stdio";
 import { ThenvoiMcpServer } from "./server";
 import { ThenvoiMcpSseServer } from "./sse";
@@ -19,29 +23,31 @@ export interface ThenvoiMcpBackend {
 export interface CreateThenvoiMcpBackendOptions {
   kind: ThenvoiMcpBackendKind;
   enableMemoryTools: boolean;
+  /**
+   * Returns the tools for a given room. In single-room mode (`multiRoom: false`),
+   * called once during init with `""` — must return the tools instance regardless of the argument.
+   */
   getToolsForRoom: (roomId: string) => AdapterToolsProtocol | undefined;
   additionalTools?: McpToolRegistration[];
+  multiRoom?: boolean;
 }
 
 export async function createThenvoiMcpBackend(
   options: CreateThenvoiMcpBackendOptions,
 ): Promise<ThenvoiMcpBackend> {
-  const registrations = buildRoomScopedRegistrations(
-    options.getToolsForRoom,
-    {
-      enableMemoryTools: options.enableMemoryTools,
-      enableContactTools: true,
-      additionalTools: options.additionalTools,
-    },
-  );
+  const registrationOptions = {
+    enableMemoryTools: options.enableMemoryTools,
+    enableContactTools: true,
+    additionalTools: options.additionalTools,
+  };
 
-  const allowedTools = mcpToolNames(new Set(registrations.map((registration) => registration.name)));
-
+  // SDK builds its own registrations and allowedTools internally — delegate entirely.
   if (options.kind === "sdk") {
     const { createThenvoiSdkMcpServer } = await import("./sdk");
     const server = createThenvoiSdkMcpServer({
-      enableMemoryTools: options.enableMemoryTools,
       getToolsForRoom: options.getToolsForRoom,
+      multiRoom: options.multiRoom,
+      enableMemoryTools: options.enableMemoryTools,
       additionalTools: options.additionalTools,
     });
 
@@ -53,9 +59,20 @@ export async function createThenvoiMcpBackend(
     };
   }
 
+  // Resolve tools once so non-SDK servers and registration building share the same instance.
+  const resolvedTools = options.multiRoom === false
+    ? resolveSingleRoomTools(options.getToolsForRoom)
+    : options.getToolsForRoom;
+
+  const registrations = options.multiRoom === false
+    ? buildSingleContextRegistrations(resolvedTools as AdapterToolsProtocol, registrationOptions)
+    : buildRoomScopedRegistrations(resolvedTools as (roomId: string) => AdapterToolsProtocol | undefined, registrationOptions);
+
+  const allowedTools = mcpToolNames(new Set(registrations.map((registration) => registration.name)));
+
   if (options.kind === "stdio") {
     const server = new ThenvoiMcpStdioServer({
-      tools: options.getToolsForRoom,
+      tools: resolvedTools,
       enableMemoryTools: options.enableMemoryTools,
       enableContactTools: true,
       additionalTools: options.additionalTools,
@@ -74,7 +91,7 @@ export async function createThenvoiMcpBackend(
 
   if (options.kind === "sse") {
     const server = new ThenvoiMcpSseServer({
-      tools: options.getToolsForRoom,
+      tools: resolvedTools,
       enableMemoryTools: options.enableMemoryTools,
       enableContactTools: true,
       additionalTools: options.additionalTools,
@@ -92,7 +109,7 @@ export async function createThenvoiMcpBackend(
   }
 
   const server = new ThenvoiMcpServer({
-    tools: options.getToolsForRoom,
+    tools: resolvedTools,
     enableMemoryTools: options.enableMemoryTools,
     enableContactTools: true,
     additionalTools: options.additionalTools,

--- a/packages/sdk/src/mcp/registrations.ts
+++ b/packages/sdk/src/mcp/registrations.ts
@@ -197,3 +197,18 @@ function serializeValue(value: unknown): string {
     return String(value);
   }
 }
+
+/**
+ * Resolves the single tools instance for single-room mode. Calls `getToolsForRoom("")`
+ * as the sentinel — callers in single-room mode must return their tools instance
+ * regardless of the room ID argument.
+ */
+export function resolveSingleRoomTools(
+  getToolsForRoom: (roomId: string) => AdapterToolsProtocol | undefined,
+): AdapterToolsProtocol {
+  const tools = getToolsForRoom("");
+  if (!tools) {
+    throw new Error("Single-room mode requires getToolsForRoom(\"\") to return a tools instance");
+  }
+  return tools;
+}

--- a/packages/sdk/src/mcp/sdk.ts
+++ b/packages/sdk/src/mcp/sdk.ts
@@ -10,14 +10,21 @@ import type { AdapterToolsProtocol } from "../contracts/protocols";
 import { mcpToolNames } from "../runtime/tools/schemas";
 import {
   buildRoomScopedRegistrations,
+  buildSingleContextRegistrations,
+  resolveSingleRoomTools,
   type McpToolRegistration,
 } from "./registrations";
 import { buildZodShape } from "./zod";
 
 export interface CreateThenvoiSdkMcpServerOptions {
   enableMemoryTools: boolean;
+  /**
+   * Returns the tools for a given room. In single-room mode (`multiRoom: false`),
+   * called once during init with `""` — must return the tools instance regardless of the argument.
+   */
   getToolsForRoom: (roomId: string) => AdapterToolsProtocol | undefined;
   additionalTools?: McpToolRegistration[];
+  multiRoom?: boolean;
 }
 
 export interface ThenvoiSdkMcpServer {
@@ -30,14 +37,15 @@ export interface ThenvoiSdkMcpServer {
 export function createThenvoiSdkMcpServer(
   options: CreateThenvoiSdkMcpServerOptions,
 ): ThenvoiSdkMcpServer {
-  const registrations = buildRoomScopedRegistrations(
-    options.getToolsForRoom,
-    {
-      enableMemoryTools: options.enableMemoryTools,
-      enableContactTools: true,
-      additionalTools: options.additionalTools,
-    },
-  );
+  const registrationOptions = {
+    enableMemoryTools: options.enableMemoryTools,
+    enableContactTools: true,
+    additionalTools: options.additionalTools,
+  };
+
+  const registrations = options.multiRoom === false
+    ? buildSingleContextRegistrations(resolveSingleRoomTools(options.getToolsForRoom), registrationOptions)
+    : buildRoomScopedRegistrations(options.getToolsForRoom, registrationOptions);
 
   const toolDefinitions = registrations.map(toSdkToolDefinition);
   const toolNames = new Set(registrations.map((r) => r.name));

--- a/packages/sdk/tests/claude-sdk-mcp.test.ts
+++ b/packages/sdk/tests/claude-sdk-mcp.test.ts
@@ -4,10 +4,8 @@ import type { AgentToolsProtocol } from "../src/core";
 import { createThenvoiSdkMcpServer } from "../src/mcp/sdk";
 
 describe("createThenvoiSdkMcpServer", () => {
-  it("builds thenvoi MCP tools and routes calls to room-scoped tool execution", async () => {
-    const calls: Array<{ name: string; args: Record<string, unknown> }> = [];
-
-    const roomTools: AgentToolsProtocol = {
+  function makeTools(calls: Array<{ name: string; args: Record<string, unknown> }>): AgentToolsProtocol {
+    return {
       capabilities: { peers: false, contacts: false, memory: false },
       sendMessage: async () => ({ ok: true }),
       sendEvent: async () => ({ ok: true }),
@@ -34,6 +32,12 @@ describe("createThenvoiSdkMcpServer", () => {
         return { ok: true };
       },
     };
+  }
+
+  it("builds thenvoi MCP tools and routes calls to room-scoped tool execution", async () => {
+    const calls: Array<{ name: string; args: Record<string, unknown> }> = [];
+
+    const roomTools = makeTools(calls);
 
     const bridge = createThenvoiSdkMcpServer({
       enableMemoryTools: false,
@@ -60,6 +64,37 @@ describe("createThenvoiSdkMcpServer", () => {
         args: {
           content: "hello",
           mentions: ["@a"],
+        },
+      },
+    ]);
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("builds thenvoi MCP tools without room_id when multiRoom is false", async () => {
+    const calls: Array<{ name: string; args: Record<string, unknown> }> = [];
+    const bridge = createThenvoiSdkMcpServer({
+      multiRoom: false,
+      enableMemoryTools: false,
+      getToolsForRoom: () => makeTools(calls),
+    });
+
+    const sendMessageTool = bridge.toolDefinitions.find((entry) => entry.name === "thenvoi_send_message");
+    expect(sendMessageTool).toBeDefined();
+    if (!sendMessageTool) {
+      throw new Error("thenvoi_send_message tool definition missing");
+    }
+
+    const result = await sendMessageTool.handler({
+      content: "hello",
+      mentions: ["@b"],
+    }, {});
+
+    expect(calls).toEqual([
+      {
+        name: "thenvoi_send_message",
+        args: {
+          content: "hello",
+          mentions: ["@b"],
         },
       },
     ]);

--- a/packages/sdk/tests/mcp-backends.test.ts
+++ b/packages/sdk/tests/mcp-backends.test.ts
@@ -25,6 +25,42 @@ describe("createThenvoiMcpBackend", () => {
     expect(backend.allowedTools).toContain("mcp__thenvoi__thenvoi_send_message");
   });
 
+  it("creates a single-room sdk backend without requiring room-scoped execution", async () => {
+    const calls: Array<{ name: string; args: Record<string, unknown> }> = [];
+    const tools = new FakeTools();
+    tools.executeToolCall = async (name: string, args: Record<string, unknown>) => {
+      calls.push({ name, args });
+      return { ok: true };
+    };
+
+    const backend = await createThenvoiMcpBackend({
+      kind: "sdk",
+      multiRoom: false,
+      enableMemoryTools: false,
+      getToolsForRoom: () => tools,
+    });
+    backends.push(backend);
+
+    expect(backend.kind).toBe("sdk");
+    expect(backend.allowedTools).toContain("mcp__thenvoi__thenvoi_send_message");
+
+    const toolDefinitions = (backend.server as { toolDefinitions: Array<{ name: string; handler: (args: Record<string, unknown>, ctx: Record<string, unknown>) => Promise<{ isError?: true }> }> }).toolDefinitions;
+    const sendMessage = toolDefinitions.find((tool) => tool.name === "thenvoi_send_message");
+    expect(sendMessage).toBeDefined();
+    if (!sendMessage) {
+      throw new Error("thenvoi_send_message tool definition missing");
+    }
+
+    const result = await sendMessage.handler({ content: "hello" }, {});
+    expect(result.isError).toBeUndefined();
+    expect(calls).toEqual([
+      {
+        name: "thenvoi_send_message",
+        args: { content: "hello" },
+      },
+    ]);
+  });
+
   it("creates an http backend and starts the local server", async () => {
     const backend = await createThenvoiMcpBackend({
       kind: "http",


### PR DESCRIPTION
## Summary
- add a single-room option to the Claude SDK MCP bridge and backend helpers
- reuse single-context MCP registrations when `multiRoom: false`
- cover the new bridge and backend path with tests

## Test plan
- [x] `pnpm --dir packages/sdk test -- claude-sdk-mcp.test.ts mcp-backends.test.ts mcp-registrations.test.ts`
- [x] `pnpm --dir packages/sdk typecheck`