### PR TITLE
feat(linear): support ephemeral activities for temporary status indicators

### DIFF
--- a/packages/sdk/examples/linear-thenvoi/linear-thenvoi-bridge-agent.ts
+++ b/packages/sdk/examples/linear-thenvoi/linear-thenvoi-bridge-agent.ts
@@ -125,8 +125,8 @@ Rules:
 - If you call get_issue or list_comments, use the exact UUID issue_id from the bridge payload. Never use issue_identifier with those tools.
 - Never create or modify a Linear ticket without asking the user for permission first.
 - Use the exact Linear tool names exposed in this room:
-  - linear_post_thought for bridge reasoning updates
-  - linear_post_action for visible work progress
+  - linear_post_thought for bridge reasoning updates (set ephemeral: true for transient status like "Thinking…" or "Looking up peers…")
+  - linear_post_action for visible work progress (set ephemeral: true for transient steps like "Searching codebase…")
   - linear_post_error for failures
   - linear_post_response for the final answer and session completion
   - linear_update_plan when you have a step list worth showing (renders as a native checklist in the Linear Agent Session UI with live status indicators)
@@ -150,6 +150,7 @@ Rules:
 - If the request is implementation, ask a relevant implementation specialist to work in an isolated workspace and report concrete files, run steps, and blockers.
 - Use linear_add_issue_comment for durable handoff notes when the plan or implementation summary should live on the ticket itself.
 - Do not create chatter. Use linear_post_thought and linear_post_action only when state meaningfully changes.
+- Use ephemeral: true for transient status indicators (connecting, looking up peers, waiting for specialist) that will be replaced by the next activity. Omit ephemeral (or set false) for meaningful milestones that should stay in the session feed.
 - Do not restate completion after the session is already complete.
 - Use linear_ask_user only when the room is blocked on human input.
 - Use linear_post_response only after you have enough information to give the user the final answer.

--- a/packages/sdk/src/integrations/linear/activities.ts
+++ b/packages/sdk/src/integrations/linear/activities.ts
@@ -47,8 +47,9 @@ async function postBodyActivity(
   sessionId: string,
   type: L.AgentActivityType,
   body: string,
+  options?: { ephemeral?: boolean },
 ): Promise<void> {
-  await postActivity(client, sessionId, { type, body });
+  await postActivity(client, sessionId, { type, body }, options);
 }
 
 export async function postThought(
@@ -57,7 +58,7 @@ export async function postThought(
   body: string,
   options?: { ephemeral?: boolean },
 ): Promise<void> {
-  await postActivity(client, sessionId, { type: L.AgentActivityType.Thought, body }, options);
+  await postBodyActivity(client, sessionId, L.AgentActivityType.Thought, body, options);
 }
 
 export async function postError(

--- a/packages/sdk/src/integrations/linear/activities.ts
+++ b/packages/sdk/src/integrations/linear/activities.ts
@@ -7,6 +7,7 @@ export interface LinearActivityClient {
   createAgentActivity(input: {
     agentSessionId: string;
     content: Record<string, unknown>;
+    ephemeral?: boolean;
   }): Promise<unknown>;
   updateAgentSession?: (
     id: string,
@@ -32,10 +33,12 @@ async function postActivity(
   client: LinearActivityClient,
   sessionId: string,
   content: Record<string, unknown>,
+  options?: { ephemeral?: boolean },
 ): Promise<void> {
   await client.createAgentActivity({
     agentSessionId: sessionId,
     content,
+    ...(options?.ephemeral ? { ephemeral: true } : {}),
   });
 }
 
@@ -52,8 +55,9 @@ export async function postThought(
   client: LinearActivityClient,
   sessionId: string,
   body: string,
+  options?: { ephemeral?: boolean },
 ): Promise<void> {
-  await postBodyActivity(client, sessionId, L.AgentActivityType.Thought, body);
+  await postActivity(client, sessionId, { type: L.AgentActivityType.Thought, body }, options);
 }
 
 export async function postError(
@@ -84,12 +88,13 @@ export async function postAction(
   client: LinearActivityClient,
   sessionId: string,
   body: string,
+  options?: { ephemeral?: boolean },
 ): Promise<void> {
   await postActivity(client, sessionId, {
     type: L.AgentActivityType.Action,
     action: body,
     parameter: "",
-  });
+  }, options);
 }
 
 type LinearPlanStatus = "pending" | "inProgress" | "completed" | "canceled";

--- a/packages/sdk/src/integrations/linear/tools.ts
+++ b/packages/sdk/src/integrations/linear/tools.ts
@@ -67,7 +67,7 @@ export function createLinearTools(options: CreateLinearToolsOptions): CustomTool
         client,
         args.session_id as string,
         args.body as string,
-        args.ephemeral ? { ephemeral: true } : undefined,
+        args.ephemeral === true ? { ephemeral: true } : undefined,
       );
       return { ok: true };
     },
@@ -83,7 +83,7 @@ export function createLinearTools(options: CreateLinearToolsOptions): CustomTool
         client,
         args.session_id as string,
         args.body as string,
-        args.ephemeral ? { ephemeral: true } : undefined,
+        args.ephemeral === true ? { ephemeral: true } : undefined,
       );
       return { ok: true };
     },

--- a/packages/sdk/src/integrations/linear/tools.ts
+++ b/packages/sdk/src/integrations/linear/tools.ts
@@ -50,23 +50,44 @@ export function createLinearTools(options: CreateLinearToolsOptions): CustomTool
     });
   };
 
-  addSessionBodyTool(
-    "linear_post_thought",
-    "Post a thought to the Linear agent session, visible to the user as internal reasoning.",
-    async (args) => {
-      await postThought(client, args.session_id as string, args.body as string);
-      return { ok: true };
-    },
-  );
+  const ephemeralSessionBodySchema = sessionBodySchema.extend({
+    ephemeral: z.boolean().optional().describe(
+      "If true, this activity is displayed temporarily and replaced when the next activity arrives. " +
+      "Use for transient status indicators like \"Thinking...\", \"Searching...\", or \"Waiting for response...\".",
+    ),
+  });
 
-  addSessionBodyTool(
-    "linear_post_action",
-    "Post an action to the Linear agent session, showing the user what step is being taken.",
-    async (args) => {
-      await postAction(client, args.session_id as string, args.body as string);
+  tools.push({
+    name: "linear_post_thought",
+    description: "Post a thought to the Linear agent session, visible to the user as internal reasoning. " +
+      "Set ephemeral: true for transient status updates that should disappear when the next activity arrives.",
+    schema: ephemeralSessionBodySchema,
+    handler: async (args: Record<string, unknown>) => {
+      await postThought(
+        client,
+        args.session_id as string,
+        args.body as string,
+        args.ephemeral ? { ephemeral: true } : undefined,
+      );
       return { ok: true };
     },
-  );
+  });
+
+  tools.push({
+    name: "linear_post_action",
+    description: "Post an action to the Linear agent session, showing the user what step is being taken. " +
+      "Set ephemeral: true for transient status updates that should disappear when the next activity arrives.",
+    schema: ephemeralSessionBodySchema,
+    handler: async (args: Record<string, unknown>) => {
+      await postAction(
+        client,
+        args.session_id as string,
+        args.body as string,
+        args.ephemeral ? { ephemeral: true } : undefined,
+      );
+      return { ok: true };
+    },
+  });
 
   addSessionBodyTool(
     "linear_post_error",

--- a/packages/sdk/src/integrations/linear/tools.ts
+++ b/packages/sdk/src/integrations/linear/tools.ts
@@ -57,37 +57,38 @@ export function createLinearTools(options: CreateLinearToolsOptions): CustomTool
     ),
   });
 
-  tools.push({
-    name: "linear_post_thought",
-    description: "Post a thought to the Linear agent session, visible to the user as internal reasoning. " +
-      "Set ephemeral: true for transient status updates that should disappear when the next activity arrives.",
-    schema: ephemeralSessionBodySchema,
-    handler: async (args: Record<string, unknown>) => {
-      await postThought(
-        client,
-        args.session_id as string,
-        args.body as string,
-        args.ephemeral === true ? { ephemeral: true } : undefined,
-      );
-      return { ok: true };
-    },
-  });
+  const addEphemeralSessionBodyTool = (
+    name: string,
+    description: string,
+    activityFn: typeof postThought,
+  ): void => {
+    tools.push({
+      name,
+      description: description + " Set ephemeral: true for transient status updates that should disappear when the next activity arrives.",
+      schema: ephemeralSessionBodySchema,
+      handler: async (args: Record<string, unknown>) => {
+        await activityFn(
+          client,
+          args.session_id as string,
+          args.body as string,
+          args.ephemeral === true ? { ephemeral: true } : undefined,
+        );
+        return { ok: true };
+      },
+    });
+  };
 
-  tools.push({
-    name: "linear_post_action",
-    description: "Post an action to the Linear agent session, showing the user what step is being taken. " +
-      "Set ephemeral: true for transient status updates that should disappear when the next activity arrives.",
-    schema: ephemeralSessionBodySchema,
-    handler: async (args: Record<string, unknown>) => {
-      await postAction(
-        client,
-        args.session_id as string,
-        args.body as string,
-        args.ephemeral === true ? { ephemeral: true } : undefined,
-      );
-      return { ok: true };
-    },
-  });
+  addEphemeralSessionBodyTool(
+    "linear_post_thought",
+    "Post a thought to the Linear agent session, visible to the user as internal reasoning.",
+    postThought,
+  );
+
+  addEphemeralSessionBodyTool(
+    "linear_post_action",
+    "Post an action to the Linear agent session, showing the user what step is being taken.",
+    postAction,
+  );
 
   addSessionBodyTool(
     "linear_post_error",

--- a/packages/sdk/tests/linear-activities.test.ts
+++ b/packages/sdk/tests/linear-activities.test.ts
@@ -43,6 +43,28 @@ describe("linear activities", () => {
     });
   });
 
+  it("postThought passes ephemeral flag as top-level field", async () => {
+    const client = makeMockClient();
+    await postThought(client, "session-1", "Thinking...", { ephemeral: true });
+
+    expect(client.calls).toHaveLength(1);
+    expect(client.createAgentActivity).toHaveBeenCalledWith({
+      agentSessionId: "session-1",
+      content: { type: "thought", body: "Thinking..." },
+      ephemeral: true,
+    });
+  });
+
+  it("postThought omits ephemeral when not set", async () => {
+    const client = makeMockClient();
+    await postThought(client, "session-1", "Important finding");
+
+    expect(client.createAgentActivity).toHaveBeenCalledWith({
+      agentSessionId: "session-1",
+      content: { type: "thought", body: "Important finding" },
+    });
+  });
+
   it("postAction calls createAgentActivity with action type", async () => {
     const client = makeMockClient();
     await postAction(client, "session-2", "Searching codebase");
@@ -51,6 +73,17 @@ describe("linear activities", () => {
     expect(client.calls[0]).toMatchObject({
       agentSessionId: "session-2",
       content: { type: "action", action: "Searching codebase", parameter: "" },
+    });
+  });
+
+  it("postAction passes ephemeral flag as top-level field", async () => {
+    const client = makeMockClient();
+    await postAction(client, "session-2", "Searching...", { ephemeral: true });
+
+    expect(client.createAgentActivity).toHaveBeenCalledWith({
+      agentSessionId: "session-2",
+      content: { type: "action", action: "Searching...", parameter: "" },
+      ephemeral: true,
     });
   });
 

--- a/packages/sdk/tests/linear-tools.test.ts
+++ b/packages/sdk/tests/linear-tools.test.ts
@@ -161,6 +161,44 @@ describe("createLinearTools", () => {
     });
   });
 
+  it("linear_post_thought passes ephemeral flag to the activity layer", async () => {
+    const client = makeMockClient();
+    const tools = createLinearTools({ client });
+    const tool = tools.find((entry) => entry.name === "linear_post_thought")!;
+
+    const result = await executeCustomTool(tool, {
+      session_id: "sess-1",
+      body: "Thinking...",
+      ephemeral: true,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(client.createAgentActivity).toHaveBeenCalledWith({
+      agentSessionId: "sess-1",
+      content: { type: "thought", body: "Thinking..." },
+      ephemeral: true,
+    });
+  });
+
+  it("linear_post_action passes ephemeral flag to the activity layer", async () => {
+    const client = makeMockClient();
+    const tools = createLinearTools({ client });
+    const tool = tools.find((entry) => entry.name === "linear_post_action")!;
+
+    const result = await executeCustomTool(tool, {
+      session_id: "sess-1",
+      body: "Searching...",
+      ephemeral: true,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(client.createAgentActivity).toHaveBeenCalledWith({
+      agentSessionId: "sess-1",
+      content: { type: "action", action: "Searching...", parameter: "" },
+      ephemeral: true,
+    });
+  });
+
   it("linear_ask_user validates and calls the activity layer", async () => {
     const client = makeMockClient();
     const tools = createLinearTools({ client });


### PR DESCRIPTION
## Summary
- Add optional `ephemeral` flag to `postThought` and `postAction` so transient status updates (e.g. "Thinking…", "Searching…") are displayed temporarily in the Linear session UI and replaced by the next activity
- The flag is passed as a top-level field on `createAgentActivity` input, not inside the content object
- Update bridge agent prompt with guidance on when to use ephemeral vs permanent activities
- Add 5 tests covering ephemeral flag propagation through both the activity layer and tools layer

Closes INT-311

## Test plan
- [x] Unit tests for `postThought` with ephemeral flag
- [x] Unit tests for `postThought` without ephemeral flag (no extra field sent)
- [x] Unit tests for `postAction` with ephemeral flag
- [x] Unit tests for `linear_post_thought` tool ephemeral propagation
- [x] Unit tests for `linear_post_action` tool ephemeral propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)