### PR TITLE
feat: set session external URL to link back to Thenvoi room

### DIFF
--- a/packages/sdk/src/integrations/linear/activities.ts
+++ b/packages/sdk/src/integrations/linear/activities.ts
@@ -17,6 +17,10 @@ export interface LinearActivityClient {
   ) => Promise<unknown>;
   issue?: (issueId: string) => Promise<unknown>;
   workflowStates?: (variables?: Record<string, unknown>) => Promise<unknown>;
+  agentSessionUpdateExternalUrl?: (
+    id: string,
+    input: Record<string, unknown>,
+  ) => Promise<unknown>;
 }
 
 export interface PlanStep {

--- a/packages/sdk/src/integrations/linear/bridge/handler.ts
+++ b/packages/sdk/src/integrations/linear/bridge/handler.ts
@@ -394,7 +394,7 @@ async function trySetSessionExternalUrl(input: {
   logger: Logger;
 }): Promise<void> {
   if (typeof input.linearClient.agentSessionUpdateExternalUrl !== "function") {
-    input.logger.warn("linear_thenvoi_bridge.set_external_url_skipped_no_api", {
+    input.logger.info("linear_thenvoi_bridge.set_external_url_skipped_no_api", {
       sessionId: input.sessionId,
     });
     return;

--- a/packages/sdk/src/integrations/linear/bridge/handler.ts
+++ b/packages/sdk/src/integrations/linear/bridge/handler.ts
@@ -29,7 +29,7 @@ interface NormalizedBridgeConfig {
   roomStrategy: "issue" | "session";
   writebackMode: "final_only" | "activity_stream";
   hostAgentHandle: string | null;
-  thenvoiAppBaseUrl: string | null;
+  thenvoiAppBaseUrl: string;
 }
 
 const DEFAULT_THENVOI_APP_BASE_URL = "https://app.thenvoi.com";
@@ -160,17 +160,18 @@ export async function handleAgentSessionEvent(
       logger,
       runtime,
     });
-    if (action === "created" && config.thenvoiAppBaseUrl) {
+    if (action === "created") {
+      const roomId = roomRecord.thenvoiRoomId;
       externalUrlPromise = trySetSessionExternalUrl({
         linearClient: input.deps.linearClient,
         sessionId,
-        roomId: roomRecord.thenvoiRoomId,
+        roomId,
         appBaseUrl: config.thenvoiAppBaseUrl,
         logger,
       }).catch((urlError) => {
         logger.warn("linear_thenvoi_bridge.set_external_url_failed", {
           sessionId,
-          roomId: roomRecord!.thenvoiRoomId,
+          roomId,
           error: urlError instanceof Error ? urlError.message : String(urlError),
         });
       });
@@ -393,13 +394,14 @@ async function trySetSessionExternalUrl(input: {
   logger: Logger;
 }): Promise<void> {
   if (typeof input.linearClient.agentSessionUpdateExternalUrl !== "function") {
-    input.logger.info("linear_thenvoi_bridge.set_external_url_skipped_no_api", {
+    input.logger.warn("linear_thenvoi_bridge.set_external_url_skipped_no_api", {
       sessionId: input.sessionId,
     });
     return;
   }
 
-  const roomUrl = `${input.appBaseUrl}/rooms/${input.roomId}`;
+  const base = input.appBaseUrl.replace(/\/+$/, "");
+  const roomUrl = `${base}/rooms/${input.roomId}`;
   await input.linearClient.agentSessionUpdateExternalUrl(input.sessionId, {
     externalUrls: [{ label: "View in Thenvoi", url: roomUrl }],
   });

--- a/packages/sdk/src/integrations/linear/bridge/handler.ts
+++ b/packages/sdk/src/integrations/linear/bridge/handler.ts
@@ -29,7 +29,10 @@ interface NormalizedBridgeConfig {
   roomStrategy: "issue" | "session";
   writebackMode: "final_only" | "activity_stream";
   hostAgentHandle: string | null;
+  thenvoiAppBaseUrl: string | null;
 }
+
+const DEFAULT_THENVOI_APP_BASE_URL = "https://app.thenvoi.com";
 
 const SUPPORTED_ACTIONS = new Set(["created", "updated", "canceled", "prompted"]);
 const MAX_PEER_LOOKUP_PAGES = 25;
@@ -137,6 +140,7 @@ export async function handleAgentSessionEvent(
   }
 
   let roomRecord: SessionRoomRecord | null = null;
+  let externalUrlPromise: Promise<void> | undefined;
   try {
     const hostAgentHandle = await resolveHostAgentHandle({
       thenvoiRest: input.deps.thenvoiRest,
@@ -156,6 +160,21 @@ export async function handleAgentSessionEvent(
       logger,
       runtime,
     });
+    if (action === "created" && config.thenvoiAppBaseUrl) {
+      externalUrlPromise = trySetSessionExternalUrl({
+        linearClient: input.deps.linearClient,
+        sessionId,
+        roomId: roomRecord.thenvoiRoomId,
+        appBaseUrl: config.thenvoiAppBaseUrl,
+        logger,
+      }).catch((urlError) => {
+        logger.warn("linear_thenvoi_bridge.set_external_url_failed", {
+          sessionId,
+          roomId: roomRecord!.thenvoiRoomId,
+          error: urlError instanceof Error ? urlError.message : String(urlError),
+        });
+      });
+    }
 
     const sessionIntent = detectSessionIntent({
       issueStateType: extractIssueStateField(input.payload.agentSession.issue, "type"),
@@ -278,6 +297,9 @@ export async function handleAgentSessionEvent(
       updatedAt: new Date().toISOString(),
     });
 
+    // Ensure external URL has been set before returning (already has .catch, won't throw).
+    await externalUrlPromise;
+
     logger.info("linear_thenvoi_bridge.message_forwarded", {
       sessionId,
       issueId,
@@ -285,6 +307,10 @@ export async function handleAgentSessionEvent(
       action,
     });
   } catch (error) {
+    // Ensure background operations have settled before re-throwing
+    // (the promise already has .catch, so this won't throw).
+    await externalUrlPromise;
+
     // Report errors back to Linear before re-throwing.
     try {
       await postError(
@@ -359,11 +385,38 @@ export async function completeLinearSession(input: {
   });
 }
 
+async function trySetSessionExternalUrl(input: {
+  linearClient: HandleAgentSessionEventInput["deps"]["linearClient"];
+  sessionId: string;
+  roomId: string;
+  appBaseUrl: string;
+  logger: Logger;
+}): Promise<void> {
+  if (typeof input.linearClient.agentSessionUpdateExternalUrl !== "function") {
+    input.logger.info("linear_thenvoi_bridge.set_external_url_skipped_no_api", {
+      sessionId: input.sessionId,
+    });
+    return;
+  }
+
+  const roomUrl = `${input.appBaseUrl}/rooms/${input.roomId}`;
+  await input.linearClient.agentSessionUpdateExternalUrl(input.sessionId, {
+    externalUrls: [{ label: "View in Thenvoi", url: roomUrl }],
+  });
+
+  input.logger.info("linear_thenvoi_bridge.external_url_set", {
+    sessionId: input.sessionId,
+    roomId: input.roomId,
+    url: roomUrl,
+  });
+}
+
 function normalizeConfig(config: LinearThenvoiBridgeConfig): NormalizedBridgeConfig {
   return {
     roomStrategy: config.roomStrategy ?? "issue",
     writebackMode: config.writebackMode ?? "final_only",
     hostAgentHandle: normalizeOptionalHandle(config.hostAgentHandle),
+    thenvoiAppBaseUrl: config.thenvoiAppBaseUrl ?? DEFAULT_THENVOI_APP_BASE_URL,
   };
 }
 

--- a/packages/sdk/src/integrations/linear/types.ts
+++ b/packages/sdk/src/integrations/linear/types.ts
@@ -17,6 +17,7 @@ export interface LinearThenvoiBridgeConfig {
   planningAgentHandles?: string[];
   implementationAgentHandles?: string[];
   recoveredRoomRetryBaseDelayMs?: number;
+  thenvoiAppBaseUrl?: string;
 }
 
 export interface SessionRoomRecord {

--- a/packages/sdk/tests/linear-bridge-room-strategy.test.ts
+++ b/packages/sdk/tests/linear-bridge-room-strategy.test.ts
@@ -207,6 +207,7 @@ function makePayload(sessionId: string, issueId: string) {
 function makeLinearClient(): HandleAgentSessionEventInput["deps"]["linearClient"] {
   return {
     createAgentActivity: async () => ({ ok: true }),
+    agentSessionUpdateExternalUrl: async () => ({ success: true }),
   } as unknown as HandleAgentSessionEventInput["deps"]["linearClient"];
 }
 

--- a/packages/sdk/tests/linear-bridge-webhook-actions.test.ts
+++ b/packages/sdk/tests/linear-bridge-webhook-actions.test.ts
@@ -128,11 +128,14 @@ function makePayload(action: "created" | "updated" | "canceled") {
 
 function makeLinearClient(): HandleAgentSessionEventInput["deps"]["linearClient"] & {
   createAgentActivity: ReturnType<typeof vi.fn>;
+  agentSessionUpdateExternalUrl: ReturnType<typeof vi.fn>;
 } {
   return {
     createAgentActivity: vi.fn(async () => ({ ok: true })),
+    agentSessionUpdateExternalUrl: vi.fn(async () => ({ success: true })),
   } as unknown as HandleAgentSessionEventInput["deps"]["linearClient"] & {
     createAgentActivity: ReturnType<typeof vi.fn>;
+    agentSessionUpdateExternalUrl: ReturnType<typeof vi.fn>;
   };
 }
 
@@ -560,5 +563,101 @@ describe("linear bridge webhook actions", () => {
     await expect(store.listPendingBootstrapRequests()).resolves.toEqual([
       expect.objectContaining({ messageType: "task" }),
     ]);
+  });
+
+  it("sets external URL on Linear session on created event", async () => {
+    const restApi = new LinearThenvoiExampleRestApi();
+    const store = new MemorySessionRoomStore();
+    const linearClient = makeLinearClient();
+
+    await handleAgentSessionEvent({
+      payload: makePayload("created"),
+      config,
+      deps: { thenvoiRest: restApi, linearClient, store },
+    });
+
+    expect(linearClient.agentSessionUpdateExternalUrl).toHaveBeenCalledWith(
+      "session-1",
+      {
+        externalUrls: [{ label: "View in Thenvoi", url: expect.stringMatching(/^https:\/\/app\.thenvoi\.com\/rooms\//) }],
+      },
+    );
+  });
+
+  it("uses custom thenvoiAppBaseUrl for external URL", async () => {
+    const restApi = new LinearThenvoiExampleRestApi();
+    const store = new MemorySessionRoomStore();
+    const linearClient = makeLinearClient();
+
+    await handleAgentSessionEvent({
+      payload: makePayload("created"),
+      config: { ...config, thenvoiAppBaseUrl: "https://custom.example.com" },
+      deps: { thenvoiRest: restApi, linearClient, store },
+    });
+
+    expect(linearClient.agentSessionUpdateExternalUrl).toHaveBeenCalledWith(
+      "session-1",
+      {
+        externalUrls: [{ label: "View in Thenvoi", url: expect.stringContaining("https://custom.example.com/rooms/") }],
+      },
+    );
+  });
+
+  it("does not set external URL on updated events", async () => {
+    const restApi = new LinearThenvoiExampleRestApi();
+    const store = new MemorySessionRoomStore();
+    const linearClient = makeLinearClient();
+
+    // Create first to set up the room.
+    await handleAgentSessionEvent({
+      payload: makePayload("created"),
+      config,
+      deps: { thenvoiRest: restApi, linearClient, store },
+    });
+
+    const updatedClient = makeLinearClient();
+    await handleAgentSessionEvent({
+      payload: makePayload("updated"),
+      config,
+      deps: { thenvoiRest: restApi, linearClient: updatedClient, store },
+    });
+
+    expect(updatedClient.agentSessionUpdateExternalUrl).not.toHaveBeenCalled();
+  });
+
+  it("continues normally when setting external URL fails", async () => {
+    const restApi = new LinearThenvoiExampleRestApi();
+    const store = new MemorySessionRoomStore();
+    const linearClient = makeLinearClient();
+    linearClient.agentSessionUpdateExternalUrl.mockRejectedValueOnce(new Error("API error"));
+
+    await handleAgentSessionEvent({
+      payload: makePayload("created"),
+      config,
+      deps: { thenvoiRest: restApi, linearClient, store },
+    });
+
+    // Should still forward the message successfully despite external URL failure.
+    expect(restApi.roomEvents).toHaveLength(1);
+    expect(restApi.roomEvents[0]?.metadata).toMatchObject({
+      linear_event_action: "created",
+      linear_session_id: "session-1",
+    });
+  });
+
+  it("skips external URL when agentSessionUpdateExternalUrl is unavailable", async () => {
+    const restApi = new LinearThenvoiExampleRestApi();
+    const store = new MemorySessionRoomStore();
+    const linearClient = makeLinearClient();
+    delete (linearClient as Partial<typeof linearClient>).agentSessionUpdateExternalUrl;
+
+    await handleAgentSessionEvent({
+      payload: makePayload("created"),
+      config,
+      deps: { thenvoiRest: restApi, linearClient, store },
+    });
+
+    // Should still forward the message successfully.
+    expect(restApi.roomEvents).toHaveLength(1);
   });
 });

--- a/packages/sdk/tests/linear-webhook-handler.test.ts
+++ b/packages/sdk/tests/linear-webhook-handler.test.ts
@@ -117,6 +117,7 @@ async function startServer(dispatcher?: LinearBridgeDispatcher) {
   const store = new MemorySessionRoomStore();
   const linearClient = {
     createAgentActivity: vi.fn(async () => ({ ok: true })),
+    agentSessionUpdateExternalUrl: vi.fn(async () => ({ success: true })),
   };
   const handler = createLinearWebhookHandler({
     config,
@@ -322,6 +323,7 @@ describe("createLinearWebhookHandler", () => {
         .fn()
         .mockRejectedValueOnce(new Error("initial error reporting failed"))
         .mockResolvedValueOnce({ ok: true }),
+      agentSessionUpdateExternalUrl: vi.fn(async () => ({ success: true })),
     };
     const thenvoiRest = {
       getAgentMe: vi.fn(async () => ({ id: "agent-1", handle: "linear-host" })),


### PR DESCRIPTION
## Summary

- After the bridge resolves or creates a Thenvoi room on a `created` session event, calls Linear's `agentSessionUpdateExternalUrl` mutation to set an external URL linking back to the Thenvoi room
- Linear renders an "Open" button in the Agent Session UI that navigates the user directly to the Thenvoi room where multi-agent collaboration is happening
- Adds `thenvoiAppBaseUrl` config option to `LinearThenvoiBridgeConfig` (defaults to `https://app.thenvoi.com`)
- Adds `agentSessionUpdateExternalUrl` as an optional method on `LinearActivityClient`
- Best-effort: failures are logged and never block session processing
- Only fires on `created` events — the URL only needs to be set once per session

Closes INT-296

## Test plan

- [x] New test: sets external URL on Linear session on created event
- [x] New test: uses custom `thenvoiAppBaseUrl` for external URL
- [x] New test: does not set external URL on updated events
- [x] New test: continues normally when setting external URL fails
- [x] New test: skips when `agentSessionUpdateExternalUrl` is unavailable on the client
- [x] Updated mock clients in existing tests to include `agentSessionUpdateExternalUrl`
- [x] All 544 SDK tests pass, TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)