### PR TITLE
feat(linear): handle stale session detection and recovery

### DIFF
--- a/packages/sdk/src/integrations/linear/bridge/handler.ts
+++ b/packages/sdk/src/integrations/linear/bridge/handler.ts
@@ -13,6 +13,7 @@ import type {
 } from "../types";
 import { dedupeHandles, stripHandlePrefix } from "../handles";
 import { postThought, postError } from "../activities";
+import { sendRecoveryActivityIfStale } from "../stale-session-guard";
 import {
   buildBridgeMessage,
   detectSessionIntent,
@@ -124,10 +125,23 @@ export async function handleAgentSessionEvent(
     return;
   }
 
+  // If the session already exists and may have gone stale, send a recovery
+  // activity before the main update so Linear reactivates the session.
+  if (action === "updated" && existingBySession) {
+    await sendRecoveryActivityIfStale({
+      session: existingBySession,
+      linearClient: input.deps.linearClient,
+      store: input.deps.store,
+      logger,
+    });
+  }
+
   // Acknowledge receipt to Linear before room resolution (created only).
+  let lastLinearActivityAt: string | null = null;
   if (action === "created" && !options?.skipAcknowledgment) {
     try {
       await postThought(input.deps.linearClient, sessionId, "Received session. Setting up workspace...");
+      lastLinearActivityAt = new Date().toISOString();
     } catch (ackError) {
       logger.warn("linear_thenvoi_bridge.acknowledgment_failed", {
         sessionId,
@@ -271,11 +285,13 @@ export async function handleAgentSessionEvent(
       });
     }
 
+    const now = new Date().toISOString();
     await saveSessionRecord(input.deps.store, {
       ...roomRecord,
       status: "active",
       lastEventKey: eventKey,
-      updatedAt: new Date().toISOString(),
+      lastLinearActivityAt: lastLinearActivityAt ?? roomRecord.lastLinearActivityAt ?? now,
+      updatedAt: now,
     });
 
     logger.info("linear_thenvoi_bridge.message_forwarded", {
@@ -351,11 +367,13 @@ export async function completeLinearSession(input: {
     return;
   }
 
+  const now = new Date().toISOString();
   await saveSessionRecord(input.store, {
     ...existing,
     status: "completed",
     lastEventKey: input.lastEventKey ?? existing.lastEventKey ?? null,
-    updatedAt: new Date().toISOString(),
+    lastLinearActivityAt: now,
+    updatedAt: now,
   });
 }
 
@@ -499,6 +517,14 @@ async function handlePromptedAction(input: {
     });
     return;
   }
+
+  // Send a recovery activity if the session may have gone stale while waiting.
+  await sendRecoveryActivityIfStale({
+    session: existing,
+    linearClient: input.deps.linearClient,
+    store: input.deps.store,
+    logger: input.logger,
+  });
 
   const message = `[Linear User Response]: ${userResponse}`;
   const metadata = {

--- a/packages/sdk/src/integrations/linear/bridge/index.ts
+++ b/packages/sdk/src/integrations/linear/bridge/index.ts
@@ -5,3 +5,9 @@ export {
   handleAgentSessionEvent,
 } from "./handler";
 export type { LinearBridgeRuntime } from "./handler";
+export {
+  StaleSessionGuard,
+  isSessionStale,
+  sendRecoveryActivityIfStale,
+} from "../stale-session-guard";
+export type { StaleSessionGuardOptions } from "../stale-session-guard";

--- a/packages/sdk/src/integrations/linear/index.ts
+++ b/packages/sdk/src/integrations/linear/index.ts
@@ -2,8 +2,11 @@ export {
   createLinearBridgeRuntime,
   completeLinearSession,
   handleAgentSessionEvent,
+  StaleSessionGuard,
+  isSessionStale,
+  sendRecoveryActivityIfStale,
 } from "./bridge";
-export type { LinearBridgeRuntime } from "./bridge";
+export type { LinearBridgeRuntime, StaleSessionGuardOptions } from "./bridge";
 export {
   buildLinearAuthorizationHeader,
   createLinearClient,
@@ -45,3 +48,4 @@ export type {
   LinearBridgeDispatcher,
 } from "./webhook";
 export { DEFAULT_STATUS_MAPPING } from "./constants";
+export { STALE_SESSION_CHECK_INTERVAL_MS, STALE_SESSION_THRESHOLD_MS } from "./types";

--- a/packages/sdk/src/integrations/linear/stale-session-guard.ts
+++ b/packages/sdk/src/integrations/linear/stale-session-guard.ts
@@ -1,0 +1,197 @@
+import type { Logger } from "../../core/logger";
+import { NoopLogger } from "../../core/logger";
+import { postThought, type LinearActivityClient } from "./activities";
+import type { SessionRoomRecord, SessionRoomStore } from "./types";
+import { STALE_SESSION_CHECK_INTERVAL_MS, STALE_SESSION_THRESHOLD_MS } from "./types";
+
+export interface StaleSessionGuardOptions {
+  store: SessionRoomStore;
+  linearClient: LinearActivityClient;
+  logger?: Logger;
+  /** Interval (ms) between keepalive checks. Defaults to 20 minutes. */
+  checkIntervalMs?: number;
+  /** Max age (ms) of last activity before sending a keepalive. Defaults to 25 minutes. */
+  staleThresholdMs?: number;
+  /** Message sent as a keepalive thought. */
+  keepAliveMessage?: string;
+}
+
+const DEFAULT_KEEPALIVE_MESSAGE =
+  "Still working — waiting for specialist output in the collaboration room.";
+
+/**
+ * Periodically checks active Linear sessions and sends a keepalive activity
+ * to prevent Linear from marking them as stale (30-minute inactivity timeout).
+ */
+export class StaleSessionGuard {
+  private readonly store: SessionRoomStore;
+  private readonly linearClient: LinearActivityClient;
+  private readonly logger: Logger;
+  private readonly checkIntervalMs: number;
+  private readonly staleThresholdMs: number;
+  private readonly keepAliveMessage: string;
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  public constructor(options: StaleSessionGuardOptions) {
+    this.store = options.store;
+    this.linearClient = options.linearClient;
+    this.logger = options.logger ?? new NoopLogger();
+    this.checkIntervalMs = options.checkIntervalMs ?? STALE_SESSION_CHECK_INTERVAL_MS;
+    this.staleThresholdMs = options.staleThresholdMs ?? STALE_SESSION_THRESHOLD_MS;
+    this.keepAliveMessage = options.keepAliveMessage ?? DEFAULT_KEEPALIVE_MESSAGE;
+  }
+
+  /** Start the periodic keepalive check. Safe to call multiple times. */
+  public start(): void {
+    if (this.timer) {
+      return;
+    }
+
+    this.logger.info("stale_session_guard.started", {
+      checkIntervalMs: this.checkIntervalMs,
+      staleThresholdMs: this.staleThresholdMs,
+    });
+
+    this.timer = setInterval(() => {
+      void this.tick();
+    }, this.checkIntervalMs);
+
+    // Allow the process to exit even if the timer is running.
+    if (typeof this.timer === "object" && "unref" in this.timer) {
+      this.timer.unref();
+    }
+  }
+
+  /** Stop the periodic keepalive check. */
+  public stop(): void {
+    if (!this.timer) {
+      return;
+    }
+
+    clearInterval(this.timer);
+    this.timer = null;
+    this.logger.info("stale_session_guard.stopped", {});
+  }
+
+  /** Run a single keepalive check. Exposed for testing and manual invocation. */
+  public async tick(): Promise<number> {
+    if (!this.store.listActiveSessions) {
+      this.logger.warn("stale_session_guard.store_missing_listActiveSessions", {});
+      return 0;
+    }
+
+    let sessions: SessionRoomRecord[];
+    try {
+      sessions = await this.store.listActiveSessions();
+    } catch (error) {
+      this.logger.error("stale_session_guard.list_sessions_failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return 0;
+    }
+
+    const now = Date.now();
+    let kept = 0;
+
+    for (const session of sessions) {
+      if (isSessionStale(session, now, this.staleThresholdMs)) {
+        try {
+          await postThought(this.linearClient, session.linearSessionId, this.keepAliveMessage);
+          const activityTimestamp = new Date().toISOString();
+          await this.store.upsert({
+            ...session,
+            lastLinearActivityAt: activityTimestamp,
+            updatedAt: activityTimestamp,
+          });
+          kept += 1;
+          this.logger.info("stale_session_guard.keepalive_sent", {
+            sessionId: session.linearSessionId,
+            lastLinearActivityAt: session.lastLinearActivityAt,
+          });
+        } catch (error) {
+          this.logger.warn("stale_session_guard.keepalive_failed", {
+            sessionId: session.linearSessionId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
+
+    if (kept > 0) {
+      this.logger.info("stale_session_guard.tick_complete", {
+        totalSessions: sessions.length,
+        keepalivesSent: kept,
+      });
+    }
+
+    return kept;
+  }
+}
+
+/**
+ * Returns `true` when the session's last Linear activity is older than
+ * `thresholdMs`, meaning it risks being marked stale by Linear.
+ */
+export function isSessionStale(
+  session: SessionRoomRecord,
+  nowMs: number,
+  thresholdMs: number,
+): boolean {
+  // If we've never tracked an activity, fall back to the record's updatedAt
+  // (which is set when the session was last written to the store).
+  const referenceIso = session.lastLinearActivityAt ?? session.updatedAt;
+  const referenceMs = new Date(referenceIso).getTime();
+
+  if (Number.isNaN(referenceMs)) {
+    return true;
+  }
+
+  return nowMs - referenceMs >= thresholdMs;
+}
+
+/**
+ * Checks whether a session may have gone stale and sends a recovery activity
+ * before the main update. Call this before posting significant activities to
+ * a session that may have been idle for a long time.
+ */
+export async function sendRecoveryActivityIfStale(input: {
+  session: SessionRoomRecord;
+  linearClient: LinearActivityClient;
+  store: SessionRoomStore;
+  logger: Logger;
+  staleThresholdMs?: number;
+}): Promise<boolean> {
+  const thresholdMs = input.staleThresholdMs ?? STALE_SESSION_THRESHOLD_MS;
+
+  if (!isSessionStale(input.session, Date.now(), thresholdMs)) {
+    return false;
+  }
+
+  try {
+    await postThought(
+      input.linearClient,
+      input.session.linearSessionId,
+      "Resuming session — reconnecting after extended specialist work.",
+    );
+
+    const now = new Date().toISOString();
+    await input.store.upsert({
+      ...input.session,
+      lastLinearActivityAt: now,
+      updatedAt: now,
+    });
+
+    input.logger.info("stale_session_guard.recovery_activity_sent", {
+      sessionId: input.session.linearSessionId,
+      lastLinearActivityAt: input.session.lastLinearActivityAt,
+    });
+
+    return true;
+  } catch (error) {
+    input.logger.warn("stale_session_guard.recovery_activity_failed", {
+      sessionId: input.session.linearSessionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}

--- a/packages/sdk/src/integrations/linear/store.ts
+++ b/packages/sdk/src/integrations/linear/store.ts
@@ -9,6 +9,7 @@ interface SessionRoomRow {
   thenvoi_room_id: string;
   status: SessionRoomRecord["status"];
   last_event_key: string | null;
+  last_linear_activity_at: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -53,6 +54,7 @@ class SqliteSessionRoomStore implements SessionRoomStore {
           thenvoi_room_id,
           status,
           last_event_key,
+          last_linear_activity_at,
           created_at,
           updated_at
         FROM linear_thenvoi_session_rooms
@@ -77,6 +79,7 @@ class SqliteSessionRoomStore implements SessionRoomStore {
           thenvoi_room_id,
           status,
           last_event_key,
+          last_linear_activity_at,
           created_at,
           updated_at
         FROM linear_thenvoi_session_rooms
@@ -102,15 +105,17 @@ class SqliteSessionRoomStore implements SessionRoomStore {
           thenvoi_room_id,
           status,
           last_event_key,
+          last_linear_activity_at,
           created_at,
           updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(linear_session_id)
         DO UPDATE SET
           linear_issue_id = excluded.linear_issue_id,
           thenvoi_room_id = excluded.thenvoi_room_id,
           status = excluded.status,
           last_event_key = excluded.last_event_key,
+          last_linear_activity_at = excluded.last_linear_activity_at,
           updated_at = excluded.updated_at
         `,
       )
@@ -120,6 +125,7 @@ class SqliteSessionRoomStore implements SessionRoomStore {
         record.thenvoiRoomId,
         record.status,
         record.lastEventKey ?? null,
+        record.lastLinearActivityAt ?? null,
         record.createdAt,
         record.updatedAt,
       );
@@ -227,6 +233,37 @@ class SqliteSessionRoomStore implements SessionRoomStore {
       .run(new Date().toISOString(), eventKey);
   }
 
+  public async listActiveSessions(): Promise<SessionRoomRecord[]> {
+    const db = await this.getDb();
+    const rawRows = db
+      .prepare(
+        `
+        SELECT
+          linear_session_id,
+          linear_issue_id,
+          thenvoi_room_id,
+          status,
+          last_event_key,
+          last_linear_activity_at,
+          created_at,
+          updated_at
+        FROM linear_thenvoi_session_rooms
+        WHERE status IN ('active', 'waiting')
+        ORDER BY updated_at DESC
+        `,
+      )
+      .all();
+
+    if (!Array.isArray(rawRows)) {
+      return [];
+    }
+
+    return rawRows
+      .map((raw) => parseSessionRoomRow(raw))
+      .filter((row): row is SessionRoomRow => row !== null)
+      .map((row) => this.toRecord(row));
+  }
+
   public async close(): Promise<void> {
     if (!this.dbPromise) {
       return;
@@ -319,6 +356,17 @@ class SqliteSessionRoomStore implements SessionRoomStore {
       }
     }
 
+    try {
+      db.exec(`
+        ALTER TABLE linear_thenvoi_session_rooms
+        ADD COLUMN last_linear_activity_at TEXT
+      `);
+    } catch (error) {
+      if (!isDuplicateColumnError(error)) {
+        throw error;
+      }
+    }
+
     return db;
   }
 
@@ -329,6 +377,7 @@ class SqliteSessionRoomStore implements SessionRoomStore {
       thenvoiRoomId: row.thenvoi_room_id,
       status: row.status,
       lastEventKey: row.last_event_key,
+      lastLinearActivityAt: row.last_linear_activity_at,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     };
@@ -398,6 +447,7 @@ function parseSessionRoomRow(value: unknown): SessionRoomRow | null {
   const thenvoiRoomId = asString(row.thenvoi_room_id);
   const status = asString(row.status);
   const lastEventKey = asNullableString(row.last_event_key);
+  const lastLinearActivityAt = asNullableString(row.last_linear_activity_at);
   const createdAt = asString(row.created_at);
   const updatedAt = asString(row.updated_at);
 
@@ -408,6 +458,7 @@ function parseSessionRoomRow(value: unknown): SessionRoomRow | null {
     || !status
     || !isSessionStatus(status)
     || lastEventKey === undefined
+    || lastLinearActivityAt === undefined
     || !createdAt
     || !updatedAt
   ) {
@@ -420,6 +471,7 @@ function parseSessionRoomRow(value: unknown): SessionRoomRow | null {
     thenvoi_room_id: thenvoiRoomId,
     status,
     last_event_key: lastEventKey,
+    last_linear_activity_at: lastLinearActivityAt,
     created_at: createdAt,
     updated_at: updatedAt,
   };

--- a/packages/sdk/src/integrations/linear/types.ts
+++ b/packages/sdk/src/integrations/linear/types.ts
@@ -8,6 +8,16 @@ export type RoomStrategy = "issue" | "session";
 export type WritebackMode = "final_only" | "activity_stream";
 export type SessionStatus = "active" | "waiting" | "completed" | "canceled" | "errored";
 
+/** Default interval (ms) between stale-session keepalive checks. */
+export const STALE_SESSION_CHECK_INTERVAL_MS = 20 * 60_000;
+
+/**
+ * Maximum age (ms) of the last Linear activity before a session is considered
+ * at risk of going stale. Linear marks sessions stale after 30 minutes of
+ * inactivity; we send a keepalive well before that threshold.
+ */
+export const STALE_SESSION_THRESHOLD_MS = 25 * 60_000;
+
 export interface LinearThenvoiBridgeConfig {
   linearAccessToken: string;
   linearWebhookSecret: string;
@@ -25,6 +35,8 @@ export interface SessionRoomRecord {
   thenvoiRoomId: string;
   status: SessionStatus;
   lastEventKey?: string | null;
+  /** ISO-8601 timestamp of the last activity sent to Linear for this session. */
+  lastLinearActivityAt?: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -50,6 +62,8 @@ export interface SessionRoomStore {
   enqueueBootstrapRequest(request: PendingBootstrapRequest): Promise<void>;
   listPendingBootstrapRequests(limit?: number): Promise<PendingBootstrapRequest[]>;
   markBootstrapRequestProcessed(eventKey: string): Promise<void>;
+  /** List sessions with active or waiting status (used by stale-session keepalive). */
+  listActiveSessions?(): Promise<SessionRoomRecord[]>;
   close?(): Promise<void>;
 }
 

--- a/packages/sdk/src/linear/index.ts
+++ b/packages/sdk/src/linear/index.ts
@@ -1,5 +1,8 @@
 export {
   DEFAULT_STATUS_MAPPING,
+  STALE_SESSION_CHECK_INTERVAL_MS,
+  STALE_SESSION_THRESHOLD_MS,
+  StaleSessionGuard,
   buildLinearAuthorizationHeader,
   completeLinearSession,
   createLinearClient,
@@ -11,12 +14,14 @@ export {
   createSqliteSessionRoomStore,
   dedupeHandles,
   handleAgentSessionEvent,
+  isSessionStale,
   postAction,
   postElicitation,
   postError,
   postResponse,
   postThought,
   isLinearApiKey,
+  sendRecoveryActivityIfStale,
   stripHandlePrefix,
   updatePlan,
 } from "../integrations/linear";
@@ -36,5 +41,6 @@ export type {
   SessionRoomRecord,
   SessionRoomStore,
   SessionStatus,
+  StaleSessionGuardOptions,
   WritebackMode,
 } from "../integrations/linear";

--- a/packages/sdk/tests/linear-stale-session-guard.test.ts
+++ b/packages/sdk/tests/linear-stale-session-guard.test.ts
@@ -1,0 +1,329 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  StaleSessionGuard,
+  isSessionStale,
+  sendRecoveryActivityIfStale,
+  type LinearActivityClient,
+  type SessionRoomRecord,
+  type SessionRoomStore,
+  type PendingBootstrapRequest,
+  STALE_SESSION_THRESHOLD_MS,
+} from "../src/linear";
+
+function makeMockClient(): LinearActivityClient & {
+  calls: Array<{ agentSessionId: string; content: Record<string, unknown> }>;
+} {
+  const calls: Array<{ agentSessionId: string; content: Record<string, unknown> }> = [];
+  return {
+    calls,
+    createAgentActivity: vi.fn(async (input) => {
+      calls.push(input);
+      return { ok: true };
+    }),
+  };
+}
+
+function makeRecord(overrides?: Partial<SessionRoomRecord>): SessionRoomRecord {
+  const now = new Date().toISOString();
+  return {
+    linearSessionId: "session-1",
+    linearIssueId: "issue-1",
+    thenvoiRoomId: "room-1",
+    status: "active",
+    lastEventKey: null,
+    lastLinearActivityAt: now,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+class MemorySessionRoomStore implements SessionRoomStore {
+  public readonly records = new Map<string, SessionRoomRecord>();
+  public readonly bootstrapRequests = new Map<string, PendingBootstrapRequest>();
+
+  public async getBySessionId(sessionId: string): Promise<SessionRoomRecord | null> {
+    return this.records.get(sessionId) ?? null;
+  }
+
+  public async getByIssueId(issueId: string): Promise<SessionRoomRecord | null> {
+    const values = [...this.records.values()]
+      .filter((r) => r.linearIssueId === issueId && r.status !== "canceled")
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+    return values[0] ?? null;
+  }
+
+  public async upsert(record: SessionRoomRecord): Promise<void> {
+    this.records.set(record.linearSessionId, record);
+  }
+
+  public async markCanceled(sessionId: string): Promise<void> {
+    const current = this.records.get(sessionId);
+    if (current) {
+      this.records.set(sessionId, { ...current, status: "canceled", updatedAt: new Date().toISOString() });
+    }
+  }
+
+  public async enqueueBootstrapRequest(request: PendingBootstrapRequest): Promise<void> {
+    this.bootstrapRequests.set(request.eventKey, request);
+  }
+
+  public async listPendingBootstrapRequests(): Promise<PendingBootstrapRequest[]> {
+    return [...this.bootstrapRequests.values()];
+  }
+
+  public async markBootstrapRequestProcessed(eventKey: string): Promise<void> {
+    this.bootstrapRequests.delete(eventKey);
+  }
+
+  public async listActiveSessions(): Promise<SessionRoomRecord[]> {
+    return [...this.records.values()].filter(
+      (r) => r.status === "active" || r.status === "waiting",
+    );
+  }
+}
+
+describe("isSessionStale", () => {
+  it("returns true when session has no lastLinearActivityAt and updatedAt is old", () => {
+    const thirtyMinutesAgo = new Date(Date.now() - 30 * 60_000).toISOString();
+    const session = makeRecord({
+      lastLinearActivityAt: null,
+      updatedAt: thirtyMinutesAgo,
+    });
+
+    expect(isSessionStale(session, Date.now(), STALE_SESSION_THRESHOLD_MS)).toBe(true);
+  });
+
+  it("returns false when lastLinearActivityAt is recent", () => {
+    const session = makeRecord({
+      lastLinearActivityAt: new Date().toISOString(),
+    });
+
+    expect(isSessionStale(session, Date.now(), STALE_SESSION_THRESHOLD_MS)).toBe(false);
+  });
+
+  it("returns true when lastLinearActivityAt exceeds threshold", () => {
+    const old = new Date(Date.now() - 26 * 60_000).toISOString();
+    const session = makeRecord({ lastLinearActivityAt: old });
+
+    expect(isSessionStale(session, Date.now(), STALE_SESSION_THRESHOLD_MS)).toBe(true);
+  });
+
+  it("falls back to updatedAt when lastLinearActivityAt is null", () => {
+    const recent = new Date(Date.now() - 5 * 60_000).toISOString();
+    const session = makeRecord({
+      lastLinearActivityAt: null,
+      updatedAt: recent,
+    });
+
+    expect(isSessionStale(session, Date.now(), STALE_SESSION_THRESHOLD_MS)).toBe(false);
+  });
+
+  it("returns true when reference date is invalid", () => {
+    const session = makeRecord({
+      lastLinearActivityAt: "invalid-date",
+    });
+
+    expect(isSessionStale(session, Date.now(), STALE_SESSION_THRESHOLD_MS)).toBe(true);
+  });
+});
+
+describe("sendRecoveryActivityIfStale", () => {
+  it("sends a recovery activity when session is stale", async () => {
+    const client = makeMockClient();
+    const store = new MemorySessionRoomStore();
+    const old = new Date(Date.now() - 30 * 60_000).toISOString();
+    const session = makeRecord({ lastLinearActivityAt: old });
+    store.records.set(session.linearSessionId, session);
+
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    const recovered = await sendRecoveryActivityIfStale({
+      session,
+      linearClient: client,
+      store,
+      logger,
+    });
+
+    expect(recovered).toBe(true);
+    expect(client.calls).toHaveLength(1);
+    expect(client.calls[0]).toMatchObject({
+      agentSessionId: "session-1",
+      content: { type: "thought" },
+    });
+    // Store should be updated with new timestamp
+    const updated = store.records.get("session-1");
+    expect(updated?.lastLinearActivityAt).not.toBe(old);
+  });
+
+  it("does not send activity when session is fresh", async () => {
+    const client = makeMockClient();
+    const store = new MemorySessionRoomStore();
+    const session = makeRecord();
+
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    const recovered = await sendRecoveryActivityIfStale({
+      session,
+      linearClient: client,
+      store,
+      logger,
+    });
+
+    expect(recovered).toBe(false);
+    expect(client.calls).toHaveLength(0);
+  });
+
+  it("returns false and logs warning when activity post fails", async () => {
+    const client = makeMockClient();
+    client.createAgentActivity = vi.fn(async () => {
+      throw new Error("network error");
+    });
+    const store = new MemorySessionRoomStore();
+    const old = new Date(Date.now() - 30 * 60_000).toISOString();
+    const session = makeRecord({ lastLinearActivityAt: old });
+
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    const recovered = await sendRecoveryActivityIfStale({
+      session,
+      linearClient: client,
+      store,
+      logger,
+    });
+
+    expect(recovered).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "stale_session_guard.recovery_activity_failed",
+      expect.objectContaining({ sessionId: "session-1" }),
+    );
+  });
+});
+
+describe("StaleSessionGuard", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("tick sends keepalive for stale sessions", async () => {
+    const client = makeMockClient();
+    const store = new MemorySessionRoomStore();
+    const old = new Date(Date.now() - 26 * 60_000).toISOString();
+    store.records.set("session-stale", makeRecord({
+      linearSessionId: "session-stale",
+      lastLinearActivityAt: old,
+    }));
+    store.records.set("session-fresh", makeRecord({
+      linearSessionId: "session-fresh",
+      lastLinearActivityAt: new Date().toISOString(),
+    }));
+
+    const guard = new StaleSessionGuard({ store, linearClient: client });
+    const kept = await guard.tick();
+
+    expect(kept).toBe(1);
+    expect(client.calls).toHaveLength(1);
+    expect(client.calls[0]?.agentSessionId).toBe("session-stale");
+  });
+
+  it("tick skips completed/canceled sessions", async () => {
+    const client = makeMockClient();
+    const store = new MemorySessionRoomStore();
+    const old = new Date(Date.now() - 30 * 60_000).toISOString();
+    store.records.set("session-completed", makeRecord({
+      linearSessionId: "session-completed",
+      status: "completed",
+      lastLinearActivityAt: old,
+    }));
+    store.records.set("session-canceled", makeRecord({
+      linearSessionId: "session-canceled",
+      status: "canceled",
+      lastLinearActivityAt: old,
+    }));
+
+    const guard = new StaleSessionGuard({ store, linearClient: client });
+    const kept = await guard.tick();
+
+    expect(kept).toBe(0);
+    expect(client.calls).toHaveLength(0);
+  });
+
+  it("tick returns 0 when store lacks listActiveSessions", async () => {
+    const client = makeMockClient();
+    const storeWithoutList: SessionRoomStore = {
+      getBySessionId: vi.fn(async () => null),
+      getByIssueId: vi.fn(async () => null),
+      upsert: vi.fn(async () => {}),
+      markCanceled: vi.fn(async () => {}),
+      enqueueBootstrapRequest: vi.fn(async () => {}),
+      listPendingBootstrapRequests: vi.fn(async () => []),
+      markBootstrapRequestProcessed: vi.fn(async () => {}),
+    };
+
+    const guard = new StaleSessionGuard({ store: storeWithoutList, linearClient: client });
+    const kept = await guard.tick();
+
+    expect(kept).toBe(0);
+  });
+
+  it("start and stop manage the interval timer", () => {
+    const client = makeMockClient();
+    const store = new MemorySessionRoomStore();
+
+    const guard = new StaleSessionGuard({
+      store,
+      linearClient: client,
+      checkIntervalMs: 1000,
+    });
+
+    guard.start();
+    // Starting again is a no-op.
+    guard.start();
+
+    guard.stop();
+    // Stopping again is a no-op.
+    guard.stop();
+  });
+
+  it("tick updates lastLinearActivityAt in store after keepalive", async () => {
+    const client = makeMockClient();
+    const store = new MemorySessionRoomStore();
+    const old = new Date(Date.now() - 30 * 60_000).toISOString();
+    store.records.set("session-1", makeRecord({
+      linearSessionId: "session-1",
+      lastLinearActivityAt: old,
+    }));
+
+    const guard = new StaleSessionGuard({ store, linearClient: client });
+    await guard.tick();
+
+    const updated = store.records.get("session-1");
+    expect(updated?.lastLinearActivityAt).not.toBe(old);
+    expect(new Date(updated!.lastLinearActivityAt!).getTime()).toBeGreaterThan(
+      new Date(old).getTime(),
+    );
+  });
+
+  it("uses custom keepalive message", async () => {
+    const client = makeMockClient();
+    const store = new MemorySessionRoomStore();
+    const old = new Date(Date.now() - 30 * 60_000).toISOString();
+    store.records.set("session-1", makeRecord({
+      linearSessionId: "session-1",
+      lastLinearActivityAt: old,
+    }));
+
+    const guard = new StaleSessionGuard({
+      store,
+      linearClient: client,
+      keepAliveMessage: "Custom keepalive",
+    });
+    await guard.tick();
+
+    expect(client.calls[0]?.content).toMatchObject({
+      body: "Custom keepalive",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `lastLinearActivityAt` field to `SessionRoomRecord` to track when the last activity was sent to Linear for each session
- Implements `StaleSessionGuard` class with periodic keepalive checks (default every 20 min) that sends a `postThought` to Linear before sessions go stale (Linear's 30-min inactivity timeout)
- Adds `sendRecoveryActivityIfStale()` called automatically in `handlePromptedAction` and `handleAgentSessionEvent` (updated action) to reactivate potentially stale sessions before main updates
- Updates SQLite store with new column migration and `listActiveSessions()` query
- `listActiveSessions` is optional on `SessionRoomStore` to avoid breaking custom implementations

## Test plan

- [x] 14 new unit tests covering `isSessionStale`, `sendRecoveryActivityIfStale`, and `StaleSessionGuard` (tick, start/stop, store without method, custom messages)
- [x] All 72 existing linear tests pass
- [x] Full test suite passes (553 tests, 84 files)
- [x] Typecheck clean
- [x] Lint clean (no new warnings)

Closes INT-313

🤖 Generated with [Claude Code](https://claude.com/claude-code)