### PR TITLE
chore: ignore package-lock.json (repo uses pnpm)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ agent_config.yaml
 *.key
 credentials.json
 *.sqlite
+
+# Not using npm - yarn/pnpm only
+package-lock.json


### PR DESCRIPTION
Prevents accidental npm installs from polluting the repo with a conflicting lockfile.