### PR TITLE
ci: include README in npm package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,10 @@ jobs:
         if: steps.release.outputs['packages/sdk--release_created'] == 'true' || steps.release.outputs['packages/openclaw--release_created'] == 'true'
         run: pnpm build
 
+      - name: Copy README into SDK package
+        if: steps.release.outputs['packages/sdk--release_created'] == 'true'
+        run: cp README.md packages/sdk/README.md
+
       - name: Publish SDK to npm (@thenvoi)
         if: steps.release.outputs['packages/sdk--release_created'] == 'true'
         run: |


### PR DESCRIPTION
## Summary
- Copies the root `README.md` into `packages/sdk/` during the release workflow, before `npm publish`
- Ensures the README displays on the npm registry page for `@thenvoi/sdk` and `@band-ai/sdk`

Closes INT-454

## Test plan
- [ ] Trigger a release and verify the npm package page shows the README

✌️