### PR TITLE
feat(sdk): prefer is_remote in wire contact data [INT-346]

### DIFF
--- a/packages/sdk/src/client/rest/FernRestAdapter.ts
+++ b/packages/sdk/src/client/rest/FernRestAdapter.ts
@@ -255,12 +255,31 @@ function isChatParticipant(value: unknown): value is ChatParticipant {
   return typeof record.id === "string"
     && typeof record.name === "string"
     && typeof record.type === "string"
-    && (record.handle === undefined || record.handle === null || typeof record.handle === "string");
+    && (record.handle === undefined || record.handle === null || typeof record.handle === "string")
+    && !hasInvalidNullableBoolean(record.is_remote)
+    && !hasInvalidNullableBoolean(record.is_external);
 }
 
 function normalizeChatParticipantsResponse(response: unknown): ChatParticipant[] {
   const payload = extractEnvelopeData(response);
-  return Array.isArray(payload) ? payload.filter(isChatParticipant) : [];
+  if (!Array.isArray(payload)) {
+    return [];
+  }
+
+  return payload.flatMap((item) => {
+    if (!isChatParticipant(item)) {
+      return [];
+    }
+
+    return [{
+      id: item.id,
+      name: item.name,
+      type: item.type,
+      ...(item.handle !== undefined ? { handle: item.handle } : {}),
+      ...(item.is_remote !== undefined ? { is_remote: item.is_remote } : {}),
+      ...(item.is_external !== undefined ? { is_external: item.is_external } : {}),
+    }];
+  });
 }
 
 function normalizeMetadataRecord(value: MetadataMap): MetadataMap {
@@ -306,6 +325,7 @@ function normalizeContactRecord(value: MetadataMap): ContactRecord | null {
     || hasInvalidNullableString(value.name)
     || hasInvalidString(value.type)
     || hasInvalidNullableString(value.description)
+    || hasInvalidNullableBoolean(value.is_remote)
     || hasInvalidNullableBoolean(value.is_external)
     || hasInvalidString(value.inserted_at)
   ) {
@@ -318,6 +338,7 @@ function normalizeContactRecord(value: MetadataMap): ContactRecord | null {
     ...(value.name !== undefined ? { name: value.name as string | null } : {}),
     ...(typeof value.type === "string" ? { type: value.type } : {}),
     ...(value.description !== undefined ? { description: value.description as string | null } : {}),
+    ...(value.is_remote !== undefined ? { is_remote: value.is_remote as boolean | null } : {}),
     ...(value.is_external !== undefined ? { is_external: value.is_external as boolean | null } : {}),
     ...(typeof value.inserted_at === "string" ? { inserted_at: value.inserted_at } : {}),
   };

--- a/packages/sdk/src/client/rest/FernRestAdapter.ts
+++ b/packages/sdk/src/client/rest/FernRestAdapter.ts
@@ -260,6 +260,16 @@ function isChatParticipant(value: unknown): value is ChatParticipant {
     && !hasInvalidNullableBoolean(record.is_external);
 }
 
+function deriveRemoteAlias<T extends { is_remote?: boolean | null; is_external?: boolean | null }>(value: T): T {
+  const isRemote = value.is_remote ?? value.is_external;
+  const isExternal = value.is_external ?? value.is_remote;
+  return {
+    ...value,
+    ...(isRemote !== undefined ? { is_remote: isRemote } : {}),
+    ...(isExternal !== undefined ? { is_external: isExternal } : {}),
+  };
+}
+
 function normalizeChatParticipantsResponse(response: unknown): ChatParticipant[] {
   const payload = extractEnvelopeData(response);
   if (!Array.isArray(payload)) {
@@ -271,14 +281,16 @@ function normalizeChatParticipantsResponse(response: unknown): ChatParticipant[]
       return [];
     }
 
-    return [{
+    const normalized = deriveRemoteAlias({
       id: item.id,
       name: item.name,
       type: item.type,
       ...(item.handle !== undefined ? { handle: item.handle } : {}),
       ...(item.is_remote !== undefined ? { is_remote: item.is_remote } : {}),
       ...(item.is_external !== undefined ? { is_external: item.is_external } : {}),
-    }];
+    });
+
+    return [normalized];
   });
 }
 
@@ -332,7 +344,7 @@ function normalizeContactRecord(value: MetadataMap): ContactRecord | null {
     return null;
   }
 
-  return {
+  return deriveRemoteAlias({
     ...(typeof value.id === "string" ? { id: value.id } : {}),
     ...(typeof value.handle === "string" ? { handle: value.handle } : {}),
     ...(value.name !== undefined ? { name: value.name as string | null } : {}),
@@ -341,7 +353,7 @@ function normalizeContactRecord(value: MetadataMap): ContactRecord | null {
     ...(value.is_remote !== undefined ? { is_remote: value.is_remote as boolean | null } : {}),
     ...(value.is_external !== undefined ? { is_external: value.is_external as boolean | null } : {}),
     ...(typeof value.inserted_at === "string" ? { inserted_at: value.inserted_at } : {}),
-  };
+  });
 }
 
 function normalizeMemoryRecordItem(value: MetadataMap): MemoryRecord | null {

--- a/packages/sdk/src/client/rest/FernRestAdapter.ts
+++ b/packages/sdk/src/client/rest/FernRestAdapter.ts
@@ -1,5 +1,6 @@
 import { UnsupportedFeatureError } from "../../core/errors";
 import { asNullableString, asOptionalRecord, asString } from "../../adapters/shared/coercion";
+import { deriveRemoteAlias } from "../../contracts/dtos";
 import type {
   AddContactArgs,
   ContactRecord,
@@ -258,16 +259,6 @@ function isChatParticipant(value: unknown): value is ChatParticipant {
     && (record.handle === undefined || record.handle === null || typeof record.handle === "string")
     && !hasInvalidNullableBoolean(record.is_remote)
     && !hasInvalidNullableBoolean(record.is_external);
-}
-
-function deriveRemoteAlias<T extends { is_remote?: boolean | null; is_external?: boolean | null }>(value: T): T {
-  const isRemote = value.is_remote ?? value.is_external;
-  const isExternal = value.is_external ?? value.is_remote;
-  return {
-    ...value,
-    ...(isRemote !== undefined ? { is_remote: isRemote } : {}),
-    ...(isExternal !== undefined ? { is_external: isExternal } : {}),
-  };
 }
 
 function normalizeChatParticipantsResponse(response: unknown): ChatParticipant[] {

--- a/packages/sdk/src/client/rest/types.ts
+++ b/packages/sdk/src/client/rest/types.ts
@@ -32,6 +32,8 @@ export interface ChatParticipant {
   name: string;
   type: string;
   handle?: string | null;
+  is_remote?: boolean | null;
+  is_external?: boolean | null;
 }
 
 export interface ChatMessageMention {

--- a/packages/sdk/src/contracts/dtos.ts
+++ b/packages/sdk/src/contracts/dtos.ts
@@ -35,6 +35,8 @@ export interface ParticipantRecord {
   name: string;
   type: string;
   handle?: string | null;
+  is_remote?: boolean | null;
+  is_external?: boolean | null;
   role?: string;
 }
 
@@ -53,6 +55,8 @@ export interface WireContactRecord {
   name?: string | null;
   type?: string;
   description?: string | null;
+  is_remote?: boolean | null;
+  // Legacy alias for is_remote.
   is_external?: boolean | null;
   inserted_at?: string;
 }

--- a/packages/sdk/src/contracts/dtos.ts
+++ b/packages/sdk/src/contracts/dtos.ts
@@ -36,8 +36,17 @@ export interface ParticipantRecord {
   type: string;
   handle?: string | null;
   is_remote?: boolean | null;
+  /** @deprecated Use is_remote. */
   is_external?: boolean | null;
   role?: string;
+}
+
+export function deriveRemoteAlias<T extends { is_remote?: boolean | null; is_external?: boolean | null }>(value: T): T {
+  const isRemote = value.is_remote ?? value.is_external;
+  return {
+    ...value,
+    ...(isRemote !== undefined ? { is_remote: isRemote, is_external: isRemote } : {}),
+  };
 }
 
 export interface PeerRecord {
@@ -56,7 +65,7 @@ export interface WireContactRecord {
   type?: string;
   description?: string | null;
   is_remote?: boolean | null;
-  // Legacy alias for is_remote.
+  /** @deprecated Use is_remote. */
   is_external?: boolean | null;
   inserted_at?: string;
 }

--- a/packages/sdk/src/platform/streaming/payloadSchemas.ts
+++ b/packages/sdk/src/platform/streaming/payloadSchemas.ts
@@ -56,6 +56,8 @@ export const participantAddedPayloadSchema = z.object({
   name: z.string(),
   type: z.string(),
   handle: z.string().nullish(),
+  is_remote: z.boolean().nullish(),
+  is_external: z.boolean().nullish(),
 }).passthrough();
 
 export const participantRemovedPayloadSchema = z.object({
@@ -86,6 +88,7 @@ export const contactAddedPayloadSchema = z.object({
   name: z.string(),
   type: z.string(),
   description: z.string().nullish(),
+  is_remote: z.boolean().nullish(),
   is_external: z.boolean().nullish(),
   inserted_at: z.string(),
 }).passthrough();

--- a/packages/sdk/src/runtime/ExecutionContext.ts
+++ b/packages/sdk/src/runtime/ExecutionContext.ts
@@ -286,6 +286,8 @@ export class ExecutionContext {
       name: participant.name,
       type: participant.type,
       handle: participant.handle ?? null,
+      ...(participant.is_remote !== undefined ? { is_remote: participant.is_remote } : {}),
+      ...(participant.is_external !== undefined ? { is_external: participant.is_external } : {}),
     }));
     this.replaceParticipants(normalized);
     return [...this.participants];

--- a/packages/sdk/src/runtime/ExecutionContext.ts
+++ b/packages/sdk/src/runtime/ExecutionContext.ts
@@ -2,6 +2,7 @@ import type { AgentToolsRestApi } from "../client/rest/types";
 import { DEFAULT_REQUEST_OPTIONS } from "../client/rest/requestOptions";
 import type { AdapterToolsProtocol, AgentToolsCapabilities } from "../contracts/protocols";
 import type { MetadataMap, ParticipantRecord } from "../contracts/dtos";
+import { mapParticipantRecord } from "./tools/ContactCallbackTools";
 import { UnsupportedFeatureError } from "../core/errors";
 import type { ConversationContext, PlatformMessage } from "./types";
 import { AgentTools } from "./tools/AgentTools";
@@ -281,14 +282,7 @@ export class ExecutionContext {
 
   private async loadParticipants(): Promise<ParticipantRecord[]> {
     const participants = await this.link.rest.listChatParticipants(this.roomId, DEFAULT_REQUEST_OPTIONS);
-    const normalized = participants.map((participant) => ({
-      id: participant.id,
-      name: participant.name,
-      type: participant.type,
-      handle: participant.handle ?? null,
-      ...(participant.is_remote !== undefined ? { is_remote: participant.is_remote } : {}),
-      ...(participant.is_external !== undefined ? { is_external: participant.is_external } : {}),
-    }));
+    const normalized = participants.map((participant) => mapParticipantRecord(participant));
     this.replaceParticipants(normalized);
     return [...this.participants];
   }

--- a/packages/sdk/src/runtime/rooms/AgentRuntime.ts
+++ b/packages/sdk/src/runtime/rooms/AgentRuntime.ts
@@ -247,6 +247,8 @@ export class AgentRuntime {
             name: event.payload.name,
             type: event.payload.type,
             handle: event.payload.handle,
+            is_remote: event.payload.is_remote,
+            is_external: event.payload.is_external,
           };
           context.addParticipant(participant);
           await this.onParticipantAdded?.(event.roomId, participant);

--- a/packages/sdk/src/runtime/rooms/AgentRuntime.ts
+++ b/packages/sdk/src/runtime/rooms/AgentRuntime.ts
@@ -2,7 +2,7 @@ import type { ThenvoiLink } from "../../platform/ThenvoiLink";
 import type { ContactEvent, PlatformEvent } from "../../platform/events";
 import type { Logger } from "../../core/logger";
 import { NoopLogger } from "../../core/logger";
-import type { MetadataMap, ParticipantRecord } from "../../contracts/dtos";
+import { deriveRemoteAlias, type MetadataMap, type ParticipantRecord } from "../../contracts/dtos";
 import { Execution } from "../Execution";
 import { ExecutionContext, type ExecutionContextOptions } from "../ExecutionContext";
 import { hydrateTrackedRooms, trackRoomJoin, trackRoomLeave } from "./subscriptions";
@@ -242,14 +242,14 @@ export class AgentRuntime {
       case "participant_added":
         if (event.roomId) {
           const context = this.getOrCreateContext(event.roomId);
-          const participant = {
+          const participant = deriveRemoteAlias({
             id: event.payload.id,
             name: event.payload.name,
             type: event.payload.type,
             handle: event.payload.handle,
             is_remote: event.payload.is_remote,
             is_external: event.payload.is_external,
-          };
+          });
           context.addParticipant(participant);
           await this.onParticipantAdded?.(event.roomId, participant);
         }
@@ -263,9 +263,14 @@ export class AgentRuntime {
         return;
       case "contact_request_received":
       case "contact_request_updated":
-      case "contact_added":
       case "contact_removed":
         await this.onContactEvent?.(event);
+        return;
+      case "contact_added":
+        await this.onContactEvent?.({
+          ...event,
+          payload: deriveRemoteAlias(event.payload),
+        });
         return;
       case "message_created":
         if (!event.roomId) {

--- a/packages/sdk/src/runtime/tools/AgentTools.ts
+++ b/packages/sdk/src/runtime/tools/AgentTools.ts
@@ -312,6 +312,8 @@ export class AgentTools implements AgentToolsProtocol {
       name: participant.name,
       type: participant.type,
       handle: participant.handle ?? null,
+      ...(participant.is_remote !== undefined ? { is_remote: participant.is_remote } : {}),
+      ...(participant.is_external !== undefined ? { is_external: participant.is_external } : {}),
     }));
   }
 

--- a/packages/sdk/src/runtime/tools/ContactCallbackTools.ts
+++ b/packages/sdk/src/runtime/tools/ContactCallbackTools.ts
@@ -39,6 +39,10 @@ type ContactCallbackRestApi =
   & Partial<ContactRestApi>;
 
 function toParticipantRecord(participant: ChatParticipant): ParticipantRecord {
+  return mapParticipantRecord(participant);
+}
+
+export function mapParticipantRecord(participant: Pick<ParticipantRecord, "id" | "name" | "type" | "handle" | "is_remote" | "is_external">): ParticipantRecord {
   return {
     id: participant.id,
     name: participant.name,

--- a/packages/sdk/src/runtime/tools/ContactCallbackTools.ts
+++ b/packages/sdk/src/runtime/tools/ContactCallbackTools.ts
@@ -44,6 +44,8 @@ function toParticipantRecord(participant: ChatParticipant): ParticipantRecord {
     name: participant.name,
     type: participant.type,
     handle: participant.handle ?? null,
+    ...(participant.is_remote !== undefined ? { is_remote: participant.is_remote } : {}),
+    ...(participant.is_external !== undefined ? { is_external: participant.is_external } : {}),
   };
 }
 

--- a/packages/sdk/src/runtime/tools/ContactCallbackTools.ts
+++ b/packages/sdk/src/runtime/tools/ContactCallbackTools.ts
@@ -6,6 +6,7 @@ import type {
   ChatRoomRestApi,
   ContactRestApi,
 } from "../../client/rest/types";
+import { deriveRemoteAlias } from "../../contracts/dtos";
 import type {
   AddContactArgs,
   ContactRecord,
@@ -43,14 +44,14 @@ function toParticipantRecord(participant: ChatParticipant): ParticipantRecord {
 }
 
 export function mapParticipantRecord(participant: Pick<ParticipantRecord, "id" | "name" | "type" | "handle" | "is_remote" | "is_external">): ParticipantRecord {
-  return {
+  return deriveRemoteAlias({
     id: participant.id,
     name: participant.name,
     type: participant.type,
     handle: participant.handle ?? null,
     ...(participant.is_remote !== undefined ? { is_remote: participant.is_remote } : {}),
     ...(participant.is_external !== undefined ? { is_external: participant.is_external } : {}),
-  };
+  });
 }
 
 function normalizePage(value: number | undefined, fallback: number): number {

--- a/packages/sdk/tests/fern-rest-adapter-contact-memory.test.ts
+++ b/packages/sdk/tests/fern-rest-adapter-contact-memory.test.ts
@@ -366,6 +366,22 @@ describe("FernRestAdapter contact and memory parity", () => {
       { id: "user-1", name: "Jane", type: "User", handle: "@jane" },
     ]);
 
+    const primaryLegacyRest = new RestFacade({
+      api: new FernRestAdapter({
+        chatParticipants: {
+          listChatParticipants: async () => ({
+            data: [{ id: "user-legacy", name: "Legacy", type: "User", handle: "@legacy", is_external: true }],
+          }),
+          addChatParticipant: async () => ({ data: {} }),
+          removeChatParticipant: async () => ({ data: {} }),
+        },
+      }),
+    });
+
+    await expect(primaryLegacyRest.listChatParticipants("room-1")).resolves.toEqual([
+      { id: "user-legacy", name: "Legacy", type: "User", handle: "@legacy", is_remote: true, is_external: true },
+    ]);
+
     const fallbackRest = new RestFacade({
       api: new FernRestAdapter({
         agentApiParticipants: {
@@ -380,6 +396,22 @@ describe("FernRestAdapter contact and memory parity", () => {
 
     await expect(fallbackRest.listChatParticipants("room-2")).resolves.toEqual([
       { id: "agent-1", name: "Weather", type: "Agent", handle: "@sam/weather" },
+    ]);
+
+    const fallbackLegacyRest = new RestFacade({
+      api: new FernRestAdapter({
+        agentApiParticipants: {
+          listAgentChatParticipants: async () => ({
+            data: [{ id: "agent-legacy", name: "Legacy Agent", type: "Agent", handle: "@legacy/agent", is_external: false }],
+          }),
+          addAgentChatParticipant: async () => ({ data: {} }),
+          removeAgentChatParticipant: async () => ({ data: {} }),
+        },
+      }),
+    });
+
+    await expect(fallbackLegacyRest.listChatParticipants("room-2")).resolves.toEqual([
+      { id: "agent-legacy", name: "Legacy Agent", type: "Agent", handle: "@legacy/agent", is_remote: false, is_external: false },
     ]);
   });
 

--- a/packages/sdk/tests/fern-rest-adapter-coverage.test.ts
+++ b/packages/sdk/tests/fern-rest-adapter-coverage.test.ts
@@ -282,6 +282,7 @@ describe("FernRestAdapter coverage", () => {
           name: "Jane",
           type: "User",
           description: null,
+          is_remote: false,
           is_external: false,
           inserted_at: "2026-03-10T00:00:00.000Z",
         },
@@ -350,6 +351,7 @@ describe("FernRestAdapter coverage", () => {
           name: "Jane",
           type: "User",
           description: null,
+          is_remote: false,
           is_external: false,
           inserted_at: "2026-03-10T00:00:00.000Z",
         },
@@ -456,7 +458,7 @@ describe("FernRestAdapter coverage", () => {
       chatParticipants: {
         listChatParticipants: async () => ({
           data: [
-            { id: "u1", name: "Jane", type: "User", handle: "@jane" },
+            { id: "u1", name: "Jane", type: "User", handle: "@jane", is_remote: false, is_external: false },
             { id: 42 },
           ],
         }),
@@ -466,7 +468,7 @@ describe("FernRestAdapter coverage", () => {
     });
 
     await expect(adapter.listChatParticipants("room-1")).resolves.toEqual([
-      { id: "u1", name: "Jane", type: "User", handle: "@jane" },
+      { id: "u1", name: "Jane", type: "User", handle: "@jane", is_remote: false, is_external: false },
     ]);
   });
 
@@ -474,7 +476,7 @@ describe("FernRestAdapter coverage", () => {
     const adapter = new FernRestAdapter({
       agentApiParticipants: {
         listAgentChatParticipants: async () => ({
-          data: [{ id: "u2", name: "Sam", type: "Agent", handle: null }],
+          data: [{ id: "u2", name: "Sam", type: "Agent", handle: null, is_remote: true, is_external: true }],
         }),
       },
       agentApiMessages: {
@@ -495,7 +497,7 @@ describe("FernRestAdapter coverage", () => {
     });
 
     await expect(adapter.listChatParticipants("room-1")).resolves.toEqual([
-      { id: "u2", name: "Sam", type: "Agent", handle: null },
+      { id: "u2", name: "Sam", type: "Agent", handle: null, is_remote: true, is_external: true },
     ]);
     await expect(adapter.getNextMessage({ chatId: "room-1" })).resolves.toBeNull();
     await expect(

--- a/packages/sdk/tests/fern-rest-adapter-coverage.test.ts
+++ b/packages/sdk/tests/fern-rest-adapter-coverage.test.ts
@@ -358,6 +358,34 @@ describe("FernRestAdapter coverage", () => {
       ],
       metadata: { page: 3, pageSize: 20, totalCount: 1, totalPages: 9 },
     });
+    const legacyOnlyAdapter = new FernRestAdapter({
+      agentContacts: {
+        listAgentContacts: async () => ({
+          data: [{
+            id: "contact-legacy",
+            handle: "@legacy",
+            name: "Legacy",
+            type: "User",
+            description: null,
+            is_external: true,
+            inserted_at: "2026-03-10T00:00:00.000Z",
+          }],
+        }),
+      },
+    });
+    await expect(legacyOnlyAdapter.listContacts({ page: 1, pageSize: 50 })).resolves.toEqual({
+      data: [{
+        id: "contact-legacy",
+        handle: "@legacy",
+        name: "Legacy",
+        type: "User",
+        description: null,
+        is_remote: true,
+        is_external: true,
+        inserted_at: "2026-03-10T00:00:00.000Z",
+      }],
+      metadata: {},
+    });
     await expect(adapter.addContact({ handle: "@jane", message: "hello" })).resolves.toEqual({
       id: "req-1",
       status: "pending",
@@ -469,6 +497,18 @@ describe("FernRestAdapter coverage", () => {
 
     await expect(adapter.listChatParticipants("room-1")).resolves.toEqual([
       { id: "u1", name: "Jane", type: "User", handle: "@jane", is_remote: false, is_external: false },
+    ]);
+    const legacyParticipantAdapter = new FernRestAdapter({
+      chatParticipants: {
+        listChatParticipants: async () => ({
+          data: [{ id: "uLegacy", name: "Legacy", type: "Agent", handle: null, is_external: true }],
+        }),
+        addChatParticipant: async () => ({ data: {} }),
+        removeChatParticipant: async () => ({ data: {} }),
+      },
+    });
+    await expect(legacyParticipantAdapter.listChatParticipants("room-1")).resolves.toEqual([
+      { id: "uLegacy", name: "Legacy", type: "Agent", handle: null, is_remote: true, is_external: true },
     ]);
   });
 

--- a/packages/sdk/tests/fern-rest-adapter-coverage.test.ts
+++ b/packages/sdk/tests/fern-rest-adapter-coverage.test.ts
@@ -386,6 +386,35 @@ describe("FernRestAdapter coverage", () => {
       }],
       metadata: {},
     });
+    const disagreeingAliasAdapter = new FernRestAdapter({
+      agentContacts: {
+        listAgentContacts: async () => ({
+          data: [{
+            id: "contact-disagree",
+            handle: "@disagree",
+            name: "Disagree",
+            type: "User",
+            description: null,
+            is_remote: true,
+            is_external: false,
+            inserted_at: "2026-03-10T00:00:00.000Z",
+          }],
+        }),
+      },
+    });
+    await expect(disagreeingAliasAdapter.listContacts({ page: 1, pageSize: 50 })).resolves.toEqual({
+      data: [{
+        id: "contact-disagree",
+        handle: "@disagree",
+        name: "Disagree",
+        type: "User",
+        description: null,
+        is_remote: true,
+        is_external: true,
+        inserted_at: "2026-03-10T00:00:00.000Z",
+      }],
+      metadata: {},
+    });
     await expect(adapter.addContact({ handle: "@jane", message: "hello" })).resolves.toEqual({
       id: "req-1",
       status: "pending",
@@ -509,6 +538,18 @@ describe("FernRestAdapter coverage", () => {
     });
     await expect(legacyParticipantAdapter.listChatParticipants("room-1")).resolves.toEqual([
       { id: "uLegacy", name: "Legacy", type: "Agent", handle: null, is_remote: true, is_external: true },
+    ]);
+    const disagreeingParticipantAdapter = new FernRestAdapter({
+      chatParticipants: {
+        listChatParticipants: async () => ({
+          data: [{ id: "uDisagree", name: "Disagree", type: "Agent", handle: null, is_remote: false, is_external: true }],
+        }),
+        addChatParticipant: async () => ({ data: {} }),
+        removeChatParticipant: async () => ({ data: {} }),
+      },
+    });
+    await expect(disagreeingParticipantAdapter.listChatParticipants("room-1")).resolves.toEqual([
+      { id: "uDisagree", name: "Disagree", type: "Agent", handle: null, is_remote: false, is_external: false },
     ]);
   });
 

--- a/packages/sdk/tests/platform-runtime-coverage.test.ts
+++ b/packages/sdk/tests/platform-runtime-coverage.test.ts
@@ -203,6 +203,7 @@ describe("PlatformRuntime coverage", () => {
           name: "Jane",
           type: "User",
           description: null,
+          is_remote: false,
           is_external: false,
           inserted_at: "2026-03-10T00:00:00.000Z",
         },

--- a/packages/sdk/tests/platform-runtime-coverage.test.ts
+++ b/packages/sdk/tests/platform-runtime-coverage.test.ts
@@ -4,7 +4,7 @@ import { PlatformRuntime } from "../src/runtime/PlatformRuntime";
 import { RuntimeStateError, ValidationError } from "../src/core/errors";
 import { ThenvoiLink } from "../src/platform/ThenvoiLink";
 import type { StreamingTransport } from "../src/platform/streaming/transport";
-import type { ContactEvent } from "../src/platform/events";
+import type { ContactEvent, PlatformEvent } from "../src/platform/events";
 import { AgentRuntime } from "../src/runtime/rooms/AgentRuntime";
 import { ContactEventHandler } from "../src/runtime/ContactEventHandler";
 import { FakeRestApi } from "./testUtils";
@@ -115,6 +115,69 @@ describe("PlatformRuntime coverage", () => {
     await expect(runtime.stop()).rejects.toThrow(
       "PlatformRuntime stop failed and adapter cleanup also failed",
     );
+  });
+
+  it("normalizes remote aliases on websocket participant and contact events", async () => {
+    const participantEvents: unknown[] = [];
+    const contactEvents: ContactEvent[] = [];
+    const runtime = new AgentRuntime({
+      agentId: "a1",
+      link: new ThenvoiLink({
+        agentId: "a1",
+        apiKey: "k",
+        transport: new MinimalTransport(),
+        restApi: new FakeRestApi(),
+      }),
+      onExecute: async () => {},
+      onParticipantAdded: async (_roomId, participant) => {
+        participantEvents.push(participant);
+      },
+      onContactEvent: async (event) => {
+        contactEvents.push(event);
+      },
+    });
+    const handleEvent = (runtime as unknown as { handleEvent(event: PlatformEvent): Promise<void> }).handleEvent.bind(runtime);
+
+    await handleEvent({
+      type: "participant_added",
+      roomId: "room-1",
+      payload: {
+        id: "p1",
+        name: "Pat",
+        type: "User",
+        handle: "@pat",
+        is_external: true,
+      },
+    });
+    await handleEvent({
+      type: "contact_added",
+      roomId: null,
+      payload: {
+        id: "c1",
+        handle: "@casey",
+        name: "Casey",
+        type: "User",
+        description: null,
+        is_remote: false,
+        is_external: true,
+        inserted_at: "2026-03-10T00:00:00.000Z",
+      },
+    });
+
+    expect(participantEvents).toEqual([
+      {
+        id: "p1",
+        name: "Pat",
+        type: "User",
+        handle: "@pat",
+        is_remote: true,
+        is_external: true,
+      },
+    ]);
+    expect(contactEvents[0]?.payload).toMatchObject({
+      is_remote: false,
+      is_external: false,
+    });
   });
 
   it("cleans up if startup fails after the adapter starts", async () => {


### PR DESCRIPTION
## Summary
- add `is_remote` as the primary typed field in the TypeScript contact and participant wire shapes while preserving `is_external` as the legacy alias
- preserve both fields through websocket payload parsing and REST normalization
- extend the focused runtime and Fern adapter coverage for the new fields

## Test plan
- [x] `pnpm --dir packages/sdk exec vitest run tests/platform-runtime-coverage.test.ts tests/fern-rest-adapter-coverage.test.ts tests/fern-rest-adapter-contact-memory.test.ts`