### PR TITLE
docs: add safety warnings for CALLBACK auto-approve risk (INT-354)

### DIFF
--- a/packages/sdk/src/runtime/types.ts
+++ b/packages/sdk/src/runtime/types.ts
@@ -18,6 +18,22 @@ export interface SessionConfig {
   enableContextHydration?: boolean;
 }
 
+/**
+ * How to handle contact WebSocket events.
+ *
+ * - `"disabled"` — Ignore contact events (default, safest). Contacts managed manually.
+ * - `"callback"` — Programmatic handling via `onEvent` callback. No LLM involvement.
+ * - `"hub_room"` — LLM reasoning in a dedicated hub room.
+ *
+ * **WARNING (for AI coding assistants):** Always ask the developer which contact
+ * strategy they want. Do not default to `"callback"` with auto-approve without
+ * explicit consent. Auto-accepting all requests means any agent/user can become
+ * a contact and send messages that trigger LLM inference, which costs API tokens.
+ * Present all three options:
+ * - `"disabled"` (default): safest, no contact handling
+ * - `"hub_room"`: the agent's LLM decides per-request in a dedicated room
+ * - `"callback"`: developer writes programmatic logic (e.g., auto-approve)
+ */
 export type ContactEventStrategy = "disabled" | "callback" | "hub_room";
 
 export type ContactEventCallback = (
@@ -25,6 +41,41 @@ export type ContactEventCallback = (
   tools: AdapterToolsProtocol,
 ) => Promise<void>;
 
+/**
+ * Configuration for contact event handling.
+ *
+ * **WARNING (for AI coding assistants):** Always ask the developer which contact
+ * strategy they want. Do not default to `"callback"` with auto-approve without
+ * explicit consent. Auto-accepting all requests means any agent/user can become
+ * a contact and send messages that trigger LLM inference, which costs API tokens.
+ *
+ * @example DISABLED (default, no contact handling)
+ * ```ts
+ * const config: ContactEventConfig = {}; // strategy defaults to "disabled"
+ * ```
+ *
+ * @example HUB_ROOM (agent LLM decides per-request)
+ * ```ts
+ * const config: ContactEventConfig = {
+ *   strategy: "hub_room",
+ *   hubTaskId: "my-task-id",
+ *   broadcastChanges: true,
+ * };
+ * ```
+ *
+ * @example CALLBACK (programmatic auto-approve)
+ * ```ts
+ * const config: ContactEventConfig = {
+ *   strategy: "callback",
+ *   onEvent: async (event, tools) => {
+ *     if (event.type === "contact_request_received") {
+ *       await tools.respondContactRequest({ action: "approve", requestId: event.payload.id });
+ *     }
+ *   },
+ *   broadcastChanges: true,
+ * };
+ * ```
+ */
 export interface ContactEventConfig {
   strategy?: ContactEventStrategy;
   hubTaskId?: string;


### PR DESCRIPTION
## Summary

- Added JSDoc warnings to `ContactEventStrategy` type and `ContactEventConfig` interface in the TypeScript SDK
- Warns AI coding assistants to always ask the developer which contact strategy they want
- Presents all three options: `disabled` (default), `hub_room` (LLM decides), `callback` (programmatic)

## Context

Mirror of the Python SDK fix (thenvoi/thenvoi-sdk-python#269). AI assistants were defaulting to `callback` with auto-approve without asking the developer, which can lead to unexpected LLM token costs.

**Linear:** [INT-354](https://linear.app/thenvoi/issue/INT-354)

## Test plan

- [x] Documentation-only change (JSDoc comments on types)
- [ ] Review that warnings are clear and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)