### PR TITLE
feat: automatically set agent as delegate on Linear issues

### DIFF
--- a/packages/sdk/src/integrations/linear/bridge/handler.ts
+++ b/packages/sdk/src/integrations/linear/bridge/handler.ts
@@ -12,11 +12,12 @@ import type {
   SessionRoomRecord,
 } from "../types";
 import { dedupeHandles, stripHandlePrefix } from "../handles";
-import { postThought, postError } from "../activities";
+import { postThought, postAction, postError } from "../activities";
 import {
   buildBridgeMessage,
   detectSessionIntent,
   extractIssueAssigneeField,
+  extractIssueDelegateField,
   extractIssueStateField,
   extractIssueTeamId,
   extractIssueTeamKey,
@@ -136,6 +137,28 @@ export async function handleAgentSessionEvent(
     }
   }
 
+  // Auto-delegate: set the agent as delegate on the issue when no delegate exists.
+  if (action === "created" && issueId) {
+    const appUserId = input.payload.appUserId;
+    if (appUserId) {
+      try {
+        await trySetAgentAsDelegate({
+          linearClient: input.deps.linearClient,
+          issueId,
+          appUserId,
+          logger,
+        });
+      } catch (delegateError) {
+        logger.warn("linear_thenvoi_bridge.auto_delegate_failed", {
+          sessionId,
+          issueId,
+          appUserId,
+          error: delegateError instanceof Error ? delegateError.message : String(delegateError),
+        });
+      }
+    }
+  }
+
   let roomRecord: SessionRoomRecord | null = null;
   try {
     const hostAgentHandle = await resolveHostAgentHandle({
@@ -205,6 +228,10 @@ export async function handleAgentSessionEvent(
       issueAssigneeName:
         extractIssueAssigneeField(input.payload.agentSession.issue, "displayName")
         ?? extractIssueAssigneeField(input.payload.agentSession.issue, "name"),
+      issueDelegateId: extractIssueDelegateField(input.payload.agentSession.issue, "id"),
+      issueDelegateName:
+        extractIssueDelegateField(input.payload.agentSession.issue, "displayName")
+        ?? extractIssueDelegateField(input.payload.agentSession.issue, "name"),
       commentBody: input.payload.agentSession.comment?.body,
       commentId: input.payload.agentSession.comment?.id,
       sessionIntent,
@@ -374,6 +401,32 @@ function normalizeOptionalHandle(handle: string | null | undefined): string | nu
 
   const normalized = stripHandlePrefix(handle);
   return normalized.length > 0 ? normalized : null;
+}
+
+async function trySetAgentAsDelegate(input: {
+  linearClient: HandleAgentSessionEventInput["deps"]["linearClient"];
+  issueId: string;
+  appUserId: string;
+  logger: Logger;
+}): Promise<void> {
+  const issue = await input.linearClient.issue(input.issueId);
+  const existingDelegateId = issue.delegateId;
+  if (existingDelegateId) {
+    input.logger.info("linear_thenvoi_bridge.delegate_already_set", {
+      issueId: input.issueId,
+      existingDelegateId,
+    });
+    return;
+  }
+
+  await input.linearClient.updateIssue(input.issueId, {
+    delegateId: input.appUserId,
+  });
+
+  input.logger.info("linear_thenvoi_bridge.delegate_set", {
+    issueId: input.issueId,
+    delegateId: input.appUserId,
+  });
 }
 
 async function resolveHostAgentHandle(input: {

--- a/packages/sdk/src/integrations/linear/bridge/handler.ts
+++ b/packages/sdk/src/integrations/linear/bridge/handler.ts
@@ -138,7 +138,7 @@ export async function handleAgentSessionEvent(
   }
 
   // Auto-delegate: fire in background, runs concurrently with room resolution (best-effort).
-  let delegatePromise: Promise<void> | undefined;
+  let delegatePromise: Promise<boolean> | undefined;
   if (action === "created" && issueId) {
     const appUserId = input.payload.appUserId;
     if (appUserId) {
@@ -154,6 +154,7 @@ export async function handleAgentSessionEvent(
           appUserId,
           error: delegateError instanceof Error ? delegateError.message : String(delegateError),
         });
+        return false;
       });
     }
   }
@@ -203,6 +204,18 @@ export async function handleAgentSessionEvent(
       logger,
     });
 
+    // Await auto-delegate before building the message so delegate info is up-to-date.
+    const delegateWasSet = await delegatePromise?.catch(() => false);
+
+    let issueDelegateId = extractIssueDelegateField(input.payload.agentSession.issue, "id");
+    let issueDelegateName: string | null =
+      extractIssueDelegateField(input.payload.agentSession.issue, "displayName")
+      ?? extractIssueDelegateField(input.payload.agentSession.issue, "name");
+    if (delegateWasSet && input.payload.appUserId) {
+      issueDelegateId = input.payload.appUserId;
+      issueDelegateName = issueDelegateName ?? input.payload.appUserId;
+    }
+
     const message = buildBridgeMessage({
       sessionId,
       issueId,
@@ -227,10 +240,8 @@ export async function handleAgentSessionEvent(
       issueAssigneeName:
         extractIssueAssigneeField(input.payload.agentSession.issue, "displayName")
         ?? extractIssueAssigneeField(input.payload.agentSession.issue, "name"),
-      issueDelegateId: extractIssueDelegateField(input.payload.agentSession.issue, "id"),
-      issueDelegateName:
-        extractIssueDelegateField(input.payload.agentSession.issue, "displayName")
-        ?? extractIssueDelegateField(input.payload.agentSession.issue, "name"),
+      issueDelegateId,
+      issueDelegateName,
       commentBody: input.payload.agentSession.comment?.body,
       commentId: input.payload.agentSession.comment?.id,
       sessionIntent,
@@ -343,7 +354,8 @@ export async function handleAgentSessionEvent(
 
     throw error;
   } finally {
-    await delegatePromise;
+    // Ensure the delegate promise is settled even if the handler threw before awaiting it above.
+    await delegatePromise?.catch(() => {});
   }
 }
 
@@ -409,7 +421,7 @@ async function trySetAgentAsDelegate(input: {
   issueId: string;
   appUserId: string;
   logger: Logger;
-}): Promise<void> {
+}): Promise<boolean> {
   const issue = await input.linearClient.issue(input.issueId);
   const existingDelegateId = issue.delegateId;
   if (existingDelegateId) {
@@ -417,7 +429,7 @@ async function trySetAgentAsDelegate(input: {
       issueId: input.issueId,
       existingDelegateId,
     });
-    return;
+    return false;
   }
 
   await input.linearClient.updateIssue(input.issueId, {
@@ -428,6 +440,7 @@ async function trySetAgentAsDelegate(input: {
     issueId: input.issueId,
     delegateId: input.appUserId,
   });
+  return true;
 }
 
 async function resolveHostAgentHandle(input: {

--- a/packages/sdk/src/integrations/linear/bridge/handler.ts
+++ b/packages/sdk/src/integrations/linear/bridge/handler.ts
@@ -138,7 +138,7 @@ export async function handleAgentSessionEvent(
   }
 
   // Auto-delegate: fire in background, runs concurrently with room resolution (best-effort).
-  let delegatePromise: Promise<boolean> | undefined;
+  let delegatePromise: Promise<{ set: boolean; delegateName: string | null }> | undefined;
   if (action === "created" && issueId) {
     const appUserId = input.payload.appUserId;
     if (appUserId) {
@@ -154,7 +154,7 @@ export async function handleAgentSessionEvent(
           appUserId,
           error: delegateError instanceof Error ? delegateError.message : String(delegateError),
         });
-        return false;
+        return { set: false, delegateName: null };
       });
     }
   }
@@ -205,15 +205,15 @@ export async function handleAgentSessionEvent(
     });
 
     // Await auto-delegate before building the message so delegate info is up-to-date.
-    const delegateWasSet = await delegatePromise?.catch(() => false);
+    const delegateResult = await delegatePromise?.catch(() => ({ set: false, delegateName: null as string | null }));
 
     let issueDelegateId = extractIssueDelegateField(input.payload.agentSession.issue, "id");
     let issueDelegateName: string | null =
       extractIssueDelegateField(input.payload.agentSession.issue, "displayName")
       ?? extractIssueDelegateField(input.payload.agentSession.issue, "name");
-    if (delegateWasSet && input.payload.appUserId) {
+    if (delegateResult?.set && input.payload.appUserId) {
       issueDelegateId = input.payload.appUserId;
-      issueDelegateName = issueDelegateName ?? input.payload.appUserId;
+      issueDelegateName = delegateResult.delegateName ?? input.payload.appUserId;
     }
 
     const message = buildBridgeMessage({
@@ -421,7 +421,7 @@ async function trySetAgentAsDelegate(input: {
   issueId: string;
   appUserId: string;
   logger: Logger;
-}): Promise<boolean> {
+}): Promise<{ set: boolean; delegateName: string | null }> {
   const issue = await input.linearClient.issue(input.issueId);
   const existingDelegateId = issue.delegateId;
   if (existingDelegateId) {
@@ -429,18 +429,28 @@ async function trySetAgentAsDelegate(input: {
       issueId: input.issueId,
       existingDelegateId,
     });
-    return false;
+    return { set: false, delegateName: null };
   }
 
   await input.linearClient.updateIssue(input.issueId, {
     delegateId: input.appUserId,
   });
 
+  // Re-fetch the issue to get the delegate's display name for the bridge message.
+  let delegateName: string | null = null;
+  try {
+    const updated = await input.linearClient.issue(input.issueId);
+    const delegate = await updated.delegate;
+    delegateName = delegate?.displayName ?? delegate?.name ?? null;
+  } catch {
+    // Best-effort: if re-fetch fails, the caller falls back to appUserId.
+  }
+
   input.logger.info("linear_thenvoi_bridge.delegate_set", {
     issueId: input.issueId,
     delegateId: input.appUserId,
   });
-  return true;
+  return { set: true, delegateName };
 }
 
 async function resolveHostAgentHandle(input: {

--- a/packages/sdk/src/integrations/linear/bridge/handler.ts
+++ b/packages/sdk/src/integrations/linear/bridge/handler.ts
@@ -205,7 +205,8 @@ export async function handleAgentSessionEvent(
     });
 
     // Await auto-delegate before building the message so delegate info is up-to-date.
-    const delegateResult = await delegatePromise?.catch(() => ({ set: false, delegateName: null as string | null }));
+    // The promise already has a .catch() at creation that converts errors to { set: false, delegateName: null }.
+    const delegateResult = await delegatePromise;
 
     let issueDelegateId = extractIssueDelegateField(input.payload.agentSession.issue, "id");
     let issueDelegateName: string | null =
@@ -353,9 +354,6 @@ export async function handleAgentSessionEvent(
     }
 
     throw error;
-  } finally {
-    // Ensure the delegate promise is settled even if the handler threw before awaiting it above.
-    await delegatePromise?.catch(() => {});
   }
 }
 

--- a/packages/sdk/src/integrations/linear/bridge/handler.ts
+++ b/packages/sdk/src/integrations/linear/bridge/handler.ts
@@ -12,7 +12,7 @@ import type {
   SessionRoomRecord,
 } from "../types";
 import { dedupeHandles, stripHandlePrefix } from "../handles";
-import { postThought, postAction, postError } from "../activities";
+import { postThought, postError } from "../activities";
 import {
   buildBridgeMessage,
   detectSessionIntent,

--- a/packages/sdk/src/integrations/linear/bridge/handler.ts
+++ b/packages/sdk/src/integrations/linear/bridge/handler.ts
@@ -137,25 +137,24 @@ export async function handleAgentSessionEvent(
     }
   }
 
-  // Auto-delegate: set the agent as delegate on the issue when no delegate exists.
+  // Auto-delegate: fire in background, runs concurrently with room resolution (best-effort).
+  let delegatePromise: Promise<void> | undefined;
   if (action === "created" && issueId) {
     const appUserId = input.payload.appUserId;
     if (appUserId) {
-      try {
-        await trySetAgentAsDelegate({
-          linearClient: input.deps.linearClient,
-          issueId,
-          appUserId,
-          logger,
-        });
-      } catch (delegateError) {
+      delegatePromise = trySetAgentAsDelegate({
+        linearClient: input.deps.linearClient,
+        issueId,
+        appUserId,
+        logger,
+      }).catch((delegateError) => {
         logger.warn("linear_thenvoi_bridge.auto_delegate_failed", {
           sessionId,
           issueId,
           appUserId,
           error: delegateError instanceof Error ? delegateError.message : String(delegateError),
         });
-      }
+      });
     }
   }
 
@@ -343,6 +342,8 @@ export async function handleAgentSessionEvent(
     }
 
     throw error;
+  } finally {
+    await delegatePromise;
   }
 }
 

--- a/packages/sdk/src/integrations/linear/bridge/handler.ts
+++ b/packages/sdk/src/integrations/linear/bridge/handler.ts
@@ -323,6 +323,10 @@ export async function handleAgentSessionEvent(
       action,
     });
   } catch (error) {
+    // Ensure auto-delegate has settled so we don't leave a fire-and-forget side-effect running
+    // after the handler returns an error (the promise already has .catch, so this won't throw).
+    await delegatePromise;
+
     // Report errors back to Linear before re-throwing.
     try {
       await postError(

--- a/packages/sdk/src/integrations/linear/bridge/message.ts
+++ b/packages/sdk/src/integrations/linear/bridge/message.ts
@@ -22,6 +22,8 @@ export function buildBridgeMessage(input: {
   issueStateType: string | null | undefined;
   issueAssigneeId: string | null | undefined;
   issueAssigneeName: string | null | undefined;
+  issueDelegateId: string | null | undefined;
+  issueDelegateName: string | null | undefined;
   commentBody: string | null | undefined;
   commentId: string | null | undefined;
   sessionIntent: SessionIntent;
@@ -63,6 +65,12 @@ export function buildBridgeMessage(input: {
   const issueAssigneeIdLine = input.issueAssigneeId
     ? `issue_assignee_id: ${input.issueAssigneeId}`
     : "issue_assignee_id: none";
+  const issueDelegateLine = input.issueDelegateName
+    ? `issue_delegate: ${input.issueDelegateName}`
+    : "issue_delegate: none";
+  const issueDelegateIdLine = input.issueDelegateId
+    ? `issue_delegate_id: ${input.issueDelegateId}`
+    : "issue_delegate_id: none";
   const sessionStatusLine = input.sessionStatus ? `session_status: ${input.sessionStatus}` : "session_status: none";
   const sessionTypeLine = input.sessionType ? `session_type: ${input.sessionType}` : "session_type: none";
   const sessionCreatedLine = input.sessionCreatedAt
@@ -111,6 +119,8 @@ Linear session context:
 - ${issueStateTypeLine}
 - ${issueAssigneeLine}
 - ${issueAssigneeIdLine}
+- ${issueDelegateLine}
+- ${issueDelegateIdLine}
 - inferred_session_intent: ${input.sessionIntent}
 - writeback_mode: ${input.writebackMode}
 - ${appUserLine}
@@ -217,6 +227,12 @@ export function extractIssueStateField(issue: unknown, field: "id" | "name" | "t
 export function extractIssueAssigneeField(issue: unknown, field: "id" | "name" | "displayName"): string | null {
   const assignee = extractNestedRecord(issue, "assignee");
   const value = assignee?.[field];
+  return typeof value === "string" ? value : null;
+}
+
+export function extractIssueDelegateField(issue: unknown, field: "id" | "name" | "displayName"): string | null {
+  const delegate = extractNestedRecord(issue, "delegate");
+  const value = delegate?.[field];
   return typeof value === "string" ? value : null;
 }
 

--- a/packages/sdk/src/integrations/linear/tools.ts
+++ b/packages/sdk/src/integrations/linear/tools.ts
@@ -197,6 +197,7 @@ function addIssueTools(input: {
         priority: z.number().int().min(0).max(4).optional().describe("Priority 0-4"),
         state_id: z.string().optional().describe("Workflow state ID"),
         assignee_id: z.string().nullable().optional().describe("Assignee user ID, or null to unassign"),
+        delegate_id: z.string().nullable().optional().describe("Agent user ID to delegate the issue to, or null to clear delegate"),
         estimate: z.number().int().optional().describe("Estimate points"),
         due_date: z.string().optional().describe("Due date ISO string"),
       }),
@@ -212,6 +213,7 @@ function addIssueTools(input: {
           || args.priority !== undefined
           || args.state_id !== undefined
           || args.assignee_id !== undefined
+          || args.delegate_id !== undefined
           || args.estimate !== undefined
           || args.due_date !== undefined
         );
@@ -227,6 +229,7 @@ function addIssueTools(input: {
             ...(args.priority !== undefined ? { priority: args.priority } : {}),
             ...(args.state_id !== undefined ? { stateId: args.state_id } : {}),
             ...(args.assignee_id !== undefined ? { assigneeId: args.assignee_id } : {}),
+            ...(args.delegate_id !== undefined ? { delegateId: args.delegate_id } : {}),
             ...(args.estimate !== undefined ? { estimate: args.estimate } : {}),
             ...(args.due_date !== undefined ? { dueDate: args.due_date } : {}),
           },
@@ -304,6 +307,8 @@ async function readIssue(client: LinearActivityClient, issueId: string): Promise
     updatedAt?: string | null;
     state?: { id?: string | null; name?: string | null; type?: string | null } | null;
     assignee?: { id?: string | null; name?: string | null; displayName?: string | null } | null;
+    delegate?: { id?: string | null; name?: string | null; displayName?: string | null } | null;
+    delegateId?: string | null;
     team?: { id?: string | null; key?: string | null; name?: string | null } | null;
   };
 
@@ -332,6 +337,13 @@ async function readIssue(client: LinearActivityClient, issueId: string): Promise
           name: issue.assignee.displayName ?? issue.assignee.name ?? null,
         }
         : null,
+      delegate: issue.delegate
+        ? {
+          id: issue.delegate.id ?? null,
+          name: issue.delegate.displayName ?? issue.delegate.name ?? null,
+        }
+        : null,
+      delegate_id: issue.delegateId ?? null,
       team: issue.team
         ? {
           id: issue.team.id ?? null,

--- a/packages/sdk/src/integrations/linear/tools.ts
+++ b/packages/sdk/src/integrations/linear/tools.ts
@@ -289,28 +289,30 @@ function resolveOptionalIssueId(
   return args.issue_id;
 }
 
+interface LinearIssueSnapshot {
+  id: string;
+  identifier?: string | null;
+  title?: string | null;
+  description?: string | null;
+  url?: string | null;
+  priority?: number | null;
+  estimate?: number | null;
+  dueDate?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  state?: { id?: string | null; name?: string | null; type?: string | null } | null;
+  assignee?: { id?: string | null; name?: string | null; displayName?: string | null } | null;
+  delegate?: { id?: string | null; name?: string | null; displayName?: string | null } | null;
+  delegateId?: string | null;
+  team?: { id?: string | null; key?: string | null; name?: string | null } | null;
+}
+
 async function readIssue(client: LinearActivityClient, issueId: string): Promise<unknown> {
   if (typeof client.issue !== "function") {
     throw new Error("linear_get_issue is unavailable: Linear client does not support issue().");
   }
 
-  const issue = await client.issue(issueId) as {
-    id: string;
-    identifier?: string | null;
-    title?: string | null;
-    description?: string | null;
-    url?: string | null;
-    priority?: number | null;
-    estimate?: number | null;
-    dueDate?: string | null;
-    createdAt?: string | null;
-    updatedAt?: string | null;
-    state?: { id?: string | null; name?: string | null; type?: string | null } | null;
-    assignee?: { id?: string | null; name?: string | null; displayName?: string | null } | null;
-    delegate?: { id?: string | null; name?: string | null; displayName?: string | null } | null;
-    delegateId?: string | null;
-    team?: { id?: string | null; key?: string | null; name?: string | null } | null;
-  };
+  const issue = await client.issue(issueId) as LinearIssueSnapshot;
 
   return {
     issue: {

--- a/packages/sdk/tests/linear-bridge-room-strategy.test.ts
+++ b/packages/sdk/tests/linear-bridge-room-strategy.test.ts
@@ -207,6 +207,8 @@ function makePayload(sessionId: string, issueId: string) {
 function makeLinearClient(): HandleAgentSessionEventInput["deps"]["linearClient"] {
   return {
     createAgentActivity: async () => ({ ok: true }),
+    issue: async () => ({ id: "issue-1", delegateId: undefined }),
+    updateIssue: async () => ({ success: true }),
   } as unknown as HandleAgentSessionEventInput["deps"]["linearClient"];
 }
 

--- a/packages/sdk/tests/linear-bridge-room-strategy.test.ts
+++ b/packages/sdk/tests/linear-bridge-room-strategy.test.ts
@@ -207,7 +207,7 @@ function makePayload(sessionId: string, issueId: string) {
 function makeLinearClient(): HandleAgentSessionEventInput["deps"]["linearClient"] {
   return {
     createAgentActivity: async () => ({ ok: true }),
-    issue: async () => ({ id: "issue-1", delegateId: undefined }),
+    issue: async () => ({ id: "issue-1", delegateId: null }),
     updateIssue: async () => ({ success: true }),
   } as unknown as HandleAgentSessionEventInput["deps"]["linearClient"];
 }

--- a/packages/sdk/tests/linear-bridge-webhook-actions.test.ts
+++ b/packages/sdk/tests/linear-bridge-webhook-actions.test.ts
@@ -594,6 +594,15 @@ describe("linear bridge webhook actions", () => {
     const restApi = new LinearThenvoiExampleRestApi();
     const store = new MemorySessionRoomStore();
     const linearClient = makeLinearClient({ delegateId: null });
+    // First call: check existing delegate (none). Second call: re-fetch after setting delegate.
+    linearClient.issue
+      .mockReset()
+      .mockResolvedValueOnce({ id: "issue-1", delegateId: null })
+      .mockResolvedValueOnce({
+        id: "issue-1",
+        delegateId: "app-user",
+        delegate: { id: "app-user", name: "Thenvoi Agent", displayName: "Thenvoi Agent" },
+      });
 
     await handleAgentSessionEvent({
       payload: makePayload("created"),
@@ -605,8 +614,9 @@ describe("linear bridge webhook actions", () => {
     expect(linearClient.updateIssue).toHaveBeenCalledWith("issue-1", {
       delegateId: "app-user",
     });
-    // Bridge message should reflect the newly-set delegate, not the stale webhook payload.
+    // Bridge message should reflect the newly-set delegate with a human-readable name.
     expect(restApi.roomEvents[0]?.content).toContain("issue_delegate_id: app-user");
+    expect(restApi.roomEvents[0]?.content).toContain("issue_delegate: Thenvoi Agent");
   });
 
   it("does not overwrite existing delegate on created event", async () => {

--- a/packages/sdk/tests/linear-bridge-webhook-actions.test.ts
+++ b/packages/sdk/tests/linear-bridge-webhook-actions.test.ts
@@ -126,13 +126,22 @@ function makePayload(action: "created" | "updated" | "canceled") {
   return payload;
 }
 
-function makeLinearClient(): HandleAgentSessionEventInput["deps"]["linearClient"] & {
+function makeLinearClient(options?: { delegateId?: string | null }): HandleAgentSessionEventInput["deps"]["linearClient"] & {
   createAgentActivity: ReturnType<typeof vi.fn>;
+  issue: ReturnType<typeof vi.fn>;
+  updateIssue: ReturnType<typeof vi.fn>;
 } {
   return {
     createAgentActivity: vi.fn(async () => ({ ok: true })),
+    issue: vi.fn(async () => ({
+      id: "issue-1",
+      delegateId: options?.delegateId ?? undefined,
+    })),
+    updateIssue: vi.fn(async () => ({ success: true })),
   } as unknown as HandleAgentSessionEventInput["deps"]["linearClient"] & {
     createAgentActivity: ReturnType<typeof vi.fn>;
+    issue: ReturnType<typeof vi.fn>;
+    updateIssue: ReturnType<typeof vi.fn>;
   };
 }
 
@@ -560,5 +569,80 @@ describe("linear bridge webhook actions", () => {
     await expect(store.listPendingBootstrapRequests()).resolves.toEqual([
       expect.objectContaining({ messageType: "task" }),
     ]);
+  });
+
+  it("sets agent as delegate on created event when no delegate exists", async () => {
+    const restApi = new LinearThenvoiExampleRestApi();
+    const store = new MemorySessionRoomStore();
+    const linearClient = makeLinearClient({ delegateId: null });
+
+    await handleAgentSessionEvent({
+      payload: makePayload("created"),
+      config,
+      deps: { thenvoiRest: restApi, linearClient, store },
+    });
+
+    expect(linearClient.issue).toHaveBeenCalledWith("issue-1");
+    expect(linearClient.updateIssue).toHaveBeenCalledWith("issue-1", {
+      delegateId: "app-user",
+    });
+  });
+
+  it("does not overwrite existing delegate on created event", async () => {
+    const restApi = new LinearThenvoiExampleRestApi();
+    const store = new MemorySessionRoomStore();
+    const linearClient = makeLinearClient({ delegateId: "existing-delegate" });
+
+    await handleAgentSessionEvent({
+      payload: makePayload("created"),
+      config,
+      deps: { thenvoiRest: restApi, linearClient, store },
+    });
+
+    expect(linearClient.issue).toHaveBeenCalledWith("issue-1");
+    expect(linearClient.updateIssue).not.toHaveBeenCalled();
+  });
+
+  it("does not attempt delegate on updated events", async () => {
+    const restApi = new LinearThenvoiExampleRestApi();
+    const store = new MemorySessionRoomStore();
+    const linearClient = makeLinearClient();
+
+    // First create to set up the room.
+    await handleAgentSessionEvent({
+      payload: makePayload("created"),
+      config,
+      deps: { thenvoiRest: restApi, linearClient, store },
+    });
+
+    const updatedClient = makeLinearClient();
+    await handleAgentSessionEvent({
+      payload: makePayload("updated"),
+      config,
+      deps: { thenvoiRest: restApi, linearClient: updatedClient, store },
+    });
+
+    // The updated client should not have fetched the issue for delegate check.
+    expect(updatedClient.updateIssue).not.toHaveBeenCalled();
+  });
+
+  it("continues normally when auto-delegate fails", async () => {
+    const restApi = new LinearThenvoiExampleRestApi();
+    const store = new MemorySessionRoomStore();
+    const linearClient = makeLinearClient();
+    linearClient.issue.mockRejectedValueOnce(new Error("API rate limit"));
+
+    await handleAgentSessionEvent({
+      payload: makePayload("created"),
+      config,
+      deps: { thenvoiRest: restApi, linearClient, store },
+    });
+
+    // Should still forward the message successfully despite delegate failure.
+    expect(restApi.roomEvents).toHaveLength(1);
+    expect(restApi.roomEvents[0]?.metadata).toMatchObject({
+      linear_event_action: "created",
+      linear_session_id: "session-1",
+    });
   });
 });

--- a/packages/sdk/tests/linear-bridge-webhook-actions.test.ts
+++ b/packages/sdk/tests/linear-bridge-webhook-actions.test.ts
@@ -623,6 +623,7 @@ describe("linear bridge webhook actions", () => {
     });
 
     // The updated client should not have fetched the issue for delegate check.
+    expect(updatedClient.issue).not.toHaveBeenCalled();
     expect(updatedClient.updateIssue).not.toHaveBeenCalled();
   });
 

--- a/packages/sdk/tests/linear-bridge-webhook-actions.test.ts
+++ b/packages/sdk/tests/linear-bridge-webhook-actions.test.ts
@@ -135,7 +135,7 @@ function makeLinearClient(options?: { delegateId?: string | null }): HandleAgent
     createAgentActivity: vi.fn(async () => ({ ok: true })),
     issue: vi.fn(async () => ({
       id: "issue-1",
-      delegateId: options?.delegateId ?? undefined,
+      delegateId: options?.delegateId ?? null,
     })),
     updateIssue: vi.fn(async () => ({ success: true })),
   } as unknown as HandleAgentSessionEventInput["deps"]["linearClient"] & {
@@ -569,6 +569,25 @@ describe("linear bridge webhook actions", () => {
     await expect(store.listPendingBootstrapRequests()).resolves.toEqual([
       expect.objectContaining({ messageType: "task" }),
     ]);
+  });
+
+  it("skips delegate when appUserId is absent", async () => {
+    const restApi = new LinearThenvoiExampleRestApi();
+    const store = new MemorySessionRoomStore();
+    const linearClient = makeLinearClient();
+    const payload = makePayload("created");
+    (payload as Record<string, unknown>).appUserId = undefined;
+
+    await handleAgentSessionEvent({
+      payload,
+      config,
+      deps: { thenvoiRest: restApi, linearClient, store },
+    });
+
+    expect(linearClient.issue).not.toHaveBeenCalled();
+    expect(linearClient.updateIssue).not.toHaveBeenCalled();
+    // Should still forward the message successfully.
+    expect(restApi.roomEvents).toHaveLength(1);
   });
 
   it("sets agent as delegate on created event when no delegate exists", async () => {

--- a/packages/sdk/tests/linear-bridge-webhook-actions.test.ts
+++ b/packages/sdk/tests/linear-bridge-webhook-actions.test.ts
@@ -605,6 +605,8 @@ describe("linear bridge webhook actions", () => {
     expect(linearClient.updateIssue).toHaveBeenCalledWith("issue-1", {
       delegateId: "app-user",
     });
+    // Bridge message should reflect the newly-set delegate, not the stale webhook payload.
+    expect(restApi.roomEvents[0]?.content).toContain("issue_delegate_id: app-user");
   });
 
   it("does not overwrite existing delegate on created event", async () => {

--- a/packages/sdk/tests/linear-tools.test.ts
+++ b/packages/sdk/tests/linear-tools.test.ts
@@ -80,6 +80,8 @@ function makeMockClient(): LinearActivityClient {
       updatedAt: "2026-03-06T01:00:00.000Z",
       state: { id: "state-1", name: "In Progress", type: "started" },
       assignee: { id: "user-1", name: "Darvell" },
+      delegate: { id: "agent-1", name: "Thenvoi Agent", displayName: "Thenvoi Agent" },
+      delegateId: "agent-1",
       team: { id: "team-1", key: "SOF", name: "SoftwareFactory" },
       comments: vi.fn(async () => ({
         nodes: [
@@ -282,6 +284,8 @@ describe("createLinearTools", () => {
         identifier: "SOF-1",
         title: "Example issue",
         team: expect.objectContaining({ key: "SOF" }),
+        delegate: expect.objectContaining({ id: "agent-1", name: "Thenvoi Agent" }),
+        delegate_id: "agent-1",
       }),
     });
     expect(client.issue).toHaveBeenCalledWith(TEST_ISSUE_ID);

--- a/packages/sdk/tests/linear-webhook-handler.test.ts
+++ b/packages/sdk/tests/linear-webhook-handler.test.ts
@@ -117,6 +117,8 @@ async function startServer(dispatcher?: LinearBridgeDispatcher) {
   const store = new MemorySessionRoomStore();
   const linearClient = {
     createAgentActivity: vi.fn(async () => ({ ok: true })),
+    issue: vi.fn(async () => ({ id: "issue-1", delegateId: undefined })),
+    updateIssue: vi.fn(async () => ({ success: true })),
   };
   const handler = createLinearWebhookHandler({
     config,
@@ -322,6 +324,8 @@ describe("createLinearWebhookHandler", () => {
         .fn()
         .mockRejectedValueOnce(new Error("initial error reporting failed"))
         .mockResolvedValueOnce({ ok: true }),
+      issue: vi.fn(async () => ({ id: "issue-1", delegateId: undefined })),
+      updateIssue: vi.fn(async () => ({ success: true })),
     };
     const thenvoiRest = {
       getAgentMe: vi.fn(async () => ({ id: "agent-1", handle: "linear-host" })),

--- a/packages/sdk/tests/linear-webhook-handler.test.ts
+++ b/packages/sdk/tests/linear-webhook-handler.test.ts
@@ -117,7 +117,7 @@ async function startServer(dispatcher?: LinearBridgeDispatcher) {
   const store = new MemorySessionRoomStore();
   const linearClient = {
     createAgentActivity: vi.fn(async () => ({ ok: true })),
-    issue: vi.fn(async () => ({ id: "issue-1", delegateId: undefined })),
+    issue: vi.fn(async () => ({ id: "issue-1", delegateId: null })),
     updateIssue: vi.fn(async () => ({ success: true })),
   };
   const handler = createLinearWebhookHandler({
@@ -324,7 +324,7 @@ describe("createLinearWebhookHandler", () => {
         .fn()
         .mockRejectedValueOnce(new Error("initial error reporting failed"))
         .mockResolvedValueOnce({ ok: true }),
-      issue: vi.fn(async () => ({ id: "issue-1", delegateId: undefined })),
+      issue: vi.fn(async () => ({ id: "issue-1", delegateId: null })),
       updateIssue: vi.fn(async () => ({ success: true })),
     };
     const thenvoiRest = {


### PR DESCRIPTION
## Summary

- When the bridge receives a `created` session event, it checks if the issue already has a delegate set. If not, it sets the agent's `appUserId` as the issue delegate via `updateIssue({ delegateId })`. This makes agent ownership visible in Linear's UI.
- The auto-delegate step is best-effort — failures are logged and do not block session processing.
- Adds `delegate_id` field to the `linear_update_issue` tool so agents can also set/clear delegates explicitly.
- Includes delegate info (`delegate`, `delegate_id`) in `linear_get_issue` response and the bridge message context.

Closes INT-300

## Test plan

- [x] New test: sets agent as delegate on created event when no delegate exists
- [x] New test: does not overwrite existing delegate
- [x] New test: does not attempt delegate on updated events
- [x] New test: continues normally when auto-delegate fails (best-effort)
- [x] Updated mock clients in existing tests to include `issue`/`updateIssue` methods
- [x] All 542 SDK tests pass, TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)