### PR TITLE
feat: adopt Linear's structured Agent Plans API

### DIFF
--- a/packages/sdk/examples/linear-thenvoi/linear-thenvoi-bridge-agent.ts
+++ b/packages/sdk/examples/linear-thenvoi/linear-thenvoi-bridge-agent.ts
@@ -129,7 +129,7 @@ Rules:
   - linear_post_action for visible work progress
   - linear_post_error for failures
   - linear_post_response for the final answer and session completion
-  - linear_update_plan when you have a step list worth showing
+  - linear_update_plan when you have a step list worth showing (renders as a native checklist in the Linear Agent Session UI with live status indicators)
 - Start alone, but inspect available peers before deciding whether the bridge should handle the work itself.
 - Only use thenvoi_lookup_peers when the room does not already contain a clearly relevant collaborator or when you need to replace/expand the current set of specialists. Choose collaborators based on the actual request and the visible peer identity you observe, not from a fixed handoff graph.
 - If you choose a specialist who is not already present, add them to the room before you ask for work.

--- a/packages/sdk/src/integrations/linear/activities.ts
+++ b/packages/sdk/src/integrations/linear/activities.ts
@@ -8,6 +8,10 @@ export interface LinearActivityClient {
     agentSessionId: string;
     content: Record<string, unknown>;
   }): Promise<unknown>;
+  updateAgentSession?: (
+    id: string,
+    input: Record<string, unknown>,
+  ) => Promise<unknown>;
   updateIssue?: (
     issueId: string,
     input: Record<string, unknown>,
@@ -87,11 +91,30 @@ export async function postAction(
     parameter: "",
   });
 }
+const PLAN_STATUS_MAP: Record<PlanStep["status"], string> = {
+  pending: "pending",
+  in_progress: "inProgress",
+  completed: "completed",
+  failed: "canceled",
+};
+
 export async function updatePlan(
   client: LinearActivityClient,
   sessionId: string,
   steps: PlanStep[],
 ): Promise<void> {
+  if (typeof client.updateAgentSession === "function") {
+    const plan = {
+      steps: steps.map((step) => ({
+        content: step.title,
+        status: PLAN_STATUS_MAP[step.status],
+      })),
+    };
+
+    await client.updateAgentSession(sessionId, { plan });
+    return;
+  }
+
   const planSummary = steps
     .map((step) => {
       const icon =

--- a/packages/sdk/src/integrations/linear/activities.ts
+++ b/packages/sdk/src/integrations/linear/activities.ts
@@ -91,6 +91,7 @@ export async function postAction(
     parameter: "",
   });
 }
+
 const PLAN_STATUS_MAP: Record<PlanStep["status"], string> = {
   pending: "pending",
   in_progress: "inProgress",

--- a/packages/sdk/src/integrations/linear/activities.ts
+++ b/packages/sdk/src/integrations/linear/activities.ts
@@ -92,7 +92,9 @@ export async function postAction(
   });
 }
 
-const PLAN_STATUS_MAP: Record<PlanStep["status"], string> = {
+type LinearPlanStatus = "pending" | "inProgress" | "completed" | "canceled";
+
+const PLAN_STATUS_MAP: Record<PlanStep["status"], LinearPlanStatus> = {
   pending: "pending",
   in_progress: "inProgress",
   completed: "completed",
@@ -112,8 +114,12 @@ export async function updatePlan(
       })),
     };
 
-    await client.updateAgentSession(sessionId, { plan });
-    return;
+    try {
+      await client.updateAgentSession(sessionId, { plan });
+      return;
+    } catch {
+      // Fall through to legacy Thought-based plan
+    }
   }
 
   const planSummary = steps

--- a/packages/sdk/src/integrations/linear/activities.ts
+++ b/packages/sdk/src/integrations/linear/activities.ts
@@ -117,8 +117,8 @@ export async function updatePlan(
     try {
       await client.updateAgentSession(sessionId, { plan });
       return;
-    } catch {
-      // Fall through to legacy Thought-based plan
+    } catch (err) {
+      console.warn("updateAgentSession failed, falling back to legacy plan", err);
     }
   }
 

--- a/packages/sdk/src/integrations/linear/tools.ts
+++ b/packages/sdk/src/integrations/linear/tools.ts
@@ -105,7 +105,7 @@ export function createLinearTools(options: CreateLinearToolsOptions): CustomTool
   tools.push(
     {
       name: "linear_update_plan",
-      description: "Update the plan for the Linear agent session, showing progress on each step.",
+      description: "Update the structured plan for the Linear agent session. Renders as a native checklist in the Linear Agent Session UI with live status indicators.",
       schema: z.object({
         session_id: z.string().describe("The Linear agent session ID"),
         steps: z.array(z.object({

--- a/packages/sdk/tests/linear-activities.test.ts
+++ b/packages/sdk/tests/linear-activities.test.ts
@@ -113,6 +113,25 @@ describe("linear activities", () => {
     });
   });
 
+  it("updatePlan falls back to thought activity when updateAgentSession throws", async () => {
+    const client = makeMockClient();
+    client.updateAgentSession = vi.fn(async () => { throw new Error("mutation not found"); });
+    const steps: PlanStep[] = [
+      { title: "Analyze issue", status: "completed" },
+      { title: "Search codebase", status: "in_progress" },
+      { title: "Write fix", status: "pending" },
+      { title: "Old approach", status: "failed" },
+    ];
+
+    await updatePlan(client, "session-6", steps);
+
+    expect(client.updateAgentSession).toHaveBeenCalledOnce();
+    expect(client.calls).toHaveLength(1);
+    expect(client.calls[0]?.agentSessionId).toBe("session-6");
+    const body = (client.calls[0]?.content as { body: string }).body;
+    expect(body).toContain("**Plan:**");
+  });
+
   it("updatePlan falls back to thought activity when updateAgentSession is unavailable", async () => {
     const client = makeMockClient();
     delete (client as Partial<typeof client>).updateAgentSession;

--- a/packages/sdk/tests/linear-activities.test.ts
+++ b/packages/sdk/tests/linear-activities.test.ts
@@ -13,13 +13,20 @@ import {
 
 function makeMockClient(): LinearActivityClient & {
   calls: Array<{ agentSessionId: string; content: Record<string, unknown> }>;
+  sessionUpdates: Array<{ id: string; input: Record<string, unknown> }>;
 } {
   const calls: Array<{ agentSessionId: string; content: Record<string, unknown> }> = [];
+  const sessionUpdates: Array<{ id: string; input: Record<string, unknown> }> = [];
   return {
     calls,
+    sessionUpdates,
     createAgentActivity: vi.fn(async (input) => {
       calls.push(input);
       return { ok: true };
+    }),
+    updateAgentSession: vi.fn(async (id: string, input: Record<string, unknown>) => {
+      sessionUpdates.push({ id, input });
+      return { success: true };
     }),
   };
 }
@@ -80,8 +87,35 @@ describe("linear activities", () => {
     });
   });
 
-  it("updatePlan posts a thought with formatted plan steps", async () => {
+  it("updatePlan calls updateAgentSession with structured plan steps", async () => {
     const client = makeMockClient();
+    const steps: PlanStep[] = [
+      { title: "Analyze issue", status: "completed" },
+      { title: "Search codebase", status: "in_progress" },
+      { title: "Write fix", status: "pending" },
+      { title: "Old approach", status: "failed" },
+    ];
+
+    await updatePlan(client, "session-6", steps);
+
+    expect(client.calls).toHaveLength(0);
+    expect(client.sessionUpdates).toHaveLength(1);
+    expect(client.sessionUpdates[0]?.id).toBe("session-6");
+    expect(client.sessionUpdates[0]?.input).toEqual({
+      plan: {
+        steps: [
+          { content: "Analyze issue", status: "completed" },
+          { content: "Search codebase", status: "inProgress" },
+          { content: "Write fix", status: "pending" },
+          { content: "Old approach", status: "canceled" },
+        ],
+      },
+    });
+  });
+
+  it("updatePlan falls back to thought activity when updateAgentSession is unavailable", async () => {
+    const client = makeMockClient();
+    delete (client as Partial<typeof client>).updateAgentSession;
     const steps: PlanStep[] = [
       { title: "Analyze issue", status: "completed" },
       { title: "Search codebase", status: "in_progress" },

--- a/packages/sdk/tests/linear-tools.test.ts
+++ b/packages/sdk/tests/linear-tools.test.ts
@@ -57,6 +57,7 @@ class MemorySessionRoomStore implements SessionRoomStore {
 function makeMockClient(): LinearActivityClient {
   return {
     createAgentActivity: vi.fn(async () => ({ ok: true })),
+    updateAgentSession: vi.fn(async () => ({ success: true })),
     updateIssue: vi.fn(async () => ({ ok: true })),
     createComment: vi.fn(async () => ({ ok: true })),
     workflowStates: vi.fn(async ({ teamId }: { teamId?: string } = {}) => ({
@@ -206,7 +207,7 @@ describe("createLinearTools", () => {
     });
   });
 
-  it("linear_update_plan validates steps and calls the activity layer", async () => {
+  it("linear_update_plan validates steps and calls updateAgentSession with structured plan", async () => {
     const client = makeMockClient();
     const tools = createLinearTools({ client });
     const tool = tools.find((entry) => entry.name === "linear_update_plan")!;
@@ -220,7 +221,15 @@ describe("createLinearTools", () => {
     });
 
     expect(result).toEqual({ ok: true });
-    expect(client.createAgentActivity).toHaveBeenCalledOnce();
+    expect(client.createAgentActivity).not.toHaveBeenCalled();
+    expect(client.updateAgentSession).toHaveBeenCalledWith("sess-1", {
+      plan: {
+        steps: [
+          { content: "Step 1", status: "completed" },
+          { content: "Step 2", status: "inProgress" },
+        ],
+      },
+    });
   });
 
   it("rejects invalid input with Zod validation error", async () => {


### PR DESCRIPTION
## Summary
- Switches `linear_update_plan` from posting emoji-formatted text as a Thought activity to using Linear's native `agentSessionUpdate` mutation with a structured `plan` field
- Plans now render as a native checklist in the Linear Agent Session UI with live status indicators (`pending`, `inProgress`, `completed`, `canceled`)
- Adds `updateAgentSession` as an optional method on `LinearActivityClient`, with a graceful fallback to the legacy Thought-based plan when unavailable
- Maps internal statuses to Linear's plan statuses: `pending`→`pending`, `in_progress`→`inProgress`, `completed`→`completed`, `failed`→`canceled`

Closes INT-295

## Test plan
- [x] Existing tests updated to verify `updateAgentSession` is called with structured plan data
- [x] New fallback test verifies legacy Thought behavior when `updateAgentSession` is absent
- [x] All 540 tests pass
- [x] Build succeeds cleanly
- [ ] Manual verification in Linear Agent Session UI to confirm native plan rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)