### PR TITLE
fix: propagate logger to ThenvoiLink and forward wsUrl/restUrl in examples (INT-332)

### DIFF
--- a/packages/sdk/examples/a2a-bridge/a2a-bridge-agent.ts
+++ b/packages/sdk/examples/a2a-bridge/a2a-bridge-agent.ts
@@ -11,7 +11,7 @@ function requireA2ARemoteUrl(optionsRemoteUrl?: string): string {
 
 export function createA2ABridgeAgent(
   options?: { remoteUrl?: string },
-  overrides?: { agentId?: string; apiKey?: string },
+  overrides?: { agentId?: string; apiKey?: string; wsUrl?: string; restUrl?: string },
 ): Agent {
   const remoteUrl = requireA2ARemoteUrl(options?.remoteUrl);
   const adapter = new A2AAdapter({
@@ -24,7 +24,10 @@ export function createA2ABridgeAgent(
     config: {
       agentId: overrides?.agentId ?? "agent-a2a",
       apiKey: overrides?.apiKey ?? "api-key",
+      ...(overrides?.wsUrl ? { wsUrl: overrides.wsUrl } : {}),
+      ...(overrides?.restUrl ? { restUrl: overrides.restUrl } : {}),
     },
+    agentConfig: { autoSubscribeExistingRooms: true },
   });
 }
 

--- a/packages/sdk/examples/a2a-bridge/a2a-bridge-auth.ts
+++ b/packages/sdk/examples/a2a-bridge/a2a-bridge-auth.ts
@@ -13,7 +13,7 @@ export function createA2ABridgeAgentWithAuth(options?: {
   remoteUrl?: string;
   apiKey?: string;
   bearerToken?: string;
-}, overrides?: { agentId?: string; apiKey?: string }): Agent {
+}, overrides?: { agentId?: string; apiKey?: string; wsUrl?: string; restUrl?: string }): Agent {
   const remoteUrl = requireA2ARemoteUrl(options?.remoteUrl);
   const apiKey = options?.apiKey ?? process.env.A2A_API_KEY;
   const bearerToken = options?.bearerToken ?? process.env.A2A_BEARER_TOKEN;
@@ -32,7 +32,10 @@ export function createA2ABridgeAgentWithAuth(options?: {
     config: {
       agentId: overrides?.agentId ?? "agent-a2a-auth",
       apiKey: overrides?.apiKey ?? "api-key",
+      ...(overrides?.wsUrl ? { wsUrl: overrides.wsUrl } : {}),
+      ...(overrides?.restUrl ? { restUrl: overrides.restUrl } : {}),
     },
+    agentConfig: { autoSubscribeExistingRooms: true },
   });
 }
 

--- a/packages/sdk/examples/a2a-gateway/a2a-gateway-agent.ts
+++ b/packages/sdk/examples/a2a-gateway/a2a-gateway-agent.ts
@@ -1,4 +1,10 @@
-import { A2AGatewayAdapter, Agent, loadAgentConfig, isDirectExecution } from "../../src/index";
+import {
+  A2AGatewayAdapter,
+  Agent,
+  deriveDefaultRestUrl,
+  loadAgentConfig,
+  isDirectExecution,
+} from "../../src/index";
 import { FernRestAdapter } from "../../src/rest";
 import { ThenvoiClient } from "@thenvoi/rest-client";
 
@@ -7,10 +13,12 @@ export function createA2AGatewayAgent(
   overrides?: { agentId?: string; apiKey?: string; wsUrl?: string; restUrl?: string },
 ): Agent {
   const thenvoiApiKey = overrides?.apiKey ?? "api-key";
+  const resolvedRestUrl = overrides?.restUrl
+    ?? (overrides?.wsUrl ? deriveDefaultRestUrl(overrides.wsUrl) : undefined);
   const restApi = new FernRestAdapter(
     new ThenvoiClient({
       apiKey: thenvoiApiKey,
-      ...(overrides?.restUrl ? { baseUrl: overrides.restUrl } : {}),
+      ...(resolvedRestUrl ? { baseUrl: resolvedRestUrl } : {}),
     }),
   );
 
@@ -27,7 +35,7 @@ export function createA2AGatewayAgent(
       agentId: overrides?.agentId ?? "agent-a2a-gateway",
       apiKey: thenvoiApiKey,
       ...(overrides?.wsUrl ? { wsUrl: overrides.wsUrl } : {}),
-      ...(overrides?.restUrl ? { restUrl: overrides.restUrl } : {}),
+      ...(resolvedRestUrl ? { restUrl: resolvedRestUrl } : {}),
     },
     linkOptions: { restApi },
     agentConfig: { autoSubscribeExistingRooms: true },

--- a/packages/sdk/examples/a2a-gateway/a2a-gateway-agent.ts
+++ b/packages/sdk/examples/a2a-gateway/a2a-gateway-agent.ts
@@ -4,11 +4,14 @@ import { ThenvoiClient } from "@thenvoi/rest-client";
 
 export function createA2AGatewayAgent(
   options?: { port?: number; gatewayUrl?: string; authToken?: string },
-  overrides?: { agentId?: string; apiKey?: string },
+  overrides?: { agentId?: string; apiKey?: string; wsUrl?: string; restUrl?: string },
 ): Agent {
   const thenvoiApiKey = overrides?.apiKey ?? "api-key";
   const restApi = new FernRestAdapter(
-    new ThenvoiClient({ apiKey: thenvoiApiKey }),
+    new ThenvoiClient({
+      apiKey: thenvoiApiKey,
+      ...(overrides?.restUrl ? { baseUrl: overrides.restUrl } : {}),
+    }),
   );
 
   const adapter = new A2AGatewayAdapter({
@@ -23,8 +26,11 @@ export function createA2AGatewayAgent(
     config: {
       agentId: overrides?.agentId ?? "agent-a2a-gateway",
       apiKey: thenvoiApiKey,
+      ...(overrides?.wsUrl ? { wsUrl: overrides.wsUrl } : {}),
+      ...(overrides?.restUrl ? { restUrl: overrides.restUrl } : {}),
     },
     linkOptions: { restApi },
+    agentConfig: { autoSubscribeExistingRooms: true },
   });
 }
 

--- a/packages/sdk/examples/anthropic/anthropic-agent.ts
+++ b/packages/sdk/examples/anthropic/anthropic-agent.ts
@@ -7,7 +7,7 @@ interface AnthropicExampleOptions {
 
 export function createAnthropicAgent(
   options: AnthropicExampleOptions = {},
-  overrides?: { agentId?: string; apiKey?: string },
+  overrides?: { agentId?: string; apiKey?: string; wsUrl?: string; restUrl?: string },
 ): Agent {
   const adapter = new AnthropicAdapter({
     anthropicModel: options.model ?? "claude-sonnet-4-6",
@@ -19,7 +19,10 @@ export function createAnthropicAgent(
     config: {
       agentId: overrides?.agentId ?? "anthropic-agent",
       apiKey: overrides?.apiKey ?? "api-key",
+      ...(overrides?.wsUrl ? { wsUrl: overrides.wsUrl } : {}),
+      ...(overrides?.restUrl ? { restUrl: overrides.restUrl } : {}),
     },
+    agentConfig: { autoSubscribeExistingRooms: true },
   });
 }
 

--- a/packages/sdk/examples/basic/basic-agent.ts
+++ b/packages/sdk/examples/basic/basic-agent.ts
@@ -1,6 +1,6 @@
 import { Agent, GenericAdapter, loadAgentConfig, isDirectExecution } from "../../src/index";
 
-export function createBasicAgent(overrides?: { agentId?: string; apiKey?: string }): Agent {
+export function createBasicAgent(overrides?: { agentId?: string; apiKey?: string; wsUrl?: string; restUrl?: string }): Agent {
   const adapter = new GenericAdapter(async ({ message, tools }) => {
     await tools.sendMessage(`Echo: ${message.content}`, [
       { id: message.senderId, handle: message.senderName ?? message.senderType },
@@ -12,7 +12,10 @@ export function createBasicAgent(overrides?: { agentId?: string; apiKey?: string
     config: {
       agentId: overrides?.agentId ?? "basic-agent",
       apiKey: overrides?.apiKey ?? "api-key",
+      ...(overrides?.wsUrl ? { wsUrl: overrides.wsUrl } : {}),
+      ...(overrides?.restUrl ? { restUrl: overrides.restUrl } : {}),
     },
+    agentConfig: { autoSubscribeExistingRooms: true },
   });
 }
 

--- a/packages/sdk/examples/claude-sdk/claude-sdk-agent.ts
+++ b/packages/sdk/examples/claude-sdk/claude-sdk-agent.ts
@@ -7,7 +7,7 @@ interface ClaudeSdkExampleOptions {
 
 export function createClaudeSdkAgent(
   options: ClaudeSdkExampleOptions = {},
-  overrides?: { agentId?: string; apiKey?: string },
+  overrides?: { agentId?: string; apiKey?: string; wsUrl?: string; restUrl?: string },
 ): Agent {
   const adapter = new ClaudeSDKAdapter({
     model: options.model ?? "claude-sonnet-4-6",
@@ -21,7 +21,10 @@ export function createClaudeSdkAgent(
     config: {
       agentId: overrides?.agentId ?? "claude-sdk-agent",
       apiKey: overrides?.apiKey ?? "api-key",
+      ...(overrides?.wsUrl ? { wsUrl: overrides.wsUrl } : {}),
+      ...(overrides?.restUrl ? { restUrl: overrides.restUrl } : {}),
     },
+    agentConfig: { autoSubscribeExistingRooms: true },
   });
 }
 

--- a/packages/sdk/examples/codex/codex-agent.ts
+++ b/packages/sdk/examples/codex/codex-agent.ts
@@ -10,7 +10,7 @@ interface CodexExampleOptions {
 
 export function createCodexAgent(
   options: CodexExampleOptions = {},
-  overrides?: { agentId?: string; apiKey?: string },
+  overrides?: { agentId?: string; apiKey?: string; wsUrl?: string; restUrl?: string },
 ): Agent {
   const adapter = new CodexAdapter({
     config: {
@@ -30,7 +30,10 @@ export function createCodexAgent(
     config: {
       agentId: overrides?.agentId ?? "codex-agent",
       apiKey: overrides?.apiKey ?? "api-key",
+      ...(overrides?.wsUrl ? { wsUrl: overrides.wsUrl } : {}),
+      ...(overrides?.restUrl ? { restUrl: overrides.restUrl } : {}),
     },
+    agentConfig: { autoSubscribeExistingRooms: true },
   });
 }
 

--- a/packages/sdk/examples/custom-adapter/custom-adapter.ts
+++ b/packages/sdk/examples/custom-adapter/custom-adapter.ts
@@ -13,13 +13,18 @@ class EchoAdapter extends SimpleAdapter<HistoryProvider> {
 export function createCustomAdapterAgent(overrides?: {
   agentId?: string;
   apiKey?: string;
+  wsUrl?: string;
+  restUrl?: string;
 }): Agent {
   return Agent.create({
     adapter: new EchoAdapter(),
     config: {
       agentId: overrides?.agentId ?? "agent-1",
       apiKey: overrides?.apiKey ?? "api-key",
+      ...(overrides?.wsUrl ? { wsUrl: overrides.wsUrl } : {}),
+      ...(overrides?.restUrl ? { restUrl: overrides.restUrl } : {}),
     },
+    agentConfig: { autoSubscribeExistingRooms: true },
   });
 }
 

--- a/packages/sdk/examples/gemini/gemini-agent.ts
+++ b/packages/sdk/examples/gemini/gemini-agent.ts
@@ -7,7 +7,7 @@ interface GeminiExampleOptions {
 
 export function createGeminiAgent(
   options: GeminiExampleOptions = {},
-  overrides?: { agentId?: string; apiKey?: string },
+  overrides?: { agentId?: string; apiKey?: string; wsUrl?: string; restUrl?: string },
 ): Agent {
   const adapter = new GeminiAdapter({
     geminiModel: options.model ?? "gemini-3-flash-preview",
@@ -19,7 +19,10 @@ export function createGeminiAgent(
     config: {
       agentId: overrides?.agentId ?? "gemini-agent",
       apiKey: overrides?.apiKey ?? "api-key",
+      ...(overrides?.wsUrl ? { wsUrl: overrides.wsUrl } : {}),
+      ...(overrides?.restUrl ? { restUrl: overrides.restUrl } : {}),
     },
+    agentConfig: { autoSubscribeExistingRooms: true },
   });
 }
 

--- a/packages/sdk/examples/langgraph/langgraph-agent.ts
+++ b/packages/sdk/examples/langgraph/langgraph-agent.ts
@@ -18,7 +18,7 @@ export class EchoLangGraph implements LangGraphGraph {
 
 export function createLangGraphAgent(
   options?: { graph?: LangGraphGraph },
-  overrides?: { agentId?: string; apiKey?: string },
+  overrides?: { agentId?: string; apiKey?: string; wsUrl?: string; restUrl?: string },
 ): Agent {
   const adapter = new LangGraphAdapter({
     graph: options?.graph ?? new EchoLangGraph(),
@@ -31,7 +31,10 @@ export function createLangGraphAgent(
     config: {
       agentId: overrides?.agentId ?? "agent-langgraph",
       apiKey: overrides?.apiKey ?? "api-key",
+      ...(overrides?.wsUrl ? { wsUrl: overrides.wsUrl } : {}),
+      ...(overrides?.restUrl ? { restUrl: overrides.restUrl } : {}),
     },
+    agentConfig: { autoSubscribeExistingRooms: true },
   });
 }
 

--- a/packages/sdk/examples/letta/letta-agent.ts
+++ b/packages/sdk/examples/letta/letta-agent.ts
@@ -7,7 +7,7 @@ export function createLettaAgent(
     lettaApiKey?: string;
     lettaBaseUrl?: string;
   },
-  overrides?: { agentId?: string; apiKey?: string },
+  overrides?: { agentId?: string; apiKey?: string; wsUrl?: string; restUrl?: string },
 ): Agent {
   const adapter = new LettaAdapter({
     model: options.model ?? "openai/gpt-4o",
@@ -21,6 +21,8 @@ export function createLettaAgent(
     config: {
       agentId: overrides?.agentId ?? "agent-letta",
       apiKey: overrides?.apiKey ?? "api-key",
+      ...(overrides?.wsUrl ? { wsUrl: overrides.wsUrl } : {}),
+      ...(overrides?.restUrl ? { restUrl: overrides.restUrl } : {}),
     },
     agentConfig: {
       autoSubscribeExistingRooms: true,

--- a/packages/sdk/examples/openai/openai-agent.ts
+++ b/packages/sdk/examples/openai/openai-agent.ts
@@ -7,7 +7,7 @@ interface OpenAIExampleOptions {
 
 export function createOpenAIAgent(
   options: OpenAIExampleOptions = {},
-  overrides?: { agentId?: string; apiKey?: string },
+  overrides?: { agentId?: string; apiKey?: string; wsUrl?: string; restUrl?: string },
 ): Agent {
   const adapter = new OpenAIAdapter({
     openAIModel: options.model ?? "gpt-5.2",
@@ -19,7 +19,10 @@ export function createOpenAIAgent(
     config: {
       agentId: overrides?.agentId ?? "openai-agent",
       apiKey: overrides?.apiKey ?? "api-key",
+      ...(overrides?.wsUrl ? { wsUrl: overrides.wsUrl } : {}),
+      ...(overrides?.restUrl ? { restUrl: overrides.restUrl } : {}),
     },
+    agentConfig: { autoSubscribeExistingRooms: true },
   });
 }
 

--- a/packages/sdk/examples/parlant/parlant-agent.ts
+++ b/packages/sdk/examples/parlant/parlant-agent.ts
@@ -6,7 +6,7 @@ export function createParlantAgent(
     agentId: string;
     apiKey?: string;
   },
-  overrides?: { agentId?: string; apiKey?: string },
+  overrides?: { agentId?: string; apiKey?: string; wsUrl?: string; restUrl?: string },
 ): Agent {
   const adapter = new ParlantAdapter({
     environment: options.environment,
@@ -19,7 +19,10 @@ export function createParlantAgent(
     config: {
       agentId: overrides?.agentId ?? "agent-parlant",
       apiKey: overrides?.apiKey ?? "api-key",
+      ...(overrides?.wsUrl ? { wsUrl: overrides.wsUrl } : {}),
+      ...(overrides?.restUrl ? { restUrl: overrides.restUrl } : {}),
     },
+    agentConfig: { autoSubscribeExistingRooms: true },
   });
 }
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,7 +1,7 @@
 export { Agent } from "./agent/Agent";
 export type { AgentCreateOptions } from "./agent/Agent";
 
-export { ThenvoiLink } from "./platform/ThenvoiLink";
+export { ThenvoiLink, deriveDefaultRestUrl } from "./platform/ThenvoiLink";
 export type { PlatformEvent, ContactEvent } from "./platform/events";
 export { PlatformRuntime } from "./runtime/PlatformRuntime";
 export type { PlatformRuntimeOptions } from "./runtime/PlatformRuntime";

--- a/packages/sdk/src/platform/ThenvoiLink.ts
+++ b/packages/sdk/src/platform/ThenvoiLink.ts
@@ -35,7 +35,7 @@ export interface ThenvoiLinkOptions {
 
 const DEFAULT_WS_URL = "wss://app.thenvoi.com/api/v1/socket";
 
-function deriveDefaultRestUrl(wsUrl: string): string {
+export function deriveDefaultRestUrl(wsUrl: string): string {
   const parsed = new URL(wsUrl);
   const protocol = parsed.protocol === "ws:" ? "http:" : "https:";
   return `${protocol}//${parsed.host}`;

--- a/packages/sdk/src/runtime/PlatformRuntime.ts
+++ b/packages/sdk/src/runtime/PlatformRuntime.ts
@@ -146,6 +146,7 @@ export class PlatformRuntime {
         apiKey: this._apiKey,
         wsUrl: this._wsUrl,
         restUrl: this._restUrl,
+        logger: this.logger,
       });
     }
 

--- a/packages/sdk/tests/examples-basic-agent.test.ts
+++ b/packages/sdk/tests/examples-basic-agent.test.ts
@@ -2,6 +2,24 @@ import { describe, expect, it } from "vitest";
 
 import { createBasicAgent } from "../examples/basic/basic-agent";
 import { StubRestApi } from "../src/testing";
+import type {
+  StreamingTransport,
+  TopicHandlers,
+} from "../src/platform/streaming/transport";
+import { FakeRestApi } from "./testUtils";
+
+class NoopTransport implements StreamingTransport {
+  public async connect(): Promise<void> {}
+  public async disconnect(): Promise<void> {}
+  public async join(_topic: string, _handlers: TopicHandlers): Promise<void> {}
+  public async leave(_topic: string): Promise<void> {}
+  public async runForever(signal: AbortSignal): Promise<void> {
+    await new Promise<void>((resolve) => signal.addEventListener("abort", () => resolve(), { once: true }));
+  }
+  public isConnected(): boolean {
+    return true;
+  }
+}
 
 describe("basic-agent example", () => {
   it("builds an agent instance without side effects on import", () => {
@@ -17,5 +35,25 @@ describe("basic-agent example", () => {
       id: "stub-agent",
       name: "Stub Agent",
     });
+  });
+
+  it("forwards wsUrl/restUrl from config into runtime link", async () => {
+    const agent = createBasicAgent({
+      agentId: "a1",
+      apiKey: "k",
+      wsUrl: "wss://staging.thenvoi.com/api/v1/socket",
+      restUrl: "https://staging.thenvoi.com",
+    });
+
+    // Stub transport + REST so initialize() does not hit the network.
+    (agent.runtime as unknown as { linkOptions: unknown }).linkOptions = {
+      transport: new NoopTransport(),
+      restApi: new FakeRestApi(),
+    };
+
+    await agent.runtime.initialize();
+
+    expect(agent.runtime.link.wsUrl).toBe("wss://staging.thenvoi.com/api/v1/socket");
+    expect(agent.runtime.link.restUrl).toBe("https://staging.thenvoi.com");
   });
 });

--- a/packages/sdk/tests/platform-runtime.test.ts
+++ b/packages/sdk/tests/platform-runtime.test.ts
@@ -586,4 +586,27 @@ describe("PlatformRuntime", () => {
       () => new PlatformRuntime({ agentId: "", apiKey: "valid-key" }),
     ).toThrow("loadAgentConfig()");
   });
+
+  it("forwards logger to lazily-constructed ThenvoiLink", async () => {
+    const spyLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const transport = new FakeTransport();
+    const restApi = new FakeRestApi();
+
+    const runtime = new PlatformRuntime({
+      agentId: "a1",
+      apiKey: "k",
+      wsUrl: "wss://example.test/socket",
+      logger: spyLogger,
+      linkOptions: { transport, restApi },
+    });
+
+    await runtime.initialize();
+
+    expect((runtime.link as unknown as { logger: unknown }).logger).toBe(spyLogger);
+  });
 });


### PR DESCRIPTION
## Summary
- **Logger propagation:** `PlatformRuntime.doInitialize()` now forwards `logger` to `ThenvoiLink`, fixing silent transport-level logging
- **wsUrl/restUrl forwarding:** All example `create*Agent` helpers now accept and forward `wsUrl`/`restUrl` from config, so agents connect to the correct environment
- **autoSubscribeExistingRooms:** Added to 11 examples so agents process messages in pre-existing rooms on startup

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` — 83 files, 539 tests pass
- [x] Manual: langgraph example connects to dev environment via `ws_url`/`rest_url` from config
- [x] Manual: agent subscribes to existing rooms and processes pending messages on startup
- [x] Manual: logger output visible when `ConsoleLogger` passed to `Agent.create`

Closes INT-332

🤖 Generated with [Claude Code](https://claude.com/claude-code)