### PR TITLE
fix: avoid name-triggered OpenClaw mentions [INT-322]

### DIFF
--- a/packages/openclaw/src/channel.ts
+++ b/packages/openclaw/src/channel.ts
@@ -363,7 +363,7 @@ function resolveConfig(account: ThenvoiAccountConfig): { apiKey: string; agentId
 // Mention Resolution
 // =============================================================================
 
-type Mention = { id: string; name?: string };
+type Mention = { id: string };
 
 /**
  * Resolve mentions for a message: use last sender when available, then fall back
@@ -387,14 +387,14 @@ async function resolveMentions(
       (p) => p.id === lastSender.senderId && p.id !== agentId
     );
     if (senderParticipant) {
-      return { mentions: [{ id: senderParticipant.id, name: senderParticipant.name }], participants };
+      return { mentions: [{ id: senderParticipant.id }], participants };
     }
   }
 
   // 2. Fallback: first other participant
   const other = participants.find((p) => p.id !== agentId);
   if (other) {
-    return { mentions: [{ id: other.id, name: other.name }], participants };
+    return { mentions: [{ id: other.id }], participants };
   }
 
   return null;

--- a/packages/openclaw/src/channel.ts
+++ b/packages/openclaw/src/channel.ts
@@ -366,7 +366,9 @@ function resolveConfig(account: ThenvoiAccountConfig): { apiKey: string; agentId
 type Mention = { id: string; name?: string };
 
 /**
- * Resolve mentions for a message: find @Name in text, fall back to last sender, then any participant.
+ * Resolve mentions for a message: use last sender when available, then fall back
+ * to the first other participant. OpenClaw must not infer routing from @Name text
+ * inside the reply body.
  * Returns null if no participants are available to mention (caller decides how to handle).
  */
 async function resolveMentions(
@@ -374,21 +376,11 @@ async function resolveMentions(
   agentId: string,
   accountId: string,
   roomId: string,
-  text: string,
+  _text: string,
 ): Promise<{ mentions: Mention[]; participants: Array<{ id: string; name: string }> } | null> {
   const participants = await rest.listChatParticipants(roomId);
 
-  // 1. Explicit @Name mentions in text (case-insensitive)
-  const mentioned: Mention[] = [];
-  const textLower = text.toLowerCase();
-  for (const p of participants) {
-    if (p.id !== agentId && textLower.includes(`@${p.name.toLowerCase()}`)) {
-      mentioned.push({ id: p.id, name: p.name });
-    }
-  }
-  if (mentioned.length > 0) return { mentions: mentioned, participants };
-
-  // 2. Fallback: last sender in this thread
+  // 1. Fallback: last sender in this thread
   const lastSender = registry().lastSenderByThread.get(`${accountId}:${roomId}`);
   if (lastSender) {
     const senderParticipant = participants.find(
@@ -399,7 +391,7 @@ async function resolveMentions(
     }
   }
 
-  // 3. Fallback: first other participant
+  // 2. Fallback: first other participant
   const other = participants.find((p) => p.id !== agentId);
   if (other) {
     return { mentions: [{ id: other.id, name: other.name }], participants };

--- a/packages/openclaw/src/channel.ts
+++ b/packages/openclaw/src/channel.ts
@@ -366,10 +366,10 @@ function resolveConfig(account: ThenvoiAccountConfig): { apiKey: string; agentId
 type Mention = { id: string };
 
 /**
- * Resolve mentions for a message: use last sender when available, then fall back
- * to the first other participant. OpenClaw must not infer routing from @Name text
- * inside the reply body.
- * Returns null if no participants are available to mention (caller decides how to handle).
+ * Resolve mentions for a message using the last tracked sender in the thread.
+ * OpenClaw must not infer routing from @Name text inside the reply body or pick
+ * an arbitrary participant when no inbound sender has been seen.
+ * Returns null if there is no safe recipient (caller decides how to handle).
  */
 async function resolveMentions(
   rest: ThenvoiLink["rest"],
@@ -380,24 +380,19 @@ async function resolveMentions(
 ): Promise<{ mentions: Mention[]; participants: Array<{ id: string; name: string }> } | null> {
   const participants = await rest.listChatParticipants(roomId);
 
-  // 1. Fallback: last sender in this thread
   const lastSender = registry().lastSenderByThread.get(`${accountId}:${roomId}`);
-  if (lastSender) {
-    const senderParticipant = participants.find(
-      (p) => p.id === lastSender.senderId && p.id !== agentId
-    );
-    if (senderParticipant) {
-      return { mentions: [{ id: senderParticipant.id }], participants };
-    }
+  if (!lastSender) {
+    return null;
   }
 
-  // 2. Fallback: first other participant
-  const other = participants.find((p) => p.id !== agentId);
-  if (other) {
-    return { mentions: [{ id: other.id }], participants };
+  const senderParticipant = participants.find(
+    (p) => p.id === lastSender.senderId && p.id !== agentId
+  );
+  if (!senderParticipant) {
+    return null;
   }
 
-  return null;
+  return { mentions: [{ id: senderParticipant.id }], participants };
 }
 
 // =============================================================================
@@ -481,7 +476,7 @@ async function sendOutbound(ctx: OutboundContext): Promise<OutboundDeliveryResul
 
   const resolved = await resolveMentions(link.rest, link.agentId, accountId ?? "default", roomId, text);
   if (!resolved) {
-    throw new Error("Cannot send message: no other participants to mention");
+    throw new Error("Cannot send message: no tracked inbound sender to mention");
   }
 
   const result = await link.rest.createChatMessage(roomId, { content: text, mentions: resolved.mentions });

--- a/packages/openclaw/src/mcp-tools.ts
+++ b/packages/openclaw/src/mcp-tools.ts
@@ -425,8 +425,9 @@ const sendMessageTool: McpTool = {
         type: "array",
         items: { type: "string" },
         description:
-          "List of participant names to @mention. At least one required. " +
-          "Use thenvoi_get_participants to see available participants.",
+          "List of participant handles or IDs to @mention. At least one required. " +
+          "Use thenvoi_get_participants to see available participants. " +
+          "Plain names in content do not create mentions; only this list does.",
       },
     },
     required: ["room_id", "content", "mentions"],
@@ -444,17 +445,25 @@ const sendMessageTool: McpTool = {
     // Get participants to resolve names to IDs
     const participants = await rest.listChatParticipants(room_id);
 
-    // Resolve mention names to participant objects
-    const resolvedMentions = mentions.map((name) => {
-      const participant = participants.find(
-        (p) => p.name.toLowerCase() === name.toLowerCase() && p.id !== selfAgentId
-      );
+    // Resolve explicit mention references to participant IDs. Do not derive mentions
+    // from content text; writing a participant's name in the message body is plain text.
+    const resolvedMentions = mentions.map((mention) => {
+      const normalizedMention = mention.trim().replace(/^@+/, "").toLowerCase();
+      const participant = participants.find((p) => {
+        if (p.id === selfAgentId) return false;
+        const normalizedHandle = typeof p.handle === "string"
+          ? p.handle.trim().replace(/^@+/, "").toLowerCase()
+          : "";
+        return p.id === mention
+          || normalizedHandle === normalizedMention
+          || p.name.toLowerCase() === mention.trim().toLowerCase();
+      });
       if (!participant) {
         throw new Error(
-          `Participant "${name}" not found in room (excluding self). Use thenvoi_get_participants to see available participants.`
+          `Participant "${mention}" not found in room (excluding self). Use thenvoi_get_participants to see available participants.`
         );
       }
-      return { id: participant.id, name: participant.name };
+      return { id: participant.id };
     });
 
     const response = await rest.createChatMessage(room_id, {

--- a/packages/openclaw/src/prompts.ts
+++ b/packages/openclaw/src/prompts.ts
@@ -55,8 +55,8 @@ These tools require a room_id parameter. For most responses, just use plain text
 
 **When to use thenvoi_send_message instead of plain text:**
 - When you need to @mention a SPECIFIC participant (e.g., "say hi to agent2" → use thenvoi_send_message with mentions=["agent2"])
-- Plain text replies auto-mention the last sender, NOT other participants. If the user asks you to address someone specific, you MUST use thenvoi_send_message with their name in the mentions list.
-- IMPORTANT: The platform may rewrite exact participant names or handles in message content into visible @mentions. If you want to refer to someone without pinging them, avoid their exact name or handle and use indirect phrasing like "you", "the user", or "the other participant" instead.
+- Plain text replies auto-mention the last sender, NOT other participants. If the user asks you to address someone specific, you MUST use thenvoi_send_message with their handle in the mentions list.
+- IMPORTANT: Message content is plain text. You may write names naturally in content. Only handles listed in the mentions array create @mentions.
 
 ## Delegating to Other Agents (Thenvoi context only)
 

--- a/packages/openclaw/src/prompts.ts
+++ b/packages/openclaw/src/prompts.ts
@@ -56,6 +56,7 @@ These tools require a room_id parameter. For most responses, just use plain text
 **When to use thenvoi_send_message instead of plain text:**
 - When you need to @mention a SPECIFIC participant (e.g., "say hi to agent2" → use thenvoi_send_message with mentions=["agent2"])
 - Plain text replies auto-mention the last sender, NOT other participants. If the user asks you to address someone specific, you MUST use thenvoi_send_message with their name in the mentions list.
+- IMPORTANT: The platform may rewrite exact participant names or handles in message content into visible @mentions. If you want to refer to someone without pinging them, avoid their exact name or handle and use indirect phrasing like "you", "the user", or "the other participant" instead.
 
 ## Delegating to Other Agents (Thenvoi context only)
 

--- a/packages/openclaw/tests/unit/channel-gateway.test.ts
+++ b/packages/openclaw/tests/unit/channel-gateway.test.ts
@@ -144,6 +144,71 @@ describe("Channel Gateway Lifecycle", () => {
       // Verify callback received the message (sender tracking is internal)
       expect(callback).toHaveBeenCalledTimes(1);
     });
+
+    it("should route replies to the last sender even if another participant name appears in the text", async () => {
+      const callback = vi.fn();
+      setInboundCallback(callback);
+
+      const ctx = createGatewayContext("account-1", mockAccountConfig, { aborted: true });
+      await thenvoiChannel.gateway!.startAccount(ctx);
+
+      mockLinkInstance.rest.listChatParticipants = vi.fn().mockResolvedValue([
+        { id: "user-789", name: "John Doe", type: "User" },
+        { id: "user-456", name: "Jane Doe", type: "User" },
+        { id: "agent-123", name: "Test Agent", type: "Agent" },
+      ]);
+
+      deliverMessage({
+        channelId: "thenvoi" as const,
+        threadId: "room-123",
+        senderId: "user-789",
+        senderType: "User",
+        senderName: "John Doe",
+        text: "Hello",
+        timestamp: "2025-01-15T10:00:00Z",
+      }, "account-1");
+
+      await thenvoiChannel.outbound.sendText({
+        cfg: {},
+        accountId: "account-1",
+        to: "room-123",
+        text: "Jane Doe already finished the review.",
+      });
+
+      expect(mockLinkInstance.rest.createChatMessage).toHaveBeenCalledWith(
+        "room-123",
+        expect.objectContaining({
+          content: "Jane Doe already finished the review.",
+          mentions: [{ id: "user-789", name: "John Doe" }],
+        }),
+      );
+    });
+
+    it("should fall back to the first other participant when no sender is tracked", async () => {
+      const ctx = createGatewayContext("account-2", mockAccountConfig, { aborted: true });
+      await thenvoiChannel.gateway!.startAccount(ctx);
+
+      mockLinkInstance.rest.listChatParticipants = vi.fn().mockResolvedValue([
+        { id: "user-789", name: "John Doe", type: "User" },
+        { id: "user-456", name: "Jane Doe", type: "User" },
+        { id: "agent-123", name: "Test Agent", type: "Agent" },
+      ]);
+
+      await thenvoiChannel.outbound.sendText({
+        cfg: {},
+        accountId: "account-2",
+        to: "room-123",
+        text: "Following up without prior inbound context.",
+      });
+
+      expect(mockLinkInstance.rest.createChatMessage).toHaveBeenCalledWith(
+        "room-123",
+        expect.objectContaining({
+          content: "Following up without prior inbound context.",
+          mentions: [{ id: "user-789", name: "John Doe" }],
+        }),
+      );
+    });
   });
 
   describe("startAccount", () => {

--- a/packages/openclaw/tests/unit/channel-gateway.test.ts
+++ b/packages/openclaw/tests/unit/channel-gateway.test.ts
@@ -145,7 +145,7 @@ describe("Channel Gateway Lifecycle", () => {
       expect(callback).toHaveBeenCalledTimes(1);
     });
 
-    it("should route replies to the last sender even if another participant name appears in the text", async () => {
+    it("should route replies to the last sender even if another participant name or handle appears in the text", async () => {
       const callback = vi.fn();
       setInboundCallback(callback);
 
@@ -153,9 +153,9 @@ describe("Channel Gateway Lifecycle", () => {
       await thenvoiChannel.gateway!.startAccount(ctx);
 
       mockLinkInstance.rest.listChatParticipants = vi.fn().mockResolvedValue([
-        { id: "user-789", name: "John Doe", type: "User" },
-        { id: "user-456", name: "Jane Doe", type: "User" },
-        { id: "agent-123", name: "Test Agent", type: "Agent" },
+        { id: "user-789", name: "John Doe", type: "User", handle: "@john" },
+        { id: "user-456", name: "amit", type: "User", handle: "@amit" },
+        { id: "agent-123", name: "Test Agent", type: "Agent", handle: "@test-agent" },
       ]);
 
       deliverMessage({
@@ -172,14 +172,14 @@ describe("Channel Gateway Lifecycle", () => {
         cfg: {},
         accountId: "account-1",
         to: "room-123",
-        text: "Jane Doe already finished the review.",
+        text: "amit already finished the GitHub review.",
       });
 
       expect(mockLinkInstance.rest.createChatMessage).toHaveBeenCalledWith(
         "room-123",
         expect.objectContaining({
-          content: "Jane Doe already finished the review.",
-          mentions: [{ id: "user-789", name: "John Doe" }],
+          content: "amit already finished the GitHub review.",
+          mentions: [{ id: "user-789" }],
         }),
       );
     });
@@ -205,7 +205,7 @@ describe("Channel Gateway Lifecycle", () => {
         "room-123",
         expect.objectContaining({
           content: "Following up without prior inbound context.",
-          mentions: [{ id: "user-789", name: "John Doe" }],
+          mentions: [{ id: "user-789" }],
         }),
       );
     });

--- a/packages/openclaw/tests/unit/channel-gateway.test.ts
+++ b/packages/openclaw/tests/unit/channel-gateway.test.ts
@@ -184,7 +184,7 @@ describe("Channel Gateway Lifecycle", () => {
       );
     });
 
-    it("should fall back to the first other participant when no sender is tracked", async () => {
+    it("should not guess a recipient when no sender is tracked", async () => {
       const ctx = createGatewayContext("account-2", mockAccountConfig, { aborted: true });
       await thenvoiChannel.gateway!.startAccount(ctx);
 
@@ -194,20 +194,14 @@ describe("Channel Gateway Lifecycle", () => {
         { id: "agent-123", name: "Test Agent", type: "Agent" },
       ]);
 
-      await thenvoiChannel.outbound.sendText({
+      await expect(thenvoiChannel.outbound.sendText({
         cfg: {},
         accountId: "account-2",
         to: "room-123",
         text: "Following up without prior inbound context.",
-      });
+      })).rejects.toThrow("no tracked inbound sender");
 
-      expect(mockLinkInstance.rest.createChatMessage).toHaveBeenCalledWith(
-        "room-123",
-        expect.objectContaining({
-          content: "Following up without prior inbound context.",
-          mentions: [{ id: "user-789" }],
-        }),
-      );
+      expect(mockLinkInstance.rest.createChatMessage).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/openclaw/tests/unit/mcp-tools.test.ts
+++ b/packages/openclaw/tests/unit/mcp-tools.test.ts
@@ -430,14 +430,14 @@ describe("MCP Tools", () => {
   });
 
   describe("thenvoi_send_message", () => {
-    it("should send message with mentions", async () => {
+    it("should send message with explicit mentions resolved to IDs only", async () => {
       mockRest.listChatParticipants.mockResolvedValue(mockParticipants);
       mockRest.createChatMessage.mockResolvedValue(mockSendMessageResponse);
 
       const result = await executeMcpTool("thenvoi_send_message", {
         room_id: "room-001",
         content: "Hello!",
-        mentions: ["John Doe"],
+        mentions: ["@john"],
       });
 
       expect(mockRest.listChatParticipants).toHaveBeenCalledWith("room-001");
@@ -445,10 +445,33 @@ describe("MCP Tools", () => {
         "room-001",
         {
           content: "Hello!",
-          mentions: [{ id: "user-789", name: "John Doe" }],
+          mentions: [{ id: "user-789" }],
         },
       );
       expect(result).toHaveProperty("success", true);
+    });
+
+    it("should not create extra mentions when content contains another participant name or handle", async () => {
+      mockRest.listChatParticipants.mockResolvedValue([
+        { id: "user-789", name: "John Doe", type: "User", handle: "@john" },
+        { id: "user-456", name: "amit", type: "User", handle: "@amit" },
+        { id: "agent-123", name: "Test Agent", type: "Agent", handle: "@test-agent" },
+      ]);
+      mockRest.createChatMessage.mockResolvedValue(mockSendMessageResponse);
+
+      await executeMcpTool("thenvoi_send_message", {
+        room_id: "room-001",
+        content: "amit is also the GitHub handle in this example.",
+        mentions: ["@john"],
+      });
+
+      expect(mockRest.createChatMessage).toHaveBeenCalledWith(
+        "room-001",
+        {
+          content: "amit is also the GitHub handle in this example.",
+          mentions: [{ id: "user-789" }],
+        },
+      );
     });
 
     it("should throw error if mention not found", async () => {

--- a/packages/openclaw/tests/unit/prompts.test.ts
+++ b/packages/openclaw/tests/unit/prompts.test.ts
@@ -44,9 +44,9 @@ describe("Prompts", () => {
       expect(BASE_INSTRUCTIONS).toContain("Webchat");
     });
 
-    it("should warn that exact names can become visible mentions", () => {
-      expect(BASE_INSTRUCTIONS).toContain("rewrite exact participant names or handles");
-      expect(BASE_INSTRUCTIONS).toContain("indirect phrasing");
+    it("should explain that names in content are plain text", () => {
+      expect(BASE_INSTRUCTIONS).toContain("Message content is plain text");
+      expect(BASE_INSTRUCTIONS).toContain("Only handles listed in the mentions array create @mentions");
     });
   });
 

--- a/packages/openclaw/tests/unit/prompts.test.ts
+++ b/packages/openclaw/tests/unit/prompts.test.ts
@@ -43,6 +43,11 @@ describe("Prompts", () => {
       expect(BASE_INSTRUCTIONS).toContain("Example:");
       expect(BASE_INSTRUCTIONS).toContain("Webchat");
     });
+
+    it("should warn that exact names can become visible mentions", () => {
+      expect(BASE_INSTRUCTIONS).toContain("rewrite exact participant names or handles");
+      expect(BASE_INSTRUCTIONS).toContain("indirect phrasing");
+    });
   });
 
   describe("buildSystemPrompt", () => {

--- a/packages/sdk/src/runtime/formatters.ts
+++ b/packages/sdk/src/runtime/formatters.ts
@@ -76,6 +76,9 @@ export function buildParticipantsMessage(participants: Array<Record<string, unkn
   lines.push(
     "IMPORTANT: In thenvoi_send_message mentions, always use the exact handle shown above (e.g. '@john' for users, '@john/weather-agent' for agents), NOT the display name. Handles are lowercase with no spaces.",
   );
+  lines.push(
+    "IMPORTANT: If you want to refer to a participant without mentioning them, do not write their exact display name or handle in message content. The platform may convert exact names into visible @mentions. Use indirect phrasing like 'you', 'the user', or 'the reviewer' instead.",
+  );
 
   return lines.join("\n");
 }

--- a/packages/sdk/src/runtime/formatters.ts
+++ b/packages/sdk/src/runtime/formatters.ts
@@ -77,7 +77,7 @@ export function buildParticipantsMessage(participants: Array<Record<string, unkn
     "IMPORTANT: In thenvoi_send_message mentions, always use the exact handle shown above (e.g. '@john' for users, '@john/weather-agent' for agents), NOT the display name. Handles are lowercase with no spaces.",
   );
   lines.push(
-    "IMPORTANT: If you want to refer to a participant without mentioning them, do not write their exact display name or handle in message content. The platform may convert exact names into visible @mentions. Use indirect phrasing like 'you', 'the user', or 'the reviewer' instead.",
+    "IMPORTANT: Message content is plain text. Writing a participant's display name or handle in content does not mention them; only entries in the thenvoi_send_message mentions array create mentions.",
   );
 
   return lines.join("\n");

--- a/packages/sdk/src/runtime/prompts.ts
+++ b/packages/sdk/src/runtime/prompts.ts
@@ -5,7 +5,7 @@ Multi-participant chat. Messages show sender: [Name]: content.
 Messages prefixed with [System]: are platform updates (participant changes, contact updates, etc.) — not messages from users.
 Use \`thenvoi_send_message(content, mentions)\` to respond. Plain text output is not delivered.
 Mentions use handles: @<username> for users, @<username>/<agent-name> for agents.
-IMPORTANT: The platform may rewrite exact participant names or handles in message content into visible @mentions. If you want to refer to someone without mentioning them, avoid their exact display name or handle and use an indirect reference like "you", "the user", or "the reviewer" instead.
+IMPORTANT: Message content is plain text. You may write names naturally in content. Only handles listed in the mentions array create @mentions.
 
 ## CRITICAL: Delegate When You Cannot Help Directly
 

--- a/packages/sdk/src/runtime/prompts.ts
+++ b/packages/sdk/src/runtime/prompts.ts
@@ -5,6 +5,7 @@ Multi-participant chat. Messages show sender: [Name]: content.
 Messages prefixed with [System]: are platform updates (participant changes, contact updates, etc.) — not messages from users.
 Use \`thenvoi_send_message(content, mentions)\` to respond. Plain text output is not delivered.
 Mentions use handles: @<username> for users, @<username>/<agent-name> for agents.
+IMPORTANT: The platform may rewrite exact participant names or handles in message content into visible @mentions. If you want to refer to someone without mentioning them, avoid their exact display name or handle and use an indirect reference like "you", "the user", or "the reviewer" instead.
 
 ## CRITICAL: Delegate When You Cannot Help Directly
 

--- a/packages/sdk/src/runtime/tools/AgentTools.ts
+++ b/packages/sdk/src/runtime/tools/AgentTools.ts
@@ -620,9 +620,9 @@ export class AgentTools implements AgentToolsProtocol {
     }
 
     if (typeof mentions[0] !== "string") {
-      return mentions.filter(
-        (entry): entry is MentionReference => typeof entry === "object" && entry !== null && "id" in entry,
-      );
+      return mentions
+        .filter((entry): entry is MentionReference => typeof entry === "object" && entry !== null && "id" in entry)
+        .map((entry) => ({ id: entry.id }));
     }
 
     const stringMentions = mentions.filter((entry): entry is string => typeof entry === "string");
@@ -631,10 +631,7 @@ export class AgentTools implements AgentToolsProtocol {
     const participantsById = new Map<string, MentionReference>();
     const participantsByName = new Map<string, MentionReference>();
     for (const participant of this.participants) {
-      const ref: MentionReference = {
-        id: String(participant.id),
-        handle: typeof participant.handle === "string" ? participant.handle : undefined,
-      };
+      const ref: MentionReference = { id: String(participant.id) };
       participantsById.set(ref.id, ref);
       const handle = participant.handle;
       if (typeof handle === "string") {
@@ -971,17 +968,7 @@ export class AgentTools implements AgentToolsProtocol {
         continue;
       }
 
-      const normalized: MentionReference = { id: mention.id };
-      if (typeof mention.handle === "string") {
-        normalized.handle = mention.handle;
-      }
-      if (typeof mention.name === "string") {
-        normalized.name = mention.name;
-      }
-      if (typeof mention.username === "string") {
-        normalized.username = mention.username;
-      }
-      mentions.push(normalized);
+      mentions.push({ id: mention.id });
     }
 
     return mentions;

--- a/packages/sdk/src/runtime/tools/ContactCallbackTools.ts
+++ b/packages/sdk/src/runtime/tools/ContactCallbackTools.ts
@@ -104,7 +104,7 @@ export class ContactCallbackTools implements AdapterToolsProtocol {
     }
 
     const normalizedMentions = mentions && mentions.every((mention) => typeof mention !== "string")
-      ? mentions
+      ? mentions.map((mention) => ({ id: mention.id }))
       : undefined;
 
     return this.rest.createChatMessage(

--- a/packages/sdk/tests/agent-tools-coverage.test.ts
+++ b/packages/sdk/tests/agent-tools-coverage.test.ts
@@ -313,7 +313,7 @@ describe("AgentTools coverage", () => {
       "room-1",
       {
         content: "hi",
-        mentions: [{ id: "peer-1", handle: "@peer/one", name: "Peer One", username: "peer.one" }],
+        mentions: [{ id: "peer-1" }],
       },
       expect.any(Object),
     );
@@ -417,9 +417,9 @@ describe("AgentTools coverage", () => {
       {
         content: "hi",
         mentions: [
-          { id: "user-1", handle: "@jane" },
-          { id: "agent-1", handle: "@team/planner" },
-          { id: "user-1", handle: "@jane" },
+          { id: "user-1" },
+          { id: "agent-1" },
+          { id: "user-1" },
         ],
       },
       expect.any(Object),

--- a/packages/sdk/tests/agent-tools.test.ts
+++ b/packages/sdk/tests/agent-tools.test.ts
@@ -220,6 +220,28 @@ describe("AgentTools", () => {
     expect(resultByName).toEqual({ ok: true });
   });
 
+  it("does not infer mentions from names or handles in message content", async () => {
+    const api = new FakeRestApi();
+    const tools = new AgentTools({
+      roomId: "room-1",
+      rest: new RestFacade({ api }),
+      participants: [
+        { id: "u1", handle: "@jane", name: "jane", type: "User" },
+        { id: "u2", handle: "@john", name: "John", type: "User" },
+      ],
+    });
+
+    await tools.sendMessage("jane is also the GitHub handle in this example.", ["@john"]);
+
+    expect(api.chatMessages).toEqual([
+      {
+        chatId: "room-1",
+        content: "jane is also the GitHub handle in this example.",
+        mentions: [{ id: "u2" }],
+      },
+    ]);
+  });
+
   it("gates peers endpoint when disabled", async () => {
     const tools = new AgentTools({
       roomId: "room-1",
@@ -499,7 +521,7 @@ describe("AgentTools", () => {
       {
         chatId: "room-1",
         content: "hello",
-        mentions: [{ id: "u1", handle: "@jane", name: "Jane", username: "jane" }],
+        mentions: [{ id: "u1" }],
       },
     ]);
     expect(api.createdChats).toEqual(["task-123"]);

--- a/packages/sdk/tests/execution-context.test.ts
+++ b/packages/sdk/tests/execution-context.test.ts
@@ -31,7 +31,7 @@ describe("ExecutionContext", () => {
 
     await context.getTools().sendMessage("hello", ["@weather-agent"]);
     expect(capturedMentions[0]).toEqual([
-      { id: "peer-weather", handle: "weather-agent" },
+      { id: "peer-weather" },
     ]);
 
     context.removeParticipant("peer-weather");

--- a/packages/sdk/tests/prompts.test.ts
+++ b/packages/sdk/tests/prompts.test.ts
@@ -20,9 +20,9 @@ describe("renderSystemPrompt", () => {
     expect(result).toContain(BASE_INSTRUCTIONS);
   });
 
-  it("warns that exact names can become visible mentions", () => {
-    expect(BASE_INSTRUCTIONS).toContain("rewrite exact participant names or handles");
-    expect(BASE_INSTRUCTIONS).toContain("indirect reference");
+  it("explains that names in content are plain text", () => {
+    expect(BASE_INSTRUCTIONS).toContain("Message content is plain text");
+    expect(BASE_INSTRUCTIONS).toContain("Only handles listed in the mentions array create @mentions");
   });
 
   it("includes custom section", () => {

--- a/packages/sdk/tests/prompts.test.ts
+++ b/packages/sdk/tests/prompts.test.ts
@@ -20,6 +20,11 @@ describe("renderSystemPrompt", () => {
     expect(result).toContain(BASE_INSTRUCTIONS);
   });
 
+  it("warns that exact names can become visible mentions", () => {
+    expect(BASE_INSTRUCTIONS).toContain("rewrite exact participant names or handles");
+    expect(BASE_INSTRUCTIONS).toContain("indirect reference");
+  });
+
   it("includes custom section", () => {
     const result = renderSystemPrompt({
       agentName: "Bot",

--- a/packages/sdk/tests/runtime-utils.test.ts
+++ b/packages/sdk/tests/runtime-utils.test.ts
@@ -50,6 +50,12 @@ describe("runtime utilities", () => {
     expect(message).toContain("@jane");
   });
 
+  it("warns that exact names can trigger visible mentions", () => {
+    const message = buildParticipantsMessage([{ type: "User", name: "Jane", handle: "jane" }]);
+    expect(message).toContain("do not write their exact display name or handle");
+    expect(message).toContain("platform may convert exact names into visible @mentions");
+  });
+
   it("renders system prompt", () => {
     const prompt = renderSystemPrompt({
       agentName: "Agent",

--- a/packages/sdk/tests/runtime-utils.test.ts
+++ b/packages/sdk/tests/runtime-utils.test.ts
@@ -50,10 +50,10 @@ describe("runtime utilities", () => {
     expect(message).toContain("@jane");
   });
 
-  it("warns that exact names can trigger visible mentions", () => {
+  it("explains that mentions only come from the mentions array", () => {
     const message = buildParticipantsMessage([{ type: "User", name: "Jane", handle: "jane" }]);
-    expect(message).toContain("do not write their exact display name or handle");
-    expect(message).toContain("platform may convert exact names into visible @mentions");
+    expect(message).toContain("Message content is plain text");
+    expect(message).toContain("only entries in the thenvoi_send_message mentions array create mentions");
   });
 
   it("renders system prompt", () => {


### PR DESCRIPTION
## Summary
- stop OpenClaw from routing mentions by scanning participant names in reply text
- route replies by last sender first, then the first other participant, and cover both paths with unit tests
- add SDK and OpenClaw prompt guidance about visible mention rewrites when exact names appear in message content

## Test plan
- [x] `cd /Users/pp/thenvoi/thenvoi-sdk-typescript/.claude/worktrees/int-322 && pnpm --filter @thenvoi/sdk test -- --run tests/prompts.test.ts tests/runtime-utils.test.ts`
- [x] `cd /Users/pp/thenvoi/thenvoi-sdk-typescript/.claude/worktrees/int-322 && pnpm --filter @thenvoi/sdk build`
- [x] `cd /Users/pp/thenvoi/thenvoi-sdk-typescript/.claude/worktrees/int-322 && pnpm --filter @thenvoi/openclaw-channel-thenvoi test -- --run tests/unit/channel-gateway.test.ts tests/unit/prompts.test.ts`