### PR TITLE
feat(linear): rename agent to Band Linear PM (INT-310)

### DIFF
--- a/packages/sdk/.env.local.example
+++ b/packages/sdk/.env.local.example
@@ -13,5 +13,5 @@ CODEX_MODEL=gpt-5.3-codex
 PORT=8787
 
 # Optional if the embedded Band Linear PM agent should load a specific config entry.
-# If omitted, the bridge uses the default linear_thenvoi_bridge config key.
+# If omitted, the agent uses the default linear_thenvoi_bridge config key.
 LINEAR_THENVOI_BRIDGE_RUNTIME_CONFIG_KEY=linear_thenvoi_bridge

--- a/packages/sdk/.env.local.example
+++ b/packages/sdk/.env.local.example
@@ -12,6 +12,6 @@ THENVOI_HOST_AGENT_HANDLE=your-org/linear-orchestrator
 CODEX_MODEL=gpt-5.3-codex
 PORT=8787
 
-# Optional if the embedded bridge agent should load a specific config entry.
+# Optional if the embedded Band Linear PM agent should load a specific config entry.
 # If omitted, the bridge uses the default linear_thenvoi_bridge config key.
 LINEAR_THENVOI_BRIDGE_RUNTIME_CONFIG_KEY=linear_thenvoi_bridge

--- a/packages/sdk/agent_config.yaml.example
+++ b/packages/sdk/agent_config.yaml.example
@@ -55,7 +55,7 @@ custom_adapter_agent:
   api_key: "your-api-key"
 
 linear_thenvoi_bridge:
-  agent_id: "your-linear-bridge-agent-id"
+  agent_id: "your-band-linear-pm-agent-id"
   api_key: "your-api-key"
 
 planner_agent:

--- a/packages/sdk/examples/linear-thenvoi/README.md
+++ b/packages/sdk/examples/linear-thenvoi/README.md
@@ -14,13 +14,13 @@ The SQLite session-room mapping uses `node:sqlite`, so this example requires Nod
 ## Files
 
 - `examples/linear-thenvoi/linear-thenvoi-bridge-server.ts`
-  Real webhook server and embedded bridge runtime.
+  Webhook server and embedded Band Linear PM runtime.
 - `examples/linear-thenvoi/linear-thenvoi-bridge-agent.ts`
   Band Linear PM agent using the Codex adapter and Linear tools.
 
 ## Environment
 
-Create a local `.env.local` from `.env.local.example`. The bridge only needs a few real values:
+Create a local `.env.local` from `.env.local.example`. The agent only needs a few real values:
 
 ```bash
 LINEAR_ACCESS_TOKEN=lin_api_xxx
@@ -44,7 +44,7 @@ Recommended agent config key:
 
 - `linear_thenvoi_bridge`
 
-## Run The Bridge
+## Run
 
 ```bash
 pnpm dev:linear
@@ -83,5 +83,5 @@ https://<your-tunnel-host>/linear/webhook
 - `roomStrategy: "session"` creates a new Thenvoi room per Linear session.
 - `writebackMode: "activity_stream"` posts intermediate Linear activity updates.
 - `writebackMode: "final_only"` keeps writeback minimal until completion.
-- The bridge uses peer discovery and room context to pick relevant external specialists at runtime.
+- Band Linear PM uses peer discovery and room context to pick relevant external specialists at runtime.
 - For planning work, Band Linear PM sends the full issue context to the planner, ends its turn, and continues when specialist output appears.

--- a/packages/sdk/examples/linear-thenvoi/README.md
+++ b/packages/sdk/examples/linear-thenvoi/README.md
@@ -1,13 +1,13 @@
-# Linear + Thenvoi Example
+# Band Linear PM
 
-This example is the real Linear bridge path:
+This example runs the Band Linear PM agent — the Linear-facing coordinator that:
 
 1. Linear sends an `AgentSessionEvent` webhook to `/linear/webhook`
 2. the bridge resolves or reuses a Thenvoi room for that issue
-3. the embedded bridge agent coordinates real Thenvoi specialists in that room
+3. Band Linear PM coordinates real Thenvoi specialists in that room
 4. the bridge writes progress and the final response back to Linear
 
-The bridge is the only Linear-aware participant. Planner, reviewer, and coder agents stay Linear-agnostic and communicate only through Thenvoi room messages.
+Band Linear PM is the only Linear-aware participant. Planner, reviewer, and coder agents stay Linear-agnostic and communicate only through Thenvoi room messages.
 
 The SQLite session-room mapping uses `node:sqlite`, so this example requires Node.js 22+.
 
@@ -16,7 +16,7 @@ The SQLite session-room mapping uses `node:sqlite`, so this example requires Nod
 - `examples/linear-thenvoi/linear-thenvoi-bridge-server.ts`
   Real webhook server and embedded bridge runtime.
 - `examples/linear-thenvoi/linear-thenvoi-bridge-agent.ts`
-  Real bridge agent using the Codex adapter and Linear tools.
+  Band Linear PM agent using the Codex adapter and Linear tools.
 
 ## Environment
 
@@ -50,7 +50,7 @@ Recommended agent config key:
 pnpm dev:linear
 ```
 
-That starts the webhook server and the embedded bridge agent in one process.
+That starts the webhook server and the embedded Band Linear PM agent in one process.
 
 Health check:
 
@@ -84,4 +84,4 @@ https://<your-tunnel-host>/linear/webhook
 - `writebackMode: "activity_stream"` posts intermediate Linear activity updates.
 - `writebackMode: "final_only"` keeps writeback minimal until completion.
 - The bridge uses peer discovery and room context to pick relevant external specialists at runtime.
-- For planning work, the bridge should send the full issue context to the planner, end its turn, and continue when specialist output appears.
+- For planning work, Band Linear PM sends the full issue context to the planner, ends its turn, and continues when specialist output appears.

--- a/packages/sdk/examples/linear-thenvoi/README.md
+++ b/packages/sdk/examples/linear-thenvoi/README.md
@@ -3,9 +3,9 @@
 This example runs the Band Linear PM agent — the Linear-facing coordinator that:
 
 1. Linear sends an `AgentSessionEvent` webhook to `/linear/webhook`
-2. the bridge resolves or reuses a Thenvoi room for that issue
+2. the server resolves or reuses a Thenvoi room for that issue
 3. Band Linear PM coordinates real Thenvoi specialists in that room
-4. the bridge writes progress and the final response back to Linear
+4. progress and the final response are written back to Linear
 
 Band Linear PM is the only Linear-aware participant. Planner, reviewer, and coder agents stay Linear-agnostic and communicate only through Thenvoi room messages.
 

--- a/packages/sdk/examples/linear-thenvoi/linear-thenvoi-bridge-agent.ts
+++ b/packages/sdk/examples/linear-thenvoi/linear-thenvoi-bridge-agent.ts
@@ -119,13 +119,13 @@ Rules:
   - the first planner kickoff must happen in the room with thenvoi_send_message so the planner sees the full context
   - include all of this in that kickoff message: issue title, issue identifier or URL when available, issue description, the latest user ask, relevant workflow context, any constraints, and the exact deliverable you want back
   - if a reviewer is also available, ask the reviewer to tighten the returned planner draft before final writeback
-  - only fall back to a bridge-authored plan after you have actually tried the planner path and no visible planner output arrives
+  - only fall back to your own plan after you have actually tried the planner path and no visible planner output arrives
 - Use linear_get_issue and linear_list_issue_comments when you need authoritative ticket reads.
 - Use linear_list_workflow_states before moving an issue into a review state so you use the correct state id for that team.
 - If you call get_issue or list_comments, use the exact UUID issue_id from the bridge payload. Never use issue_identifier with those tools.
 - Never create or modify a Linear ticket without asking the user for permission first.
 - Use the exact Linear tool names exposed in this room:
-  - linear_post_thought for bridge reasoning updates
+  - linear_post_thought for reasoning updates
   - linear_post_action for visible work progress
   - linear_post_error for failures
   - linear_post_response for the final answer and session completion
@@ -133,7 +133,7 @@ Rules:
   - linear_select to present the user with clickable options (when elicitation is enabled)
   - linear_ask_user with options for structured choices, without options for free-text questions
   - linear_request_auth when external account linking is required
-- Start alone, but inspect available peers before deciding whether the bridge should handle the work itself.
+- Start alone, but inspect available peers before deciding whether you should handle the work yourself.
 - Only use thenvoi_lookup_peers when the room does not already contain a clearly relevant collaborator or when you need to replace/expand the current set of specialists. Choose collaborators based on the actual request and the visible peer identity you observe, not from a fixed handoff graph.
 - If you choose a specialist who is not already present, add them to the room before you ask for work.
 - Add specialists with thenvoi_add_participant using the exact peer name returned by thenvoi_lookup_peers. Do not pass a handle as the name. Omit role unless you need one; if you do set it, use member.
@@ -144,7 +144,7 @@ Rules:
 - When you invite a specialist, ask for one concrete deliverable and wait briefly for their reply before deciding the next step.
 - Once you have sent a specialist kickoff message and the next step depends on their reply, end your turn. Do not invent an immediate fallback in the same turn just because no reply is visible yet.
 - Treat specialist collaboration as asynchronous room work. The correct behavior after delegation is usually to stop, wait for the room to update, and continue on the next turn when a specialist message arrives.
-- Do not block indefinitely on silent specialists. If a collaborator does not make visible progress after a short attempt, say that explicitly and continue with the best bridge-only response or choose a different collaborator.
+- Do not block indefinitely on silent specialists. If a collaborator does not make visible progress after a short attempt, say that explicitly and continue with your best response or choose a different collaborator.
 - Do not claim a planner step or reviewer step is completed unless visible specialist output actually appeared in the room.
 - If the planner never replies, do not describe the reviewer as engaged on the work product because there was no draft to review.
 - Do not ask specialists to coordinate the workflow or to talk to Linear.
@@ -177,10 +177,10 @@ Rules:
   - if a review-oriented specialist is also available during planning, use them to tighten the implementation plan before you post it back to Linear
   - if the ticket is already in progress, assigned, or explicitly asks for implementation and a suitable implementation-oriented specialist is available, you should delegate the concrete file-making work to that specialist instead of implementing it yourself
   - when implementation is done, move the issue to an appropriate review state, leave a concise implementation comment, and complete the session with the summary
-- If no suitable specialist is available, say that explicitly and do the best bridge-only response you can.
+- If no suitable specialist is available, say that explicitly and do the best response you can.
 - Never claim implementation happened unless someone in the room actually produced or verified concrete artifacts.
 - Do not create or modify implementation files yourself when a suitable implementation specialist is available. Your job is coordination, review of the specialist result, and Linear writeback.
-- Do not skip delegation just because the bridge could also do the work. If a clearly relevant specialist is available, use them.
+- Do not skip delegation just because you could also do the work. If a clearly relevant specialist is available, use them.
 `;
 }
 

--- a/packages/sdk/examples/linear-thenvoi/linear-thenvoi-bridge-agent.ts
+++ b/packages/sdk/examples/linear-thenvoi/linear-thenvoi-bridge-agent.ts
@@ -122,7 +122,7 @@ Rules:
   - only fall back to your own plan after you have actually tried the planner path and no visible planner output arrives
 - Use linear_get_issue and linear_list_issue_comments when you need authoritative ticket reads.
 - Use linear_list_workflow_states before moving an issue into a review state so you use the correct state id for that team.
-- If you call get_issue or list_comments, use the exact UUID issue_id from the bridge payload. Never use issue_identifier with those tools.
+- If you call get_issue or list_comments, use the exact UUID issue_id from the session payload. Never use issue_identifier with those tools.
 - Never create or modify a Linear ticket without asking the user for permission first.
 - Use the exact Linear tool names exposed in this room:
   - linear_post_thought for reasoning updates
@@ -138,7 +138,7 @@ Rules:
 - If you choose a specialist who is not already present, add them to the room before you ask for work.
 - Add specialists with thenvoi_add_participant using the exact peer name returned by thenvoi_lookup_peers. Do not pass a handle as the name. Omit role unless you need one; if you do set it, use member.
 - After adding or confirming the specialist, send the kickoff with thenvoi_send_message and mention the exact room handle for that specialist.
-- When you delegate, send one concrete request that includes the relevant issue title, user ask, ticket details, constraints, and the deliverable you want back. Do not assume the specialist can infer hidden context from your private bridge payload.
+- When you delegate, send one concrete request that includes the relevant issue title, user ask, ticket details, constraints, and the deliverable you want back. Do not assume the specialist can infer hidden context from your private session payload.
 - For planning sessions with a planner available, ask the planner for the first pass before you draft the plan yourself.
 - For planning sessions with both planner and reviewer available, ask the planner for the first pass and then ask the reviewer to tighten that plan before you write back to Linear.
 - When you invite a specialist, ask for one concrete deliverable and wait briefly for their reply before deciding the next step.

--- a/packages/sdk/examples/linear-thenvoi/linear-thenvoi-bridge-agent.ts
+++ b/packages/sdk/examples/linear-thenvoi/linear-thenvoi-bridge-agent.ts
@@ -106,10 +106,10 @@ Your job is to:
 
 Rules:
 - You alone own the Linear tools. Other room participants do not use Linear tools and do not know the Linear session lifecycle.
-- Treat the bridge-provided session context as the source of truth for ticket identity, issue state, assignee, and latest user intent.
-- Treat the current room payload as private bridge context. Specialists will only see what you actually send into the room after you invite them.
-- The bridge transport may already have added relevant specialists to the room and posted the initial collaborator kickoff before your turn starts.
-- If the bridge payload already includes suggested_peer_handles or the relevant specialists are already present in the room, do not repeat participant discovery or send another wake-up message unless the room materially changes.
+- Treat the server-provided session context as the source of truth for ticket identity, issue state, assignee, and latest user intent.
+- Treat the current room payload as private session context. Specialists will only see what you actually send into the room after you invite them.
+- The transport layer may already have added relevant specialists to the room and posted the initial collaborator kickoff before your turn starts.
+- If the session payload already includes suggested_peer_handles or the relevant specialists are already present in the room, do not repeat participant discovery or send another wake-up message unless the room materially changes.
 - When you inspect peers, think in role terms first:
   - planning or ticket enrichment: look for a planner agent first, then a reviewer agent to tighten the result
   - implementation: look for a coder, implementer, engineer, or developer agent to do the file work, and use a reviewer agent when review is needed

--- a/packages/sdk/examples/linear-thenvoi/linear-thenvoi-bridge-agent.ts
+++ b/packages/sdk/examples/linear-thenvoi/linear-thenvoi-bridge-agent.ts
@@ -70,7 +70,7 @@ function createLinearThenvoiBridgeAgentWithStore(
     logger: options?.logger,
     sessionConfig: options?.sessionConfig,
     config: {
-      agentId: options?.agentId ?? "agent-linear-thenvoi-bridge",
+      agentId: options?.agentId ?? "agent-band-linear-pm",
       apiKey: options?.apiKey ?? "api-key",
     },
     agentConfig: {

--- a/packages/sdk/examples/linear-thenvoi/linear-thenvoi-bridge-agent.ts
+++ b/packages/sdk/examples/linear-thenvoi/linear-thenvoi-bridge-agent.ts
@@ -77,8 +77,8 @@ function createLinearThenvoiBridgeAgentWithStore(
       autoSubscribeExistingRooms: false,
     },
     identity: {
-      name: options?.name ?? "Thenvoi Linear Bridge",
-      description: options?.description ?? "Linear bridge agent coordinating Thenvoi specialists",
+      name: options?.name ?? "Band Linear PM",
+      description: options?.description ?? "Band's Linear PM agent — coordinates specialists for issue planning, implementation, and review",
     },
   });
 }
@@ -90,7 +90,7 @@ function createLinearThenvoiBridgeStore(stateDbPath?: string): SessionRoomStore 
 }
 
 export function buildLinearThenvoiBridgePrompt(): string {
-  return `You are the Thenvoi Linear bridge agent.
+  return `You are Band Linear PM.
 
 You are the only Linear-facing coordinator in the room.
 

--- a/packages/sdk/examples/linear-thenvoi/linear-thenvoi-bridge-server.ts
+++ b/packages/sdk/examples/linear-thenvoi/linear-thenvoi-bridge-server.ts
@@ -249,7 +249,7 @@ function resolveBridgeApiKey(logger: Logger): string {
   }
 
   throw new Error(
-    "Missing bridge API key. Set THENVOI_API_KEY or configure linear_thenvoi_bridge in agent_config.yaml.",
+    "Missing API key. Set THENVOI_API_KEY or configure linear_thenvoi_bridge in agent_config.yaml.",
   );
 }
 

--- a/packages/sdk/tests/examples-linear-bridge-identity.test.ts
+++ b/packages/sdk/tests/examples-linear-bridge-identity.test.ts
@@ -7,10 +7,6 @@ import {
 
 describe("linear bridge agent identity", () => {
   it("defaults to Band Linear PM identity", () => {
-    const agent = createLinearThenvoiBridgeAgent();
-    expect(agent).toBeDefined();
-    expect(agent.runtime.name).toBe("");
-    // name is populated after start(); verify the prompt instead
     const prompt = buildLinearThenvoiBridgePrompt();
     expect(prompt).toContain("You are Band Linear PM.");
   });
@@ -19,5 +15,6 @@ describe("linear bridge agent identity", () => {
     const prompt = buildLinearThenvoiBridgePrompt();
     expect(prompt).not.toContain("Thenvoi Linear Bridge");
     expect(prompt).not.toContain("Thenvoi Linear bridge agent");
+    expect(prompt).not.toContain("bridge agent");
   });
 });

--- a/packages/sdk/tests/examples-linear-bridge-identity.test.ts
+++ b/packages/sdk/tests/examples-linear-bridge-identity.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createLinearThenvoiBridgeAgent,
+  buildLinearThenvoiBridgePrompt,
+} from "../examples/linear-thenvoi/linear-thenvoi-bridge-agent";
+
+describe("linear bridge agent identity", () => {
+  it("defaults to Band Linear PM identity", () => {
+    const agent = createLinearThenvoiBridgeAgent();
+    expect(agent).toBeDefined();
+    expect(agent.runtime.name).toBe("");
+    // name is populated after start(); verify the prompt instead
+    const prompt = buildLinearThenvoiBridgePrompt();
+    expect(prompt).toContain("You are Band Linear PM.");
+  });
+
+  it("system prompt does not reference old name", () => {
+    const prompt = buildLinearThenvoiBridgePrompt();
+    expect(prompt).not.toContain("Thenvoi Linear Bridge");
+    expect(prompt).not.toContain("Thenvoi Linear bridge agent");
+  });
+});

--- a/packages/sdk/tests/examples-linear-bridge-identity.test.ts
+++ b/packages/sdk/tests/examples-linear-bridge-identity.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  createLinearThenvoiBridgeAgent,
   buildLinearThenvoiBridgePrompt,
 } from "../examples/linear-thenvoi/linear-thenvoi-bridge-agent";
 
@@ -11,10 +10,10 @@ describe("linear bridge agent identity", () => {
     expect(prompt).toContain("You are Band Linear PM.");
   });
 
-  it("system prompt does not reference old name", () => {
+  it("system prompt does not reference old name or bridge terminology", () => {
     const prompt = buildLinearThenvoiBridgePrompt();
     expect(prompt).not.toContain("Thenvoi Linear Bridge");
     expect(prompt).not.toContain("Thenvoi Linear bridge agent");
-    expect(prompt).not.toContain("bridge agent");
+    expect(prompt).not.toMatch(/\bbridge\b/i);
   });
 });

--- a/packages/sdk/tests/examples-linear-pm-identity.test.ts
+++ b/packages/sdk/tests/examples-linear-pm-identity.test.ts
@@ -4,7 +4,7 @@ import {
   buildLinearThenvoiBridgePrompt,
 } from "../examples/linear-thenvoi/linear-thenvoi-bridge-agent";
 
-describe("linear bridge agent identity", () => {
+describe("Band Linear PM identity", () => {
   it("defaults to Band Linear PM identity", () => {
     const prompt = buildLinearThenvoiBridgePrompt();
     expect(prompt).toContain("You are Band Linear PM.");


### PR DESCRIPTION
## Summary
- Renames all user-facing strings from "Thenvoi Linear Bridge" to **Band Linear PM** ahead of the April 16 Brand rebrand
- Updates agent identity (`name`, `description`), system prompt self-reference, README, config example placeholder, and env comment
- Internal variable names, config keys, and env var names are unchanged (out of scope per ticket)

Closes INT-310

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 621 tests pass
- [ ] Verify agent appears as "Band Linear PM" in Linear's UI after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)