### PR TITLE
feat(sdk): export CustomToolDef from root entrypoint [INT-334]

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -8,6 +8,7 @@ export type { PlatformRuntimeOptions } from "./runtime/PlatformRuntime";
 export { AgentRuntime } from "./runtime/rooms/AgentRuntime";
 export type { ExecutionContextOptions } from "./runtime/ExecutionContext";
 export { DefaultPreprocessor } from "./runtime/preprocessing/DefaultPreprocessor";
+export type { CustomToolDef } from "./runtime/tools/customTools";
 export type {
   AgentConfig,
   AgentInput,

--- a/packages/sdk/tests/parity-contract.test.ts
+++ b/packages/sdk/tests/parity-contract.test.ts
@@ -1,12 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 
 import {
   Agent,
   ThenvoiLink,
   PlatformRuntime,
 } from "../src/index";
+import type { CustomToolDef as PublicCustomToolDef } from "../src/index";
 import { AgentTools, Execution, RoomPresence } from "../src/runtime";
 import { RestFacade, type RestApi } from "../src/rest";
+import type { CustomToolDef as InternalCustomToolDef } from "../src/runtime/tools/customTools";
 
 class ContractRestApi implements RestApi {
   public async getAgentMe() {
@@ -106,6 +108,10 @@ class ContractRestApi implements RestApi {
 }
 
 describe("sdk contract", () => {
+  it("re-exports CustomToolDef from the root SDK entrypoint", () => {
+    expectTypeOf<PublicCustomToolDef>().toEqualTypeOf<InternalCustomToolDef>();
+  });
+
   it("exposes lifecycle methods", () => {
     expect(typeof Agent.prototype.start).toBe("function");
     expect(typeof Agent.prototype.stop).toBe("function");


### PR DESCRIPTION
## Summary
- re-export `CustomToolDef` from the root `@thenvoi/sdk` entrypoint
- add a focused parity contract test proving the public type matches the internal definition

## Test plan
- [x] `pnpm --dir packages/sdk exec vitest run tests/parity-contract.test.ts tests/root-import-boundary.test.ts`