### PR TITLE
chore: add Dependabot config targeting dev branch (INT-347)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  # npm (pnpm) dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "javascript"
+    reviewers:
+      - "thenvoi/integrations-team"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` with weekly update schedules for npm (pnpm) and github-actions.
- Both entries use `target-branch: "dev"` so Dependabot PRs land on `dev` instead of `main`.

## Why
`dev` is our integration branch; `main` only receives release merges. Routing Dependabot PRs through `dev` lets them go through normal review/CI before ever reaching `main`. Previously this repo had no Dependabot config.

## Test plan
- [ ] Merge and confirm the next scheduled Dependabot run opens PRs targeting `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)