### PR TITLE
feat(linear): handle permission change webhooks from Linear

### DIFF
--- a/packages/sdk/src/integrations/linear/index.ts
+++ b/packages/sdk/src/integrations/linear/index.ts
@@ -43,5 +43,6 @@ export type {
   CreateLinearWebhookHandlerOptions,
   LinearBridgeDispatchJob,
   LinearBridgeDispatcher,
+  PermissionChangeCallbacks,
 } from "./webhook";
 export { DEFAULT_STATUS_MAPPING } from "./constants";

--- a/packages/sdk/src/integrations/linear/webhook.ts
+++ b/packages/sdk/src/integrations/linear/webhook.ts
@@ -5,6 +5,8 @@ import {
   LINEAR_WEBHOOK_SIGNATURE_HEADER,
   LINEAR_WEBHOOK_TS_HEADER,
   type AgentSessionEventWebhookPayload,
+  type AppUserTeamAccessChangedWebhookPayload,
+  type OAuthAppWebhookPayload,
 } from "@linear/sdk/webhooks";
 
 import { NoopLogger, type Logger } from "../../core/logger";
@@ -33,10 +35,16 @@ export interface LinearBridgeDispatcher {
   waitForIdle?(): Promise<void>;
 }
 
+export interface PermissionChangeCallbacks {
+  onTeamAccessChanged?: (payload: AppUserTeamAccessChangedWebhookPayload) => void | Promise<void>;
+  onOAuthAppRevoked?: (payload: OAuthAppWebhookPayload) => void | Promise<void>;
+}
+
 export interface CreateLinearWebhookHandlerOptions {
   config: LinearThenvoiBridgeConfig;
   deps: LinearThenvoiBridgeDeps;
   dispatcher?: LinearBridgeDispatcher;
+  permissionCallbacks?: PermissionChangeCallbacks;
 }
 
 type NodeRequestWithBody = IncomingMessage & {
@@ -231,13 +239,13 @@ export function createLinearWebhookHandler(
     }
 
     const rawBody = await readRawBody(request as NodeRequestWithBody);
-    let payload: AgentSessionEventWebhookPayload;
+    let parsed: { type: string };
     try {
-      payload = webhookClient.parseData(
+      parsed = webhookClient.parseData(
         rawBody,
         signature,
         timestamp,
-      ) as AgentSessionEventWebhookPayload;
+      ) as { type: string };
     } catch (error) {
       logger.warn("linear_thenvoi_bridge.webhook_invalid_signature", {
         error: error instanceof Error ? error.message : String(error),
@@ -246,13 +254,62 @@ export function createLinearWebhookHandler(
       return;
     }
 
-    if (payload.type !== "AgentSessionEvent") {
+    if (parsed.type === "PermissionChange") {
+      const permPayload = parsed as unknown as AppUserTeamAccessChangedWebhookPayload;
+      logger.info("linear_thenvoi_bridge.team_access_changed", {
+        action: permPayload.action,
+        addedTeamIds: permPayload.addedTeamIds,
+        removedTeamIds: permPayload.removedTeamIds,
+        canAccessAllPublicTeams: permPayload.canAccessAllPublicTeams,
+        organizationId: permPayload.organizationId,
+      });
+
+      try {
+        await options.permissionCallbacks?.onTeamAccessChanged?.(permPayload);
+      } catch (error) {
+        logger.error("linear_thenvoi_bridge.team_access_changed_callback_failed", {
+          error: serializeError(error),
+        });
+      }
+
+      sendText(response, 200, "OK");
+      return;
+    }
+
+    if (parsed.type === "OAuthApp") {
+      const oauthPayload = parsed as unknown as OAuthAppWebhookPayload;
+      if (normalizeAction(oauthPayload.action) === "revoked") {
+        logger.warn("linear_thenvoi_bridge.oauth_app_revoked", {
+          oauthClientId: oauthPayload.oauthClientId,
+          organizationId: oauthPayload.organizationId,
+        });
+
+        try {
+          await options.permissionCallbacks?.onOAuthAppRevoked?.(oauthPayload);
+        } catch (error) {
+          logger.error("linear_thenvoi_bridge.oauth_app_revoked_callback_failed", {
+            error: serializeError(error),
+          });
+        }
+      } else {
+        logger.info("linear_thenvoi_bridge.oauth_app_event_ignored", {
+          action: oauthPayload.action,
+        });
+      }
+
+      sendText(response, 200, "OK");
+      return;
+    }
+
+    if (parsed.type !== "AgentSessionEvent") {
       logger.info("linear_thenvoi_bridge.webhook_ignored_event", {
-        type: payload.type,
+        type: parsed.type,
       });
       sendText(response, 200, "OK");
       return;
     }
+
+    const payload = parsed as unknown as AgentSessionEventWebhookPayload;
 
     const eventKey = getAgentSessionEventKey(payload);
     logger.info("linear_thenvoi_bridge.webhook_received", {

--- a/packages/sdk/src/integrations/linear/webhook.ts
+++ b/packages/sdk/src/integrations/linear/webhook.ts
@@ -256,19 +256,25 @@ export function createLinearWebhookHandler(
 
     if (parsed.type === "PermissionChange") {
       const permPayload = parsed as unknown as AppUserTeamAccessChangedWebhookPayload;
-      logger.info("linear_thenvoi_bridge.team_access_changed", {
-        action: permPayload.action,
-        addedTeamIds: permPayload.addedTeamIds,
-        removedTeamIds: permPayload.removedTeamIds,
-        canAccessAllPublicTeams: permPayload.canAccessAllPublicTeams,
-        organizationId: permPayload.organizationId,
-      });
+      if (normalizeAction(permPayload.action) === "teamaccesschanged") {
+        logger.info("linear_thenvoi_bridge.team_access_changed", {
+          action: permPayload.action,
+          addedTeamIds: permPayload.addedTeamIds,
+          removedTeamIds: permPayload.removedTeamIds,
+          canAccessAllPublicTeams: permPayload.canAccessAllPublicTeams,
+          organizationId: permPayload.organizationId,
+        });
 
-      try {
-        await options.permissionCallbacks?.onTeamAccessChanged?.(permPayload);
-      } catch (error) {
-        logger.error("linear_thenvoi_bridge.team_access_changed_callback_failed", {
-          error: serializeError(error),
+        try {
+          await options.permissionCallbacks?.onTeamAccessChanged?.(permPayload);
+        } catch (error) {
+          logger.error("linear_thenvoi_bridge.team_access_changed_callback_failed", {
+            error: serializeError(error),
+          });
+        }
+      } else {
+        logger.info("linear_thenvoi_bridge.permission_change_event_ignored", {
+          action: permPayload.action,
         });
       }
 

--- a/packages/sdk/src/integrations/linear/webhook.ts
+++ b/packages/sdk/src/integrations/linear/webhook.ts
@@ -255,8 +255,9 @@ export function createLinearWebhookHandler(
     }
 
     if (parsed.type === "PermissionChange") {
-      const permPayload = parsed as unknown as AppUserTeamAccessChangedWebhookPayload;
-      if (normalizeAction(permPayload.action) === "teamaccesschanged") {
+      const action = (parsed as { action?: string }).action;
+      if (normalizeAction(action) === "teamaccesschanged") {
+        const permPayload = parsed as unknown as AppUserTeamAccessChangedWebhookPayload;
         logger.info("linear_thenvoi_bridge.team_access_changed", {
           action: permPayload.action,
           addedTeamIds: permPayload.addedTeamIds,
@@ -274,7 +275,7 @@ export function createLinearWebhookHandler(
         }
       } else {
         logger.info("linear_thenvoi_bridge.permission_change_event_ignored", {
-          action: permPayload.action,
+          action,
         });
       }
 

--- a/packages/sdk/src/linear/index.ts
+++ b/packages/sdk/src/linear/index.ts
@@ -25,6 +25,7 @@ export type {
   LinearBridgeDispatchJob,
   LinearBridgeDispatcher,
   HandleAgentSessionEventInput,
+  PermissionChangeCallbacks,
   LinearActivityClient,
   LinearBridgeRuntime,
   LinearSessionStatus,

--- a/packages/sdk/tests/linear-webhook-handler.test.ts
+++ b/packages/sdk/tests/linear-webhook-handler.test.ts
@@ -419,6 +419,27 @@ describe("createLinearWebhookHandler", () => {
     expect(onTeamAccessChanged).toHaveBeenCalledOnce();
   });
 
+  it("ignores non-teamAccessChanged PermissionChange events without invoking callback", async () => {
+    const onTeamAccessChanged = vi.fn();
+    const { url } = await startServer(undefined, { onTeamAccessChanged });
+    const payload = { ...makeTeamAccessChangedPayload(), action: "somethingElse" };
+    const rawBody = JSON.stringify(payload);
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "linear-signature": sign(config.linearWebhookSecret, rawBody),
+        "linear-timestamp": String(payload.webhookTimestamp),
+      },
+      body: rawBody,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("OK");
+    expect(onTeamAccessChanged).not.toHaveBeenCalled();
+  });
+
   it("processes OAuthApp revoked webhook and invokes onOAuthAppRevoked callback", async () => {
     const onOAuthAppRevoked = vi.fn();
     const { url } = await startServer(undefined, { onOAuthAppRevoked });

--- a/packages/sdk/tests/linear-webhook-handler.test.ts
+++ b/packages/sdk/tests/linear-webhook-handler.test.ts
@@ -9,6 +9,7 @@ import {
   type LinearBridgeDispatcher,
   type LinearThenvoiBridgeConfig,
   type PendingBootstrapRequest,
+  type PermissionChangeCallbacks,
   type SessionRoomRecord,
   type SessionRoomStore,
 } from "../src/linear";
@@ -113,7 +114,7 @@ function sign(secret: string, rawBody: string): string {
   return createHmac("sha256", secret).update(rawBody).digest("hex");
 }
 
-async function startServer(dispatcher?: LinearBridgeDispatcher) {
+async function startServer(dispatcher?: LinearBridgeDispatcher, permissionCallbacks?: PermissionChangeCallbacks) {
   const store = new MemorySessionRoomStore();
   const linearClient = {
     createAgentActivity: vi.fn(async () => ({ ok: true })),
@@ -121,6 +122,7 @@ async function startServer(dispatcher?: LinearBridgeDispatcher) {
   const handler = createLinearWebhookHandler({
     config,
     dispatcher,
+    permissionCallbacks,
     deps: {
       thenvoiRest: new LinearThenvoiExampleRestApi(),
       linearClient: linearClient as never,
@@ -146,6 +148,38 @@ async function startServer(dispatcher?: LinearBridgeDispatcher) {
     linearClient,
     store,
     url: `http://127.0.0.1:${address.port}/linear/webhook`,
+  };
+}
+
+function makeTeamAccessChangedPayload(overrides?: {
+  addedTeamIds?: string[];
+  removedTeamIds?: string[];
+  canAccessAllPublicTeams?: boolean;
+}) {
+  return {
+    type: "PermissionChange",
+    action: "teamAccessChanged",
+    appUserId: "app-user",
+    createdAt: new Date(),
+    oauthClientId: "oauth-client",
+    organizationId: "org-1",
+    webhookId: "webhook-1",
+    webhookTimestamp: Date.now(),
+    addedTeamIds: overrides?.addedTeamIds ?? ["team-new"],
+    removedTeamIds: overrides?.removedTeamIds ?? ["team-old"],
+    canAccessAllPublicTeams: overrides?.canAccessAllPublicTeams ?? false,
+  };
+}
+
+function makeOAuthAppRevokedPayload() {
+  return {
+    type: "OAuthApp",
+    action: "revoked",
+    createdAt: new Date(),
+    oauthClientId: "oauth-client",
+    organizationId: "org-1",
+    webhookId: "webhook-1",
+    webhookTimestamp: Date.now(),
   };
 }
 
@@ -307,6 +341,173 @@ describe("createLinearWebhookHandler", () => {
     await expect(firstResponse.text()).resolves.toBe("OK");
     expect(dispatcher.dispatch).toHaveBeenCalledTimes(1);
     expect(linearClient.createAgentActivity).toHaveBeenCalledOnce();
+  });
+
+  it("processes PermissionChange webhook and invokes onTeamAccessChanged callback", async () => {
+    const onTeamAccessChanged = vi.fn();
+    const { url } = await startServer(undefined, { onTeamAccessChanged });
+    const payload = makeTeamAccessChangedPayload({
+      addedTeamIds: ["team-3", "team-4"],
+      removedTeamIds: ["team-1"],
+      canAccessAllPublicTeams: true,
+    });
+    const rawBody = JSON.stringify(payload);
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "linear-signature": sign(config.linearWebhookSecret, rawBody),
+        "linear-timestamp": String(payload.webhookTimestamp),
+      },
+      body: rawBody,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("OK");
+    expect(onTeamAccessChanged).toHaveBeenCalledOnce();
+    expect(onTeamAccessChanged).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "PermissionChange",
+        action: "teamAccessChanged",
+        addedTeamIds: ["team-3", "team-4"],
+        removedTeamIds: ["team-1"],
+        canAccessAllPublicTeams: true,
+      }),
+    );
+  });
+
+  it("returns 200 for PermissionChange webhook even without a callback", async () => {
+    const { url } = await startServer();
+    const payload = makeTeamAccessChangedPayload();
+    const rawBody = JSON.stringify(payload);
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "linear-signature": sign(config.linearWebhookSecret, rawBody),
+        "linear-timestamp": String(payload.webhookTimestamp),
+      },
+      body: rawBody,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("OK");
+  });
+
+  it("returns 200 for PermissionChange webhook even when callback throws", async () => {
+    const onTeamAccessChanged = vi.fn(async () => {
+      throw new Error("callback boom");
+    });
+    const { url } = await startServer(undefined, { onTeamAccessChanged });
+    const payload = makeTeamAccessChangedPayload();
+    const rawBody = JSON.stringify(payload);
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "linear-signature": sign(config.linearWebhookSecret, rawBody),
+        "linear-timestamp": String(payload.webhookTimestamp),
+      },
+      body: rawBody,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("OK");
+    expect(onTeamAccessChanged).toHaveBeenCalledOnce();
+  });
+
+  it("processes OAuthApp revoked webhook and invokes onOAuthAppRevoked callback", async () => {
+    const onOAuthAppRevoked = vi.fn();
+    const { url } = await startServer(undefined, { onOAuthAppRevoked });
+    const payload = makeOAuthAppRevokedPayload();
+    const rawBody = JSON.stringify(payload);
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "linear-signature": sign(config.linearWebhookSecret, rawBody),
+        "linear-timestamp": String(payload.webhookTimestamp),
+      },
+      body: rawBody,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("OK");
+    expect(onOAuthAppRevoked).toHaveBeenCalledOnce();
+    expect(onOAuthAppRevoked).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "OAuthApp",
+        action: "revoked",
+        oauthClientId: "oauth-client",
+      }),
+    );
+  });
+
+  it("returns 200 for OAuthApp revoked webhook even without a callback", async () => {
+    const { url } = await startServer();
+    const payload = makeOAuthAppRevokedPayload();
+    const rawBody = JSON.stringify(payload);
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "linear-signature": sign(config.linearWebhookSecret, rawBody),
+        "linear-timestamp": String(payload.webhookTimestamp),
+      },
+      body: rawBody,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("OK");
+  });
+
+  it("returns 200 for OAuthApp revoked webhook even when callback throws", async () => {
+    const onOAuthAppRevoked = vi.fn(async () => {
+      throw new Error("callback boom");
+    });
+    const { url } = await startServer(undefined, { onOAuthAppRevoked });
+    const payload = makeOAuthAppRevokedPayload();
+    const rawBody = JSON.stringify(payload);
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "linear-signature": sign(config.linearWebhookSecret, rawBody),
+        "linear-timestamp": String(payload.webhookTimestamp),
+      },
+      body: rawBody,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("OK");
+    expect(onOAuthAppRevoked).toHaveBeenCalledOnce();
+  });
+
+  it("ignores non-revoked OAuthApp events without invoking callback", async () => {
+    const onOAuthAppRevoked = vi.fn();
+    const { url } = await startServer(undefined, { onOAuthAppRevoked });
+    const payload = { ...makeOAuthAppRevokedPayload(), action: "authorized" };
+    const rawBody = JSON.stringify(payload);
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "linear-signature": sign(config.linearWebhookSecret, rawBody),
+        "linear-timestamp": String(payload.webhookTimestamp),
+      },
+      body: rawBody,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("OK");
+    expect(onOAuthAppRevoked).not.toHaveBeenCalled();
   });
 
   it("signals terminal async dispatch failures and surfaces them via waitForIdle", async () => {


### PR DESCRIPTION
## Summary

- Extends the webhook handler to process `PermissionChange` (`teamAccessChanged`) and `OAuthApp` (`revoked`) webhook types from Linear, which were previously silently acknowledged and ignored
- Adds a `permissionCallbacks` option to `createLinearWebhookHandler` so consumers can react to team access changes (log, update in-memory state) and OAuth revocations (initiate graceful shutdown)
- Callback errors are caught and logged — they never affect the 200 OK response to Linear

Closes INT-314

## Test plan

- [x] PermissionChange webhook invokes `onTeamAccessChanged` callback with correct payload
- [x] PermissionChange returns 200 OK even without a callback registered
- [x] PermissionChange returns 200 OK even when callback throws
- [x] OAuthApp revoked webhook invokes `onOAuthAppRevoked` callback with correct payload
- [x] OAuthApp revoked returns 200 OK even without a callback
- [x] OAuthApp revoked returns 200 OK even when callback throws
- [x] Non-revoked OAuthApp events (e.g. "authorized") are ignored — callback not invoked
- [x] All 7 existing webhook handler tests still pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)