### PR TITLE
fix(sdk): surface websocket disconnect reasons [INT-331]

### DIFF
--- a/packages/sdk/src/core/index.ts
+++ b/packages/sdk/src/core/index.ts
@@ -23,5 +23,8 @@ export {
   RuntimeStateError,
 } from "./errors";
 export { WebSocketDisconnectError } from "../platform/streaming/disconnectReason";
-export type { WebSocketDisconnectReason } from "../platform/streaming/disconnectReason";
+export type {
+  WebSocketConflictPolicy,
+  WebSocketDisconnectReason,
+} from "../platform/streaming/disconnectReason";
 export { ConsoleLogger, NoopLogger, type Logger } from "./logger";

--- a/packages/sdk/src/core/index.ts
+++ b/packages/sdk/src/core/index.ts
@@ -22,4 +22,6 @@ export {
   TransportError,
   RuntimeStateError,
 } from "./errors";
+export { WebSocketDisconnectError } from "../platform/streaming/disconnectReason";
+export type { WebSocketDisconnectReason } from "../platform/streaming/disconnectReason";
 export { ConsoleLogger, NoopLogger, type Logger } from "./logger";

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -3,6 +3,8 @@ export type { AgentCreateOptions } from "./agent/Agent";
 
 export { ThenvoiLink, deriveDefaultRestUrl } from "./platform/ThenvoiLink";
 export type { PlatformEvent, ContactEvent } from "./platform/events";
+export { WebSocketDisconnectError } from "./platform/streaming/disconnectReason";
+export type { WebSocketDisconnectReason } from "./platform/streaming/disconnectReason";
 export { PlatformRuntime } from "./runtime/PlatformRuntime";
 export type { PlatformRuntimeOptions } from "./runtime/PlatformRuntime";
 export { AgentRuntime } from "./runtime/rooms/AgentRuntime";

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -4,7 +4,10 @@ export type { AgentCreateOptions } from "./agent/Agent";
 export { ThenvoiLink, deriveDefaultRestUrl } from "./platform/ThenvoiLink";
 export type { PlatformEvent, ContactEvent } from "./platform/events";
 export { WebSocketDisconnectError } from "./platform/streaming/disconnectReason";
-export type { WebSocketDisconnectReason } from "./platform/streaming/disconnectReason";
+export type {
+  WebSocketConflictPolicy,
+  WebSocketDisconnectReason,
+} from "./platform/streaming/disconnectReason";
 export { PlatformRuntime } from "./runtime/PlatformRuntime";
 export type { PlatformRuntimeOptions } from "./runtime/PlatformRuntime";
 export { AgentRuntime } from "./runtime/rooms/AgentRuntime";

--- a/packages/sdk/src/platform/ThenvoiLink.ts
+++ b/packages/sdk/src/platform/ThenvoiLink.ts
@@ -16,7 +16,10 @@ import {
 } from "./streaming/payloadSchemas";
 import { PhoenixChannelsTransport } from "./streaming/PhoenixChannelsTransport";
 import type { StreamingTransport } from "./streaming/transport";
-import type { WebSocketDisconnectReason } from "./streaming/disconnectReason";
+import {
+  WebSocketDisconnectError,
+  type WebSocketDisconnectReason,
+} from "./streaming/disconnectReason";
 import {
   DEFAULT_AGENT_TOOLS_CAPABILITIES,
   type AgentToolsCapabilities,
@@ -44,6 +47,7 @@ export function deriveDefaultRestUrl(wsUrl: string): string {
 
 interface PendingWaiter {
   resolve: (event: PlatformEvent | null) => void;
+  reject: (error: Error) => void;
   cleanup: () => void;
 }
 
@@ -80,6 +84,7 @@ export class ThenvoiLink implements AsyncIterable<PlatformEvent> {
   private readonly waiters: PendingWaiter[] = [];
   private connected = false;
   private lastDisconnectReason: WebSocketDisconnectReason | null = null;
+  private terminalDisconnectError: WebSocketDisconnectError | null = null;
 
   public constructor(options: ThenvoiLinkOptions) {
     this.agentId = options.agentId;
@@ -145,15 +150,21 @@ export class ThenvoiLink implements AsyncIterable<PlatformEvent> {
   }
 
   public async runForever(signal: AbortSignal): Promise<void> {
+    if (this.terminalDisconnectError) {
+      throw this.terminalDisconnectError;
+    }
+
     await this.transport.runForever(signal);
   }
 
   private recordDisconnectReason(reason: WebSocketDisconnectReason): void {
+    const error = new WebSocketDisconnectError(reason);
     this.connected = false;
     this.lastDisconnectReason = reason;
+    this.terminalDisconnectError = error;
     while (this.waiters.length > 0) {
       const waiter = this.waiters.shift();
-      waiter?.resolve(null);
+      waiter?.reject(error);
     }
   }
 
@@ -185,23 +196,31 @@ export class ThenvoiLink implements AsyncIterable<PlatformEvent> {
       return;
     }
 
-    await this.transport.join(`chat_room:${roomId}`, {
+    const chatTopic = `chat_room:${roomId}`;
+    const participantsTopic = `room_participants:${roomId}`;
+
+    await this.transport.join(chatTopic, {
       message_created: (payload) => {
         this.emit("message_created", payload, roomId);
       },
     });
 
-    await this.transport.join(`room_participants:${roomId}`, {
-      participant_added: (payload) => {
-        this.emit("participant_added", payload, roomId);
-      },
-      participant_removed: (payload) => {
-        this.emit("participant_removed", payload, roomId);
-      },
-      room_deleted: (payload) => {
-        this.emit("room_deleted", payload, roomId);
-      },
-    });
+    try {
+      await this.transport.join(participantsTopic, {
+        participant_added: (payload) => {
+          this.emit("participant_added", payload, roomId);
+        },
+        participant_removed: (payload) => {
+          this.emit("participant_removed", payload, roomId);
+        },
+        room_deleted: (payload) => {
+          this.emit("room_deleted", payload, roomId);
+        },
+      });
+    } catch (error) {
+      await this.transport.leave(chatTopic);
+      throw error;
+    }
 
     this.subscribedRooms.add(roomId);
   }
@@ -239,6 +258,10 @@ export class ThenvoiLink implements AsyncIterable<PlatformEvent> {
   }
 
   public async nextEvent(signal?: AbortSignal): Promise<PlatformEvent | null> {
+    if (this.terminalDisconnectError) {
+      throw this.terminalDisconnectError;
+    }
+
     if (signal?.aborted) {
       return null;
     }
@@ -248,19 +271,19 @@ export class ThenvoiLink implements AsyncIterable<PlatformEvent> {
       return queued;
     }
 
-    return new Promise<PlatformEvent | null>((resolve) => {
+    return new Promise<PlatformEvent | null>((resolve, reject) => {
       let settled = false;
       const onAbort = () => {
         const index = this.waiters.indexOf(waiter);
         if (index >= 0) {
           this.waiters.splice(index, 1);
         }
-        finalize(null);
+        finalizeResolve(null);
       };
       const cleanup = () => {
         signal?.removeEventListener("abort", onAbort);
       };
-      const finalize = (event: PlatformEvent | null) => {
+      const finalizeResolve = (event: PlatformEvent | null) => {
         if (settled) {
           return;
         }
@@ -268,8 +291,17 @@ export class ThenvoiLink implements AsyncIterable<PlatformEvent> {
         cleanup();
         resolve(event);
       };
+      const finalizeReject = (error: Error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        reject(error);
+      };
       const waiter: PendingWaiter = {
-        resolve: finalize,
+        resolve: finalizeResolve,
+        reject: finalizeReject,
         cleanup,
       };
 

--- a/packages/sdk/src/platform/ThenvoiLink.ts
+++ b/packages/sdk/src/platform/ThenvoiLink.ts
@@ -16,6 +16,7 @@ import {
 } from "./streaming/payloadSchemas";
 import { PhoenixChannelsTransport } from "./streaming/PhoenixChannelsTransport";
 import type { StreamingTransport } from "./streaming/transport";
+import type { WebSocketDisconnectReason } from "./streaming/disconnectReason";
 import {
   DEFAULT_AGENT_TOOLS_CAPABILITIES,
   type AgentToolsCapabilities,
@@ -78,6 +79,7 @@ export class ThenvoiLink implements AsyncIterable<PlatformEvent> {
   private readonly eventQueue: PlatformEvent[] = [];
   private readonly waiters: PendingWaiter[] = [];
   private connected = false;
+  private lastDisconnectReason: WebSocketDisconnectReason | null = null;
 
   public constructor(options: ThenvoiLinkOptions) {
     this.agentId = options.agentId;
@@ -106,11 +108,18 @@ export class ThenvoiLink implements AsyncIterable<PlatformEvent> {
         apiKey: this.apiKey,
         agentId: this.agentId,
         logger: this.logger,
+        onTerminalDisconnect: (reason) => {
+          this.recordDisconnectReason(reason);
+        },
       });
   }
 
   public isConnected(): boolean {
     return this.connected;
+  }
+
+  public getDisconnectReason(): WebSocketDisconnectReason | null {
+    return this.lastDisconnectReason ?? this.transport.getDisconnectReason?.() ?? null;
   }
 
   public async connect(): Promise<void> {
@@ -137,6 +146,15 @@ export class ThenvoiLink implements AsyncIterable<PlatformEvent> {
 
   public async runForever(signal: AbortSignal): Promise<void> {
     await this.transport.runForever(signal);
+  }
+
+  private recordDisconnectReason(reason: WebSocketDisconnectReason): void {
+    this.connected = false;
+    this.lastDisconnectReason = reason;
+    while (this.waiters.length > 0) {
+      const waiter = this.waiters.shift();
+      waiter?.resolve(null);
+    }
   }
 
   public queueEvent(event: PlatformEvent): void {

--- a/packages/sdk/src/platform/ThenvoiLink.ts
+++ b/packages/sdk/src/platform/ThenvoiLink.ts
@@ -158,7 +158,11 @@ export class ThenvoiLink implements AsyncIterable<PlatformEvent> {
       await this.transport.connect();
     } catch (error) {
       if (error instanceof WebSocketDisconnectError) {
-        this.recordDisconnectError(error);
+        if (error.reason.retryable) {
+          this.lastDisconnectReason = error.reason;
+        } else {
+          this.recordDisconnectError(error);
+        }
       }
       throw error;
     }

--- a/packages/sdk/src/platform/ThenvoiLink.ts
+++ b/packages/sdk/src/platform/ThenvoiLink.ts
@@ -3,8 +3,15 @@ import { NoopLogger } from "../core/logger";
 import { FernRestAdapter } from "../client/rest/RestFacade";
 import type { FernThenvoiClientLike } from "../client/rest/types";
 import type { RestRequestOptions } from "../client/rest/requestOptions";
-import { fetchPaginated, type PaginationOptions } from "../client/rest/pagination";
-import type { PaginatedResponse, PlatformChatMessage, ThenvoiLinkRestApi } from "../client/rest/types";
+import {
+  fetchPaginated,
+  type PaginationOptions,
+} from "../client/rest/pagination";
+import type {
+  PaginatedResponse,
+  PlatformChatMessage,
+  ThenvoiLinkRestApi,
+} from "../client/rest/types";
 import type { PlatformEvent } from "./events";
 import { UnsupportedFeatureError } from "../core/errors";
 import { assertCapability } from "../contracts/capabilities";
@@ -18,6 +25,7 @@ import { PhoenixChannelsTransport } from "./streaming/PhoenixChannelsTransport";
 import type { StreamingTransport } from "./streaming/transport";
 import {
   WebSocketDisconnectError,
+  type WebSocketConflictPolicy,
   type WebSocketDisconnectReason,
 } from "./streaming/disconnectReason";
 import {
@@ -35,6 +43,7 @@ export interface ThenvoiLinkOptions {
   transport?: StreamingTransport;
   logger?: Logger;
   capabilities?: Partial<AgentToolsCapabilities>;
+  conflictPolicy?: WebSocketConflictPolicy;
 }
 
 const DEFAULT_WS_URL = "wss://app.thenvoi.com/api/v1/socket";
@@ -55,7 +64,17 @@ export interface MessageMarkOptions {
   bestEffort?: boolean;
 }
 
-function toPlatformMessage(roomId: string, message: PlatformChatMessage): PlatformMessage {
+function roomTopics(roomId: string): { chat: string; participants: string } {
+  return {
+    chat: `chat_room:${roomId}`,
+    participants: `room_participants:${roomId}`,
+  };
+}
+
+function toPlatformMessage(
+  roomId: string,
+  message: PlatformChatMessage,
+): PlatformMessage {
   return {
     id: message.id,
     roomId,
@@ -97,12 +116,14 @@ export class ThenvoiLink implements AsyncIterable<PlatformEvent> {
       ...options.capabilities,
     };
 
-    const restApi = options.restApi ?? new FernRestAdapter(
-      new ThenvoiClient({
-        apiKey: this.apiKey,
-        baseUrl: this.restUrl,
-      }) as unknown as FernThenvoiClientLike,
-    );
+    const restApi =
+      options.restApi ??
+      new FernRestAdapter(
+        new ThenvoiClient({
+          apiKey: this.apiKey,
+          baseUrl: this.restUrl,
+        }) as unknown as FernThenvoiClientLike,
+      );
 
     this.rest = restApi;
 
@@ -113,6 +134,7 @@ export class ThenvoiLink implements AsyncIterable<PlatformEvent> {
         apiKey: this.apiKey,
         agentId: this.agentId,
         logger: this.logger,
+        conflictPolicy: options.conflictPolicy,
         onTerminalDisconnect: (reason) => {
           this.recordDisconnectReason(reason);
         },
@@ -124,7 +146,7 @@ export class ThenvoiLink implements AsyncIterable<PlatformEvent> {
   }
 
   public getDisconnectReason(): WebSocketDisconnectReason | null {
-    return this.lastDisconnectReason ?? this.transport.getDisconnectReason?.() ?? null;
+    return this.lastDisconnectReason;
   }
 
   public async connect(): Promise<void> {
@@ -132,7 +154,14 @@ export class ThenvoiLink implements AsyncIterable<PlatformEvent> {
       return;
     }
 
-    await this.transport.connect();
+    try {
+      await this.transport.connect();
+    } catch (error) {
+      if (error instanceof WebSocketDisconnectError) {
+        this.recordDisconnectError(error);
+      }
+      throw error;
+    }
     this.connected = true;
   }
 
@@ -158,9 +187,12 @@ export class ThenvoiLink implements AsyncIterable<PlatformEvent> {
   }
 
   private recordDisconnectReason(reason: WebSocketDisconnectReason): void {
-    const error = new WebSocketDisconnectError(reason);
+    this.recordDisconnectError(new WebSocketDisconnectError(reason));
+  }
+
+  private recordDisconnectError(error: WebSocketDisconnectError): void {
     this.connected = false;
-    this.lastDisconnectReason = reason;
+    this.lastDisconnectReason = error.reason;
     this.terminalDisconnectError = error;
     while (this.waiters.length > 0) {
       const waiter = this.waiters.shift();
@@ -196,17 +228,32 @@ export class ThenvoiLink implements AsyncIterable<PlatformEvent> {
       return;
     }
 
-    const chatTopic = `chat_room:${roomId}`;
-    const participantsTopic = `room_participants:${roomId}`;
+    await this.joinRoomTopics(roomId);
+    this.subscribedRooms.add(roomId);
+  }
 
-    await this.transport.join(chatTopic, {
+  public async unsubscribeRoom(roomId: string): Promise<void> {
+    if (!this.subscribedRooms.has(roomId)) {
+      return;
+    }
+
+    const topics = roomTopics(roomId);
+    await this.transport.leave(topics.chat);
+    await this.transport.leave(topics.participants);
+    this.subscribedRooms.delete(roomId);
+  }
+
+  private async joinRoomTopics(roomId: string): Promise<void> {
+    const topics = roomTopics(roomId);
+
+    await this.transport.join(topics.chat, {
       message_created: (payload) => {
         this.emit("message_created", payload, roomId);
       },
     });
 
     try {
-      await this.transport.join(participantsTopic, {
+      await this.transport.join(topics.participants, {
         participant_added: (payload) => {
           this.emit("participant_added", payload, roomId);
         },
@@ -218,21 +265,9 @@ export class ThenvoiLink implements AsyncIterable<PlatformEvent> {
         },
       });
     } catch (error) {
-      await this.transport.leave(chatTopic);
+      await this.transport.leave(topics.chat);
       throw error;
     }
-
-    this.subscribedRooms.add(roomId);
-  }
-
-  public async unsubscribeRoom(roomId: string): Promise<void> {
-    if (!this.subscribedRooms.has(roomId)) {
-      return;
-    }
-
-    await this.transport.leave(`chat_room:${roomId}`);
-    await this.transport.leave(`room_participants:${roomId}`);
-    this.subscribedRooms.delete(roomId);
   }
 
   public async subscribeAgentContacts(): Promise<void> {
@@ -315,7 +350,10 @@ export class ThenvoiLink implements AsyncIterable<PlatformEvent> {
       next: async () => {
         const value = await this.nextEvent();
         if (value === null) {
-          return { done: true, value: undefined } as IteratorReturnResult<undefined>;
+          return {
+            done: true,
+            value: undefined,
+          } as IteratorReturnResult<undefined>;
         }
         return { done: false, value };
       },
@@ -413,7 +451,9 @@ export class ThenvoiLink implements AsyncIterable<PlatformEvent> {
     }
   }
 
-  public async getStaleProcessingMessages(roomId: string): Promise<PlatformMessage[]> {
+  public async getStaleProcessingMessages(
+    roomId: string,
+  ): Promise<PlatformMessage[]> {
     if (!this.rest.listMessages) {
       return [];
     }
@@ -433,7 +473,9 @@ export class ThenvoiLink implements AsyncIterable<PlatformEvent> {
     requestOptions?: RestRequestOptions,
   ): Promise<PaginatedResponse> {
     if (!this.rest.listChats) {
-      throw new UnsupportedFeatureError("Chat listing is not available in current REST adapter");
+      throw new UnsupportedFeatureError(
+        "Chat listing is not available in current REST adapter",
+      );
     }
 
     return this.rest.listChats(request, requestOptions);
@@ -444,7 +486,8 @@ export class ThenvoiLink implements AsyncIterable<PlatformEvent> {
     requestOptions?: RestRequestOptions,
   ): Promise<MetadataMap[]> {
     return fetchPaginated({
-      fetchPage: ({ page, pageSize }) => this.listChats({ page, pageSize }, requestOptions),
+      fetchPage: ({ page, pageSize }) =>
+        this.listChats({ page, pageSize }, requestOptions),
       pageSize: options?.pageSize,
       maxPages: options?.maxPages,
       strategy: options?.strategy,
@@ -452,7 +495,11 @@ export class ThenvoiLink implements AsyncIterable<PlatformEvent> {
     });
   }
 
-  private emit(eventType: SupportedSocketEvent, payload: Record<string, unknown>, roomId: string | null): void {
+  private emit(
+    eventType: SupportedSocketEvent,
+    payload: Record<string, unknown>,
+    roomId: string | null,
+  ): void {
     const schema = payloadSchemas[eventType];
     const parsed = schema.safeParse(payload);
     if (!parsed.success) {

--- a/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
+++ b/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
@@ -3,6 +3,13 @@ import { WebSocket as NodeWebSocket } from "ws";
 import { TransportError } from "../../core/errors";
 import type { Logger } from "../../core/logger";
 import { NoopLogger } from "../../core/logger";
+import {
+  WebSocketDisconnectError,
+  genericCloseReason,
+  parseSupersedeDisconnectReason,
+  parseUpgradeDisconnectReason,
+  type WebSocketDisconnectReason,
+} from "./disconnectReason";
 import type { StreamingTransport, TopicHandlers } from "./transport";
 
 interface PhoenixChannelsTransportOptions {
@@ -13,21 +20,30 @@ interface PhoenixChannelsTransportOptions {
   heartbeatIntervalMs?: number;
   reconnectAfterMs?: (tries: number) => number;
   websocketFactory?: typeof WebSocket;
+  onTerminalDisconnect?: (reason: WebSocketDisconnectReason) => void;
 }
 
 export class PhoenixChannelsTransport implements StreamingTransport {
   private readonly socket: Socket;
+  private readonly agentId?: string;
   private readonly channels = new Map<string, Channel>();
   private readonly channelRefs = new Map<string, Array<[string, number]>>();
   private readonly pendingJoins = new Map<string, Promise<void>>();
   private readonly logger: Logger;
+  private readonly onTerminalDisconnect?: (reason: WebSocketDisconnectReason) => void;
   private onHandlerError?: (error: unknown) => void;
   private connected = false;
   private connectPromise: Promise<void> | null = null;
   private connectResolve: (() => void) | null = null;
+  private connectReject: ((error: Error) => void) | null = null;
+  private lastDisconnectReason: WebSocketDisconnectReason | null = null;
+  private terminalDisconnectError: WebSocketDisconnectError | null = null;
+  private runForeverRejects = new Set<(error: unknown) => void>();
 
   public constructor(options: PhoenixChannelsTransportOptions) {
     this.logger = options.logger ?? new NoopLogger();
+    this.agentId = options.agentId;
+    this.onTerminalDisconnect = options.onTerminalDisconnect;
 
     // The phoenix JS library appends /websocket to the endpoint URL.
     // Strip it if the user-provided URL already includes it.
@@ -36,14 +52,21 @@ export class PhoenixChannelsTransport implements StreamingTransport {
       wsUrl = wsUrl.slice(0, -"/websocket".length);
     }
 
+    const reconnectAfterMs = options.reconnectAfterMs ??
+      ((tries: number) => [1_000, 2_000, 5_000, 10_000, 30_000][tries - 1] ?? 30_000);
+
     this.socket = new Socket(wsUrl, {
       params: {
         api_key: options.apiKey,
         agent_id: options.agentId,
       },
       heartbeatIntervalMs: options.heartbeatIntervalMs,
-      reconnectAfterMs: options.reconnectAfterMs ??
-        ((tries: number) => [1_000, 2_000, 5_000, 10_000, 30_000][tries - 1] ?? 30_000),
+      reconnectAfterMs: (tries: number) => {
+        if (this.terminalDisconnectError) {
+          return Number.POSITIVE_INFINITY;
+        }
+        return reconnectAfterMs(tries);
+      },
       transport: options.websocketFactory ?? resolveWebSocketFactory(),
     });
 
@@ -51,6 +74,8 @@ export class PhoenixChannelsTransport implements StreamingTransport {
       this.connected = true;
       this.connectResolve?.();
       this.connectResolve = null;
+      this.connectReject = null;
+      void this.subscribeAgentControl();
       this.logger.info("Phoenix socket opened", {
         channels: getSocketChannelCount(this.socket),
       });
@@ -58,25 +83,44 @@ export class PhoenixChannelsTransport implements StreamingTransport {
 
     this.socket.onClose((event?: { code?: number; reason?: string }) => {
       this.connected = false;
+      if (!this.terminalDisconnectError) {
+        this.lastDisconnectReason = genericCloseReason(event);
+      }
 
       // If there are no active channels, stop reconnecting — the socket has
-      // nothing to rejoin and would just churn connections.
-      if (getSocketChannelCount(this.socket) === 0) {
+      // nothing to rejoin and would just churn connections. Terminal platform
+      // disconnects call socket.disconnect() as soon as they are recorded, so
+      // avoid re-entering disconnect from the close callback.
+      if (!this.terminalDisconnectError && getSocketChannelCount(this.socket) === 0) {
         this.socket.disconnect();
       }
 
       this.logger.info("Phoenix socket closed", {
         code: event?.code ?? null,
         reason: event?.reason ?? null,
+        platformReason: this.lastDisconnectReason,
       });
     });
 
     this.socket.onError((event) => {
+      const upgradeReason = parseUpgradeDisconnectReason(event);
+      if (upgradeReason) {
+        this.lastDisconnectReason = upgradeReason;
+        const error = new WebSocketDisconnectError(upgradeReason);
+        this.connectReject?.(error);
+        this.logger.warn("Phoenix socket upgrade failed", { reason: upgradeReason });
+        return;
+      }
+
       this.logger.warn("Phoenix socket error", { event });
     });
   }
 
   public async connect(): Promise<void> {
+    if (this.terminalDisconnectError) {
+      throw this.terminalDisconnectError;
+    }
+
     if (this.connected) {
       return;
     }
@@ -113,6 +157,10 @@ export class PhoenixChannelsTransport implements StreamingTransport {
 
   public isConnected(): boolean {
     return this.connected;
+  }
+
+  public getDisconnectReason(): WebSocketDisconnectReason | null {
+    return this.lastDisconnectReason;
   }
 
   public async join(topic: string, handlers: TopicHandlers): Promise<void> {
@@ -203,13 +251,64 @@ export class PhoenixChannelsTransport implements StreamingTransport {
   }
 
   public async runForever(signal: AbortSignal): Promise<void> {
+    if (this.terminalDisconnectError) {
+      throw this.terminalDisconnectError;
+    }
+
     if (signal.aborted) {
       return;
     }
 
-    await new Promise<void>((resolve) => {
-      signal.addEventListener("abort", () => resolve(), { once: true });
+    await new Promise<void>((resolve, reject) => {
+      const onAbort = () => {
+        this.runForeverRejects.delete(reject);
+        resolve();
+      };
+      this.runForeverRejects.add(reject);
+      signal.addEventListener("abort", onAbort, { once: true });
     });
+  }
+
+  private async subscribeAgentControl(): Promise<void> {
+    if (!this.agentId) {
+      return;
+    }
+
+    try {
+      await this.join(`agent_control:${this.agentId}`, {
+        supersede: (payload) => {
+          const reason = parseSupersedeDisconnectReason(payload);
+          if (!reason) {
+            this.logger.warn("Invalid agent_control supersede payload", { payload });
+            return;
+          }
+          this.recordTerminalDisconnect(reason);
+        },
+      });
+    } catch (error) {
+      this.logger.warn("Failed to join agent_control channel", { error });
+    }
+  }
+
+  private recordTerminalDisconnect(reason: WebSocketDisconnectReason): void {
+    if (this.terminalDisconnectError) {
+      if (this.terminalDisconnectError.reason.source === "agent_control"
+        && reason.source === "agent_control"
+        && this.terminalDisconnectError.reason.correlationId
+        && this.terminalDisconnectError.reason.correlationId === reason.correlationId) {
+        return;
+      }
+    }
+
+    this.lastDisconnectReason = reason;
+    this.terminalDisconnectError = new WebSocketDisconnectError(reason);
+    this.onTerminalDisconnect?.(reason);
+    this.connectReject?.(this.terminalDisconnectError);
+    for (const reject of this.runForeverRejects) {
+      reject(this.terminalDisconnectError);
+    }
+    this.runForeverRejects.clear();
+    this.socket.disconnect();
   }
 
   private async waitForConnection(timeoutMs = 10_000): Promise<void> {
@@ -220,12 +319,20 @@ export class PhoenixChannelsTransport implements StreamingTransport {
     await new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.connectResolve = null;
+        this.connectReject = null;
         reject(new TransportError("Timed out waiting for Phoenix socket connection"));
       }, timeoutMs);
 
       this.connectResolve = () => {
         clearTimeout(timeout);
+        this.connectReject = null;
         resolve();
+      };
+      this.connectReject = (error) => {
+        clearTimeout(timeout);
+        this.connectResolve = null;
+        this.connectReject = null;
+        reject(error instanceof Error ? error : new TransportError(String(error)));
       };
     });
   }

--- a/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
+++ b/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
@@ -83,7 +83,6 @@ export class PhoenixChannelsTransport implements StreamingTransport {
     });
 
     this.socket.onOpen(() => {
-      this.connected = true;
       void this.handleOpen();
     });
 
@@ -320,6 +319,7 @@ export class PhoenixChannelsTransport implements StreamingTransport {
       return;
     }
 
+    this.connected = true;
     this.connectResolve?.();
     this.connectResolve = null;
     this.connectReject = null;

--- a/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
+++ b/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
@@ -23,6 +23,10 @@ interface PhoenixChannelsTransportOptions {
   onTerminalDisconnect?: (reason: WebSocketDisconnectReason) => void;
 }
 
+interface PendingRunForever {
+  reject(error: Error): void;
+}
+
 export class PhoenixChannelsTransport implements StreamingTransport {
   private readonly socket: Socket;
   private readonly agentId?: string;
@@ -38,7 +42,7 @@ export class PhoenixChannelsTransport implements StreamingTransport {
   private connectReject: ((error: Error) => void) | null = null;
   private lastDisconnectReason: WebSocketDisconnectReason | null = null;
   private terminalDisconnectError: WebSocketDisconnectError | null = null;
-  private runForeverRejects = new Set<(error: unknown) => void>();
+  private runForeverWaiters = new Set<PendingRunForever>();
 
   public constructor(options: PhoenixChannelsTransportOptions) {
     this.logger = options.logger ?? new NoopLogger();
@@ -254,12 +258,29 @@ export class PhoenixChannelsTransport implements StreamingTransport {
     }
 
     await new Promise<void>((resolve, reject) => {
-      const onAbort = () => {
-        this.runForeverRejects.delete(reject);
-        resolve();
+      let settled = false;
+      const abortController = new AbortController();
+      const waiter: PendingRunForever = {
+        reject: (error) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          this.runForeverWaiters.delete(waiter);
+          abortController.abort();
+          reject(error);
+        },
       };
-      this.runForeverRejects.add(reject);
-      signal.addEventListener("abort", onAbort, { once: true });
+
+      this.runForeverWaiters.add(waiter);
+      signal.addEventListener("abort", () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        this.runForeverWaiters.delete(waiter);
+        resolve();
+      }, { once: true, signal: abortController.signal });
     });
   }
 
@@ -301,22 +322,18 @@ export class PhoenixChannelsTransport implements StreamingTransport {
 
   private recordTerminalDisconnect(reason: WebSocketDisconnectReason): void {
     if (this.terminalDisconnectError) {
-      if (this.terminalDisconnectError.reason.source === "agent_control"
-        && reason.source === "agent_control"
-        && this.terminalDisconnectError.reason.correlationId
-        && this.terminalDisconnectError.reason.correlationId === reason.correlationId) {
-        return;
-      }
+      return;
     }
 
+    const error = new WebSocketDisconnectError(reason);
     this.lastDisconnectReason = reason;
-    this.terminalDisconnectError = new WebSocketDisconnectError(reason);
+    this.terminalDisconnectError = error;
     this.onTerminalDisconnect?.(reason);
-    this.connectReject?.(this.terminalDisconnectError);
-    for (const reject of this.runForeverRejects) {
-      reject(this.terminalDisconnectError);
+    this.connectReject?.(error);
+    for (const waiter of this.runForeverWaiters) {
+      waiter.reject(error);
     }
-    this.runForeverRejects.clear();
+    this.runForeverWaiters.clear();
     this.socket.disconnect();
   }
 

--- a/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
+++ b/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
@@ -67,7 +67,6 @@ export class PhoenixChannelsTransport implements StreamingTransport {
 
     this.socket = new Socket(wsUrl, {
       params: {
-        api_key: options.apiKey,
         agent_id: options.agentId,
         ...(options.conflictPolicy
           ? { on_conflict: options.conflictPolicy }
@@ -80,7 +79,7 @@ export class PhoenixChannelsTransport implements StreamingTransport {
         }
         return reconnectAfterMs(tries);
       },
-      transport: options.websocketFactory ?? resolveWebSocketFactory(),
+      transport: options.websocketFactory ?? resolveWebSocketFactory(options.apiKey),
     });
 
     this.socket.onOpen(() => {
@@ -107,7 +106,6 @@ export class PhoenixChannelsTransport implements StreamingTransport {
       if (upgradeReason) {
         if (upgradeReason.retryable) {
           this.lastDisconnectReason = upgradeReason;
-          this.connectReject?.(new WebSocketDisconnectError(upgradeReason));
         } else {
           this.recordTerminalDisconnect(upgradeReason);
         }
@@ -406,12 +404,14 @@ export class PhoenixChannelsTransport implements StreamingTransport {
   }
 }
 
-function resolveWebSocketFactory(): typeof WebSocket {
+function resolveWebSocketFactory(apiKey: string): typeof WebSocket {
   if (typeof process !== "undefined" && process.versions?.node) {
-    return createNodeWebSocketFactory();
+    return createNodeWebSocketFactory({ "x-api-key": apiKey });
   }
 
-  return WebSocket;
+  throw new TransportError(
+    "Phoenix WebSocket API-key auth requires a WebSocket transport that can set handshake headers.",
+  );
 }
 
 function unwrapErrorEvent(event: unknown): unknown {

--- a/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
+++ b/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
@@ -99,6 +99,8 @@ export class PhoenixChannelsTransport implements StreamingTransport {
       if (upgradeReason) {
         if (upgradeReason.retryable) {
           this.lastDisconnectReason = upgradeReason;
+          this.connectReject?.(new WebSocketDisconnectError(upgradeReason));
+          this.stopReconnectIfNoChannels({ suppressCloseReason: true });
         } else {
           this.recordTerminalDisconnect(upgradeReason);
         }

--- a/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
+++ b/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
@@ -105,9 +105,12 @@ export class PhoenixChannelsTransport implements StreamingTransport {
       const errorEvent = unwrapErrorEvent(event);
       const upgradeReason = parseUpgradeDisconnectReason(errorEvent);
       if (upgradeReason) {
-        this.lastDisconnectReason = upgradeReason;
-        const error = new WebSocketDisconnectError(upgradeReason);
-        this.connectReject?.(error);
+        if (upgradeReason.retryable) {
+          this.lastDisconnectReason = upgradeReason;
+          this.connectReject?.(new WebSocketDisconnectError(upgradeReason));
+        } else {
+          this.recordTerminalDisconnect(upgradeReason);
+        }
         this.logger.warn("Phoenix socket upgrade failed", {
           reason: upgradeReason,
         });

--- a/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
+++ b/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
@@ -1,3 +1,4 @@
+import type { ClientRequest, IncomingMessage } from "http";
 import { Channel, Socket } from "phoenix";
 import { WebSocket as NodeWebSocket } from "ws";
 import { TransportError } from "../../core/errors";
@@ -81,16 +82,8 @@ export class PhoenixChannelsTransport implements StreamingTransport {
 
     this.socket.onClose((event?: { code?: number; reason?: string }) => {
       this.connected = false;
-      if (!this.terminalDisconnectError) {
+      if (!this.terminalDisconnectError && !this.lastDisconnectReason) {
         this.lastDisconnectReason = genericCloseReason(event);
-      }
-
-      // If there are no active channels, stop reconnecting — the socket has
-      // nothing to rejoin and would just churn connections. Terminal platform
-      // disconnects call socket.disconnect() as soon as they are recorded, so
-      // avoid re-entering disconnect from the close callback.
-      if (!this.terminalDisconnectError && getSocketChannelCount(this.socket) === 0) {
-        this.socket.disconnect();
       }
 
       this.logger.info("Phoenix socket closed", {
@@ -110,6 +103,7 @@ export class PhoenixChannelsTransport implements StreamingTransport {
         return;
       }
 
+      this.connectReject?.(new TransportError("Phoenix socket connection failed", event));
       this.logger.warn("Phoenix socket error", { event });
     });
   }
@@ -145,12 +139,26 @@ export class PhoenixChannelsTransport implements StreamingTransport {
   }
 
   public async disconnect(): Promise<void> {
-    for (const topic of this.channels.keys()) {
-      await this.leave(topic);
-    }
+    const results = await Promise.allSettled(
+      [...this.channels.keys()].map((topic) => this.leave(topic)),
+    );
 
     this.socket.disconnect();
     this.connected = false;
+
+    const failures: unknown[] = [];
+    for (const result of results) {
+      if (result.status === "rejected") {
+        failures.push(result.reason);
+      }
+    }
+
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures,
+        "Failed to leave one or more Phoenix topics during disconnect",
+      );
+    }
   }
 
   public isConnected(): boolean {
@@ -366,10 +374,74 @@ export class PhoenixChannelsTransport implements StreamingTransport {
 
 function resolveWebSocketFactory(): typeof WebSocket {
   if (typeof process !== "undefined" && process.versions?.node) {
-    return NodeWebSocket as unknown as typeof WebSocket;
+    return createNodeWebSocketFactory();
   }
 
   return WebSocket;
+}
+
+type NodeUpgradeWebSocket = InstanceType<typeof NodeWebSocket> & {
+  once(
+    event: "unexpected-response",
+    listener: (request: ClientRequest, response: IncomingMessage) => void,
+  ): NodeUpgradeWebSocket;
+  emit(event: "error", error: Error): boolean;
+  emit(event: "close", code: number, reason: Buffer): boolean;
+};
+
+function createNodeWebSocketFactory(): typeof WebSocket {
+  return class ThenvoiNodeWebSocket extends NodeWebSocket {
+    public constructor(address: string | URL, protocols?: string | string[]) {
+      super(address, protocols);
+      const socket = this as unknown as NodeUpgradeWebSocket;
+      socket.once("unexpected-response", (request, response) => {
+        void emitUpgradeError(socket, request, response);
+      });
+    }
+  } as unknown as typeof WebSocket;
+}
+
+async function emitUpgradeError(
+  websocket: NodeUpgradeWebSocket,
+  request: ClientRequest,
+  response: IncomingMessage,
+): Promise<void> {
+  const body = await readResponseBody(response);
+  const error = new Error(`Unexpected server response: ${response.statusCode ?? "unknown"}`) as Error & {
+    status?: number;
+    statusCode?: number;
+    body?: string;
+    headers?: IncomingMessage["headers"];
+    response?: {
+      status?: number;
+      statusCode?: number;
+      body?: string;
+      headers?: IncomingMessage["headers"];
+    };
+  };
+
+  error.status = response.statusCode;
+  error.statusCode = response.statusCode;
+  error.body = body;
+  error.headers = response.headers;
+  error.response = {
+    status: response.statusCode,
+    statusCode: response.statusCode,
+    body,
+    headers: response.headers,
+  };
+
+  request.destroy?.();
+  websocket.emit("error", error);
+  websocket.emit("close", 1006, Buffer.alloc(0));
+}
+
+async function readResponseBody(response: IncomingMessage): Promise<string> {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of response as AsyncIterable<Uint8Array | string>) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
 }
 
 function removeSocketChannel(socket: Socket, channel: Channel): void {

--- a/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
+++ b/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
@@ -94,7 +94,8 @@ export class PhoenixChannelsTransport implements StreamingTransport {
     });
 
     this.socket.onError((event) => {
-      const upgradeReason = parseUpgradeDisconnectReason(event);
+      const errorEvent = unwrapErrorEvent(event);
+      const upgradeReason = parseUpgradeDisconnectReason(errorEvent);
       if (upgradeReason) {
         this.lastDisconnectReason = upgradeReason;
         const error = new WebSocketDisconnectError(upgradeReason);
@@ -103,7 +104,7 @@ export class PhoenixChannelsTransport implements StreamingTransport {
         return;
       }
 
-      this.connectReject?.(new TransportError("Phoenix socket connection failed", event));
+      this.connectReject?.(new TransportError("Phoenix socket connection failed", errorEvent));
       this.logger.warn("Phoenix socket error", { event });
     });
   }
@@ -442,6 +443,18 @@ async function readResponseBody(response: IncomingMessage): Promise<string> {
     chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
   }
   return Buffer.concat(chunks).toString("utf8");
+}
+
+function unwrapErrorEvent(event: unknown): unknown {
+  if (!isErrorEvent(event)) {
+    return event;
+  }
+
+  return event.error;
+}
+
+function isErrorEvent(event: unknown): event is { error: unknown } {
+  return typeof event === "object" && event !== null && "error" in event;
 }
 
 function removeSocketChannel(socket: Socket, channel: Channel): void {

--- a/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
+++ b/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
@@ -72,13 +72,7 @@ export class PhoenixChannelsTransport implements StreamingTransport {
 
     this.socket.onOpen(() => {
       this.connected = true;
-      this.connectResolve?.();
-      this.connectResolve = null;
-      this.connectReject = null;
-      void this.subscribeAgentControl();
-      this.logger.info("Phoenix socket opened", {
-        channels: getSocketChannelCount(this.socket),
-      });
+      void this.handleOpen();
     });
 
     this.socket.onClose((event?: { code?: number; reason?: string }) => {
@@ -269,25 +263,40 @@ export class PhoenixChannelsTransport implements StreamingTransport {
     });
   }
 
+  private async handleOpen(): Promise<void> {
+    try {
+      await this.subscribeAgentControl();
+    } catch (error) {
+      this.connected = false;
+      this.socket.disconnect();
+      this.connectReject?.(error instanceof Error ? error : new TransportError(String(error)));
+      this.logger.warn("Failed to join mandatory agent_control channel", { error });
+      return;
+    }
+
+    this.connectResolve?.();
+    this.connectResolve = null;
+    this.connectReject = null;
+    this.logger.info("Phoenix socket opened", {
+      channels: getSocketChannelCount(this.socket),
+    });
+  }
+
   private async subscribeAgentControl(): Promise<void> {
     if (!this.agentId) {
       return;
     }
 
-    try {
-      await this.join(`agent_control:${this.agentId}`, {
-        supersede: (payload) => {
-          const reason = parseSupersedeDisconnectReason(payload);
-          if (!reason) {
-            this.logger.warn("Invalid agent_control supersede payload", { payload });
-            return;
-          }
-          this.recordTerminalDisconnect(reason);
-        },
-      });
-    } catch (error) {
-      this.logger.warn("Failed to join agent_control channel", { error });
-    }
+    await this.join(`agent_control:${this.agentId}`, {
+      supersede: (payload) => {
+        const reason = parseSupersedeDisconnectReason(payload);
+        if (!reason) {
+          this.logger.warn("Invalid agent_control supersede payload", { payload });
+          return;
+        }
+        this.recordTerminalDisconnect(reason);
+      },
+    });
   }
 
   private recordTerminalDisconnect(reason: WebSocketDisconnectReason): void {

--- a/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
+++ b/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
@@ -47,6 +47,8 @@ export class PhoenixChannelsTransport implements StreamingTransport {
   private lastDisconnectReason: WebSocketDisconnectReason | null = null;
   private terminalDisconnectError: WebSocketDisconnectError | null = null;
   private runForeverWaiters = new Set<PendingRunForever>();
+  private stoppingReconnect = false;
+  private suppressNextCloseReason = false;
 
   public constructor(options: PhoenixChannelsTransportOptions) {
     this.logger = options.logger ?? new NoopLogger();
@@ -79,7 +81,8 @@ export class PhoenixChannelsTransport implements StreamingTransport {
         }
         return reconnectAfterMs(tries);
       },
-      transport: options.websocketFactory ?? resolveWebSocketFactory(options.apiKey),
+      transport:
+        options.websocketFactory ?? resolveWebSocketFactory(options.apiKey),
     });
 
     this.socket.onOpen(() => {
@@ -108,6 +111,7 @@ export class PhoenixChannelsTransport implements StreamingTransport {
       this.connectReject?.(
         new TransportError("Phoenix socket connection failed", errorEvent),
       );
+      this.stopReconnectIfNoChannels({ suppressCloseReason: true });
       this.logger.warn("Phoenix socket error", { event });
     });
   }
@@ -328,6 +332,19 @@ export class PhoenixChannelsTransport implements StreamingTransport {
     });
   }
 
+  private stopReconnectIfNoChannels(
+    options: { suppressCloseReason?: boolean } = {},
+  ): void {
+    if (this.stoppingReconnect || getSocketChannelCount(this.socket) !== 0) {
+      return;
+    }
+
+    this.suppressNextCloseReason = options.suppressCloseReason ?? false;
+    this.stoppingReconnect = true;
+    this.socket.disconnect();
+    this.stoppingReconnect = false;
+  }
+
   private async subscribeAgentControl(): Promise<void> {
     if (!this.agentId) {
       return;
@@ -349,7 +366,14 @@ export class PhoenixChannelsTransport implements StreamingTransport {
 
   private recordSocketClose(event?: { code?: number; reason?: string }): void {
     this.connected = false;
-    if (!this.terminalDisconnectError && !this.lastDisconnectReason) {
+    const suppressCloseReason = this.suppressNextCloseReason;
+    this.suppressNextCloseReason = false;
+    this.stopReconnectIfNoChannels();
+    if (
+      !suppressCloseReason &&
+      !this.terminalDisconnectError &&
+      !this.lastDisconnectReason
+    ) {
       this.lastDisconnectReason = genericCloseReason(event);
     }
 

--- a/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
+++ b/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
@@ -1,6 +1,4 @@
-import type { ClientRequest, IncomingMessage } from "http";
 import { Channel, Socket } from "phoenix";
-import { WebSocket as NodeWebSocket } from "ws";
 import { TransportError } from "../../core/errors";
 import type { Logger } from "../../core/logger";
 import { NoopLogger } from "../../core/logger";
@@ -9,8 +7,10 @@ import {
   genericCloseReason,
   parseSupersedeDisconnectReason,
   parseUpgradeDisconnectReason,
+  type WebSocketConflictPolicy,
   type WebSocketDisconnectReason,
 } from "./disconnectReason";
+import { createNodeWebSocketFactory } from "./nodeWebSocketFactory";
 import type { StreamingTransport, TopicHandlers } from "./transport";
 
 interface PhoenixChannelsTransportOptions {
@@ -21,6 +21,7 @@ interface PhoenixChannelsTransportOptions {
   heartbeatIntervalMs?: number;
   reconnectAfterMs?: (tries: number) => number;
   websocketFactory?: typeof WebSocket;
+  conflictPolicy?: WebSocketConflictPolicy;
   onTerminalDisconnect?: (reason: WebSocketDisconnectReason) => void;
 }
 
@@ -35,7 +36,9 @@ export class PhoenixChannelsTransport implements StreamingTransport {
   private readonly channelRefs = new Map<string, Array<[string, number]>>();
   private readonly pendingJoins = new Map<string, Promise<void>>();
   private readonly logger: Logger;
-  private readonly onTerminalDisconnect?: (reason: WebSocketDisconnectReason) => void;
+  private readonly onTerminalDisconnect?: (
+    reason: WebSocketDisconnectReason,
+  ) => void;
   private onHandlerError?: (error: unknown) => void;
   private connected = false;
   private connectPromise: Promise<void> | null = null;
@@ -57,13 +60,18 @@ export class PhoenixChannelsTransport implements StreamingTransport {
       wsUrl = wsUrl.slice(0, -"/websocket".length);
     }
 
-    const reconnectAfterMs = options.reconnectAfterMs ??
-      ((tries: number) => [1_000, 2_000, 5_000, 10_000, 30_000][tries - 1] ?? 30_000);
+    const reconnectAfterMs =
+      options.reconnectAfterMs ??
+      ((tries: number) =>
+        [1_000, 2_000, 5_000, 10_000, 30_000][tries - 1] ?? 30_000);
 
     this.socket = new Socket(wsUrl, {
       params: {
         api_key: options.apiKey,
         agent_id: options.agentId,
+        ...(options.conflictPolicy
+          ? { on_conflict: options.conflictPolicy }
+          : {}),
       },
       heartbeatIntervalMs: options.heartbeatIntervalMs,
       reconnectAfterMs: (tries: number) => {
@@ -100,11 +108,15 @@ export class PhoenixChannelsTransport implements StreamingTransport {
         this.lastDisconnectReason = upgradeReason;
         const error = new WebSocketDisconnectError(upgradeReason);
         this.connectReject?.(error);
-        this.logger.warn("Phoenix socket upgrade failed", { reason: upgradeReason });
+        this.logger.warn("Phoenix socket upgrade failed", {
+          reason: upgradeReason,
+        });
         return;
       }
 
-      this.connectReject?.(new TransportError("Phoenix socket connection failed", errorEvent));
+      this.connectReject?.(
+        new TransportError("Phoenix socket connection failed", errorEvent),
+      );
       this.logger.warn("Phoenix socket error", { event });
     });
   }
@@ -214,7 +226,9 @@ export class PhoenixChannelsTransport implements StreamingTransport {
           .receive("error", (error: unknown) =>
             reject(new TransportError(`Failed to join topic ${topic}`, error)),
           )
-          .receive("timeout", () => reject(new TransportError(`Timeout joining topic ${topic}`)));
+          .receive("timeout", () =>
+            reject(new TransportError(`Timeout joining topic ${topic}`)),
+          );
       });
     } catch (error) {
       for (const [event, ref] of refs) {
@@ -250,7 +264,9 @@ export class PhoenixChannelsTransport implements StreamingTransport {
         .receive("error", (error: unknown) =>
           reject(new TransportError(`Failed to leave topic ${topic}`, error)),
         )
-        .receive("timeout", () => reject(new TransportError(`Timeout leaving topic ${topic}`)));
+        .receive("timeout", () =>
+          reject(new TransportError(`Timeout leaving topic ${topic}`)),
+        );
     });
 
     this.channels.delete(topic);
@@ -282,14 +298,18 @@ export class PhoenixChannelsTransport implements StreamingTransport {
       };
 
       this.runForeverWaiters.add(waiter);
-      signal.addEventListener("abort", () => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        this.runForeverWaiters.delete(waiter);
-        resolve();
-      }, { once: true, signal: abortController.signal });
+      signal.addEventListener(
+        "abort",
+        () => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          this.runForeverWaiters.delete(waiter);
+          resolve();
+        },
+        { once: true, signal: abortController.signal },
+      );
     });
   }
 
@@ -299,8 +319,12 @@ export class PhoenixChannelsTransport implements StreamingTransport {
     } catch (error) {
       this.connected = false;
       this.socket.disconnect();
-      this.connectReject?.(error instanceof Error ? error : new TransportError(String(error)));
-      this.logger.warn("Failed to join mandatory agent_control channel", { error });
+      this.connectReject?.(
+        error instanceof Error ? error : new TransportError(String(error)),
+      );
+      this.logger.warn("Failed to join mandatory agent_control channel", {
+        error,
+      });
       return;
     }
 
@@ -321,7 +345,9 @@ export class PhoenixChannelsTransport implements StreamingTransport {
       supersede: (payload) => {
         const reason = parseSupersedeDisconnectReason(payload);
         if (!reason) {
-          this.logger.warn("Invalid agent_control supersede payload", { payload });
+          this.logger.warn("Invalid agent_control supersede payload", {
+            payload,
+          });
           return;
         }
         this.recordTerminalDisconnect(reason);
@@ -355,7 +381,9 @@ export class PhoenixChannelsTransport implements StreamingTransport {
       const timeout = setTimeout(() => {
         this.connectResolve = null;
         this.connectReject = null;
-        reject(new TransportError("Timed out waiting for Phoenix socket connection"));
+        reject(
+          new TransportError("Timed out waiting for Phoenix socket connection"),
+        );
       }, timeoutMs);
 
       this.connectResolve = () => {
@@ -367,7 +395,9 @@ export class PhoenixChannelsTransport implements StreamingTransport {
         clearTimeout(timeout);
         this.connectResolve = null;
         this.connectReject = null;
-        reject(error instanceof Error ? error : new TransportError(String(error)));
+        reject(
+          error instanceof Error ? error : new TransportError(String(error)),
+        );
       };
     });
   }
@@ -379,70 +409,6 @@ function resolveWebSocketFactory(): typeof WebSocket {
   }
 
   return WebSocket;
-}
-
-type NodeUpgradeWebSocket = InstanceType<typeof NodeWebSocket> & {
-  once(
-    event: "unexpected-response",
-    listener: (request: ClientRequest, response: IncomingMessage) => void,
-  ): NodeUpgradeWebSocket;
-  emit(event: "error", error: Error): boolean;
-  emit(event: "close", code: number, reason: Buffer): boolean;
-};
-
-function createNodeWebSocketFactory(): typeof WebSocket {
-  return class ThenvoiNodeWebSocket extends NodeWebSocket {
-    public constructor(address: string | URL, protocols?: string | string[]) {
-      super(address, protocols);
-      const socket = this as unknown as NodeUpgradeWebSocket;
-      socket.once("unexpected-response", (request, response) => {
-        void emitUpgradeError(socket, request, response);
-      });
-    }
-  } as unknown as typeof WebSocket;
-}
-
-async function emitUpgradeError(
-  websocket: NodeUpgradeWebSocket,
-  request: ClientRequest,
-  response: IncomingMessage,
-): Promise<void> {
-  const body = await readResponseBody(response);
-  const error = new Error(`Unexpected server response: ${response.statusCode ?? "unknown"}`) as Error & {
-    status?: number;
-    statusCode?: number;
-    body?: string;
-    headers?: IncomingMessage["headers"];
-    response?: {
-      status?: number;
-      statusCode?: number;
-      body?: string;
-      headers?: IncomingMessage["headers"];
-    };
-  };
-
-  error.status = response.statusCode;
-  error.statusCode = response.statusCode;
-  error.body = body;
-  error.headers = response.headers;
-  error.response = {
-    status: response.statusCode,
-    statusCode: response.statusCode,
-    body,
-    headers: response.headers,
-  };
-
-  request.destroy?.();
-  websocket.emit("error", error);
-  websocket.emit("close", 1006, Buffer.alloc(0));
-}
-
-async function readResponseBody(response: IncomingMessage): Promise<string> {
-  const chunks: Uint8Array[] = [];
-  for await (const chunk of response as AsyncIterable<Uint8Array | string>) {
-    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
-  }
-  return Buffer.concat(chunks).toString("utf8");
 }
 
 function unwrapErrorEvent(event: unknown): unknown {

--- a/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
+++ b/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
@@ -88,16 +88,7 @@ export class PhoenixChannelsTransport implements StreamingTransport {
     });
 
     this.socket.onClose((event?: { code?: number; reason?: string }) => {
-      this.connected = false;
-      if (!this.terminalDisconnectError && !this.lastDisconnectReason) {
-        this.lastDisconnectReason = genericCloseReason(event);
-      }
-
-      this.logger.info("Phoenix socket closed", {
-        code: event?.code ?? null,
-        reason: event?.reason ?? null,
-        platformReason: this.lastDisconnectReason,
-      });
+      this.recordSocketClose(event);
     });
 
     this.socket.onError((event) => {
@@ -353,6 +344,19 @@ export class PhoenixChannelsTransport implements StreamingTransport {
         }
         this.recordTerminalDisconnect(reason);
       },
+    });
+  }
+
+  private recordSocketClose(event?: { code?: number; reason?: string }): void {
+    this.connected = false;
+    if (!this.terminalDisconnectError && !this.lastDisconnectReason) {
+      this.lastDisconnectReason = genericCloseReason(event);
+    }
+
+    this.logger.info("Phoenix socket closed", {
+      code: event?.code ?? null,
+      reason: event?.reason ?? null,
+      platformReason: this.lastDisconnectReason,
     });
   }
 

--- a/packages/sdk/src/platform/streaming/disconnectReason.ts
+++ b/packages/sdk/src/platform/streaming/disconnectReason.ts
@@ -85,9 +85,9 @@ export function parseSupersedeDisconnectReason(
     code: payload.reason,
     message: payload.message,
     retryable: false,
-    retryAfter: numberOrNull(payload.retry_after),
-    targetSocketId: stringOrNull(payload.target_socket_id),
-    correlationId: stringOrNull(payload.correlation_id),
+    retryAfter: typeof payload.retry_after === "number" ? payload.retry_after : null,
+    targetSocketId: typeof payload.target_socket_id === "string" ? payload.target_socket_id : null,
+    correlationId: typeof payload.correlation_id === "string" ? payload.correlation_id : null,
   };
 }
 
@@ -96,7 +96,7 @@ export function parseUpgradeDisconnectReason(event: unknown): WebSocketUpgradeDi
     return null;
   }
 
-  const status = numberOrNull(event.status);
+  const status = typeof event.status === "number" ? event.status : null;
   const body = parseJsonObject(event.body);
   const error = isRecord(body?.error) ? body.error : null;
   if (!error || !isUpgradeCode(error.code)) {
@@ -114,8 +114,8 @@ export function parseUpgradeDisconnectReason(event: unknown): WebSocketUpgradeDi
     code: error.code,
     message: typeof error.message === "string" ? error.message : reason.message,
     retryable: reason.retryable,
-    retryAfter: numberOrNull(error.retry_after) ?? retryAfterFromHeaders(event.headers),
-    requestId: stringOrNull(error.request_id),
+    retryAfter: typeof error.retry_after === "number" ? error.retry_after : retryAfterFromHeaders(event.headers),
+    requestId: typeof error.request_id === "string" ? error.request_id : null,
   };
 }
 
@@ -156,22 +156,15 @@ function retryAfterFromHeaders(headers: unknown): number | null {
     return null;
   }
 
-  return numberOrNull(headers["retry-after"] ?? headers["Retry-After"]);
-}
-
-function numberOrNull(value: unknown): number | null {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value;
+  const retryAfter = headers["retry-after"] ?? headers["Retry-After"];
+  if (typeof retryAfter === "number") {
+    return retryAfter;
   }
-  if (typeof value === "string" && value.trim() !== "") {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : null;
+  if (typeof retryAfter === "string" && retryAfter.trim() !== "") {
+    const seconds = Number(retryAfter);
+    return Number.isFinite(seconds) ? seconds : null;
   }
   return null;
-}
-
-function stringOrNull(value: unknown): string | null {
-  return typeof value === "string" && value.length > 0 ? value : null;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/sdk/src/platform/streaming/disconnectReason.ts
+++ b/packages/sdk/src/platform/streaming/disconnectReason.ts
@@ -34,6 +34,41 @@ export type WebSocketDisconnectReason =
   | WebSocketUpgradeDisconnectReason
   | GenericWebSocketCloseReason;
 
+type UpgradeCode = WebSocketUpgradeDisconnectReason["code"];
+
+type UpgradeContext = {
+  status: number | null;
+  body: unknown;
+  headers: unknown;
+};
+
+const UPGRADE_REASONS: Record<UpgradeCode, {
+  status: WebSocketUpgradeDisconnectReason["status"];
+  message: string;
+  retryable: boolean;
+}> = {
+  invalid_on_conflict: {
+    status: 400,
+    message: "Invalid websocket conflict policy.",
+    retryable: false,
+  },
+  connection_conflict: {
+    status: 409,
+    message: "Websocket connection conflict.",
+    retryable: false,
+  },
+  too_many_requests: {
+    status: 429,
+    message: "Too many websocket connection attempts.",
+    retryable: true,
+  },
+  tracking_failed: {
+    status: 503,
+    message: "Websocket connection tracking failed.",
+    retryable: true,
+  },
+};
+
 export class WebSocketDisconnectError extends Error {
   public readonly reason: WebSocketDisconnectReason;
 
@@ -63,30 +98,25 @@ export function parseSupersedeDisconnectReason(
 }
 
 export function parseUpgradeDisconnectReason(event: unknown): WebSocketUpgradeDisconnectReason | null {
-  const fields = collectUpgradeFields(event);
-  const status = normalizeStatus(firstDefined(fields.map((field) => field.status ?? field.statusCode)));
-  if (status !== 400 && status !== 409 && status !== 429 && status !== 503) {
-    return null;
-  }
-
-  const body = parseUpgradeBody(fields);
+  const context = getUpgradeContext(event);
+  const body = parseBody(context.body);
   const error = isRecord(body?.error) ? body.error : null;
-  if (!error) {
+  if (!error || !isUpgradeCode(error.code)) {
     return null;
   }
 
-  const code = typeof error.code === "string" ? error.code : null;
-  if (!isSupportedUpgradeCode(status, code)) {
+  const expected = UPGRADE_REASONS[error.code];
+  if (context.status !== expected.status) {
     return null;
   }
 
   return {
     source: "upgrade",
-    status,
-    code,
-    message: typeof error.message === "string" ? error.message : defaultUpgradeMessage(code),
-    retryable: code === "too_many_requests" || code === "tracking_failed",
-    retryAfter: normalizeNumber(error.retry_after) ?? readRetryAfterHeader(fields),
+    status: expected.status,
+    code: error.code,
+    message: typeof error.message === "string" ? error.message : expected.message,
+    retryable: expected.retryable,
+    retryAfter: normalizeNumber(error.retry_after) ?? readRetryAfter(context.headers),
     requestId: normalizeString(error.request_id),
   };
 }
@@ -102,27 +132,42 @@ export function genericCloseReason(event?: { code?: number; reason?: string }): 
   };
 }
 
-function collectUpgradeFields(event: unknown): Array<Record<string, unknown>> {
-  const eventRecord = isRecord(event) ? event : null;
-  const errorRecord = isRecord(eventRecord?.error) ? eventRecord.error : null;
-  const records = [eventRecord, errorRecord];
-
-  for (const record of [...records]) {
-    if (isRecord(record?.response)) {
-      records.push(record.response);
-    }
-  }
-
-  return records.filter((record): record is Record<string, unknown> => record !== null);
+function isUpgradeCode(value: unknown): value is UpgradeCode {
+  return typeof value === "string" && value in UPGRADE_REASONS;
 }
 
-function parseUpgradeBody(fields: Array<Record<string, unknown>>): Record<string, unknown> | null {
-  const body = firstDefined(fields.flatMap((field) => [
-    field.body,
-    field.responseText,
-    field.data,
-  ]));
+function getUpgradeContext(event: unknown): UpgradeContext {
+  const eventRecord = isRecord(event) ? event : null;
+  const errorRecord = isRecord(eventRecord?.error) ? eventRecord.error : null;
+  const responseRecord = isRecord(errorRecord?.response)
+    ? errorRecord.response
+    : isRecord(eventRecord?.response)
+      ? eventRecord.response
+      : null;
 
+  return {
+    status: normalizeNumber(
+      eventRecord?.status
+        ?? eventRecord?.statusCode
+        ?? errorRecord?.status
+        ?? errorRecord?.statusCode
+        ?? responseRecord?.status
+        ?? responseRecord?.statusCode,
+    ),
+    body: eventRecord?.body
+      ?? errorRecord?.body
+      ?? responseRecord?.body
+      ?? eventRecord?.responseText
+      ?? errorRecord?.responseText
+      ?? responseRecord?.responseText
+      ?? eventRecord?.data
+      ?? errorRecord?.data
+      ?? responseRecord?.data,
+    headers: eventRecord?.headers ?? errorRecord?.headers ?? responseRecord?.headers,
+  };
+}
+
+function parseBody(body: unknown): Record<string, unknown> | null {
   if (isRecord(body)) {
     return body;
   }
@@ -139,31 +184,7 @@ function parseUpgradeBody(fields: Array<Record<string, unknown>>): Record<string
   }
 }
 
-function isSupportedUpgradeCode(
-  status: number,
-  code: unknown,
-): code is WebSocketUpgradeDisconnectReason["code"] {
-  return (status === 400 && code === "invalid_on_conflict")
-    || (status === 409 && code === "connection_conflict")
-    || (status === 429 && code === "too_many_requests")
-    || (status === 503 && code === "tracking_failed");
-}
-
-function defaultUpgradeMessage(code: WebSocketUpgradeDisconnectReason["code"]): string {
-  switch (code) {
-    case "invalid_on_conflict":
-      return "Invalid websocket conflict policy.";
-    case "connection_conflict":
-      return "Websocket connection conflict.";
-    case "too_many_requests":
-      return "Too many websocket connection attempts.";
-    case "tracking_failed":
-      return "Websocket connection tracking failed.";
-  }
-}
-
-function readRetryAfterHeader(fields: Array<Record<string, unknown>>): number | null {
-  const headers = firstDefined(fields.map((field) => field.headers));
+function readRetryAfter(headers: unknown): number | null {
   if (!headers) {
     return null;
   }
@@ -176,21 +197,6 @@ function readRetryAfterHeader(fields: Array<Record<string, unknown>>): number | 
     return normalizeNumber(headers["Retry-After"] ?? headers["retry-after"]);
   }
 
-  return null;
-}
-
-function firstDefined(values: unknown[]): unknown {
-  return values.find((value) => value !== undefined);
-}
-
-function normalizeStatus(value: unknown): number | null {
-  if (typeof value === "number") {
-    return value;
-  }
-  if (typeof value === "string" && value.trim() !== "") {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : null;
-  }
   return null;
 }
 

--- a/packages/sdk/src/platform/streaming/disconnectReason.ts
+++ b/packages/sdk/src/platform/streaming/disconnectReason.ts
@@ -1,5 +1,7 @@
 export type WebSocketDisconnectSource = "agent_control" | "upgrade" | "websocket_close";
 
+type NestedPath = readonly string[];
+
 export interface AgentControlSupersedeDisconnectReason {
   source: "agent_control";
   code: string;
@@ -63,7 +65,11 @@ export function parseSupersedeDisconnectReason(
 }
 
 export function parseUpgradeDisconnectReason(event: unknown): WebSocketUpgradeDisconnectReason | null {
-  const status = normalizeStatus(readNested(event, ["status"]) ?? readNested(event, ["statusCode"]) ?? readNested(event, ["response", "status"]));
+  const status = normalizeStatus(readFirst(event, [
+    ["status"],
+    ["statusCode"],
+    ["response", "status"],
+  ]));
   if (status !== 400 && status !== 409 && status !== 429 && status !== 503) {
     return null;
   }
@@ -102,20 +108,22 @@ export function genericCloseReason(event?: { code?: number; reason?: string }): 
 }
 
 function parseUpgradeBody(event: unknown): Record<string, unknown> | null {
-  const directBody = readNested(event, ["body"])
-    ?? readNested(event, ["response", "body"])
-    ?? readNested(event, ["responseText"])
-    ?? readNested(event, ["response", "responseText"])
-    ?? readNested(event, ["data"])
-    ?? readNested(event, ["response", "data"]);
+  const body = readFirst(event, [
+    ["body"],
+    ["response", "body"],
+    ["responseText"],
+    ["response", "responseText"],
+    ["data"],
+    ["response", "data"],
+  ]);
 
-  if (isRecord(directBody)) {
-    return directBody;
+  if (isRecord(body)) {
+    return body;
   }
 
-  if (typeof directBody === "string") {
+  if (typeof body === "string") {
     try {
-      const parsed = JSON.parse(directBody) as unknown;
+      const parsed = JSON.parse(body) as unknown;
       return isRecord(parsed) ? parsed : null;
     } catch {
       return null;
@@ -149,7 +157,7 @@ function defaultUpgradeMessage(code: WebSocketUpgradeDisconnectReason["code"]): 
 }
 
 function readRetryAfterHeader(event: unknown): number | null {
-  const headers = readNested(event, ["headers"]) ?? readNested(event, ["response", "headers"]);
+  const headers = readFirst(event, [["headers"], ["response", "headers"]]);
   if (!headers) {
     return null;
   }
@@ -165,7 +173,17 @@ function readRetryAfterHeader(event: unknown): number | null {
   return null;
 }
 
-function readNested(value: unknown, path: string[]): unknown {
+function readFirst(value: unknown, paths: NestedPath[]): unknown {
+  for (const path of paths) {
+    const found = readNested(value, path);
+    if (found !== undefined) {
+      return found;
+    }
+  }
+  return undefined;
+}
+
+function readNested(value: unknown, path: NestedPath): unknown {
   let cursor = value;
   for (const segment of path) {
     if (!isRecord(cursor)) {

--- a/packages/sdk/src/platform/streaming/disconnectReason.ts
+++ b/packages/sdk/src/platform/streaming/disconnectReason.ts
@@ -69,6 +69,9 @@ export function parseUpgradeDisconnectReason(event: unknown): WebSocketUpgradeDi
     ["status"],
     ["statusCode"],
     ["response", "status"],
+    ["error", "status"],
+    ["error", "statusCode"],
+    ["error", "response", "status"],
   ]));
   if (status !== 400 && status !== 409 && status !== 429 && status !== 503) {
     return null;
@@ -115,6 +118,12 @@ function parseUpgradeBody(event: unknown): Record<string, unknown> | null {
     ["response", "responseText"],
     ["data"],
     ["response", "data"],
+    ["error", "body"],
+    ["error", "response", "body"],
+    ["error", "responseText"],
+    ["error", "response", "responseText"],
+    ["error", "data"],
+    ["error", "response", "data"],
   ]);
 
   if (isRecord(body)) {
@@ -157,7 +166,12 @@ function defaultUpgradeMessage(code: WebSocketUpgradeDisconnectReason["code"]): 
 }
 
 function readRetryAfterHeader(event: unknown): number | null {
-  const headers = readFirst(event, [["headers"], ["response", "headers"]]);
+  const headers = readFirst(event, [
+    ["headers"],
+    ["response", "headers"],
+    ["error", "headers"],
+    ["error", "response", "headers"],
+  ]);
   if (!headers) {
     return null;
   }

--- a/packages/sdk/src/platform/streaming/disconnectReason.ts
+++ b/packages/sdk/src/platform/streaming/disconnectReason.ts
@@ -36,12 +36,6 @@ export type WebSocketDisconnectReason =
 
 type UpgradeCode = WebSocketUpgradeDisconnectReason["code"];
 
-type UpgradeContext = {
-  status: number | null;
-  body: unknown;
-  headers: unknown;
-};
-
 const UPGRADE_REASONS: Record<UpgradeCode, {
   status: WebSocketUpgradeDisconnectReason["status"];
   message: string;
@@ -91,33 +85,37 @@ export function parseSupersedeDisconnectReason(
     code: payload.reason,
     message: payload.message,
     retryable: false,
-    retryAfter: normalizeNumber(payload.retry_after),
-    targetSocketId: normalizeString(payload.target_socket_id),
-    correlationId: normalizeString(payload.correlation_id),
+    retryAfter: numberOrNull(payload.retry_after),
+    targetSocketId: stringOrNull(payload.target_socket_id),
+    correlationId: stringOrNull(payload.correlation_id),
   };
 }
 
 export function parseUpgradeDisconnectReason(event: unknown): WebSocketUpgradeDisconnectReason | null {
-  const context = getUpgradeContext(event);
-  const body = parseBody(context.body);
+  if (!isRecord(event)) {
+    return null;
+  }
+
+  const status = numberOrNull(event.status);
+  const body = parseJsonObject(event.body);
   const error = isRecord(body?.error) ? body.error : null;
   if (!error || !isUpgradeCode(error.code)) {
     return null;
   }
 
-  const expected = UPGRADE_REASONS[error.code];
-  if (context.status !== expected.status) {
+  const reason = UPGRADE_REASONS[error.code];
+  if (status !== reason.status) {
     return null;
   }
 
   return {
     source: "upgrade",
-    status: expected.status,
+    status: reason.status,
     code: error.code,
-    message: typeof error.message === "string" ? error.message : expected.message,
-    retryable: expected.retryable,
-    retryAfter: normalizeNumber(error.retry_after) ?? readRetryAfter(context.headers),
-    requestId: normalizeString(error.request_id),
+    message: typeof error.message === "string" ? error.message : reason.message,
+    retryable: reason.retryable,
+    retryAfter: numberOrNull(error.retry_after) ?? retryAfterFromHeaders(event.headers),
+    requestId: stringOrNull(error.request_id),
   };
 }
 
@@ -136,71 +134,32 @@ function isUpgradeCode(value: unknown): value is UpgradeCode {
   return typeof value === "string" && value in UPGRADE_REASONS;
 }
 
-function getUpgradeContext(event: unknown): UpgradeContext {
-  const eventRecord = isRecord(event) ? event : null;
-  const errorRecord = isRecord(eventRecord?.error) ? eventRecord.error : null;
-  const responseRecord = isRecord(errorRecord?.response)
-    ? errorRecord.response
-    : isRecord(eventRecord?.response)
-      ? eventRecord.response
-      : null;
-
-  return {
-    status: normalizeNumber(
-      eventRecord?.status
-        ?? eventRecord?.statusCode
-        ?? errorRecord?.status
-        ?? errorRecord?.statusCode
-        ?? responseRecord?.status
-        ?? responseRecord?.statusCode,
-    ),
-    body: eventRecord?.body
-      ?? errorRecord?.body
-      ?? responseRecord?.body
-      ?? eventRecord?.responseText
-      ?? errorRecord?.responseText
-      ?? responseRecord?.responseText
-      ?? eventRecord?.data
-      ?? errorRecord?.data
-      ?? responseRecord?.data,
-    headers: eventRecord?.headers ?? errorRecord?.headers ?? responseRecord?.headers,
-  };
-}
-
-function parseBody(body: unknown): Record<string, unknown> | null {
-  if (isRecord(body)) {
-    return body;
+function parseJsonObject(value: unknown): Record<string, unknown> | null {
+  if (isRecord(value)) {
+    return value;
   }
 
-  if (typeof body !== "string") {
+  if (typeof value !== "string") {
     return null;
   }
 
   try {
-    const parsed = JSON.parse(body) as unknown;
+    const parsed = JSON.parse(value) as unknown;
     return isRecord(parsed) ? parsed : null;
   } catch {
     return null;
   }
 }
 
-function readRetryAfter(headers: unknown): number | null {
-  if (!headers) {
+function retryAfterFromHeaders(headers: unknown): number | null {
+  if (!isRecord(headers)) {
     return null;
   }
 
-  if (typeof (headers as { get?: unknown }).get === "function") {
-    return normalizeNumber((headers as { get: (name: string) => unknown }).get("Retry-After"));
-  }
-
-  if (isRecord(headers)) {
-    return normalizeNumber(headers["Retry-After"] ?? headers["retry-after"]);
-  }
-
-  return null;
+  return numberOrNull(headers["retry-after"] ?? headers["Retry-After"]);
 }
 
-function normalizeNumber(value: unknown): number | null {
+function numberOrNull(value: unknown): number | null {
   if (typeof value === "number" && Number.isFinite(value)) {
     return value;
   }
@@ -211,7 +170,7 @@ function normalizeNumber(value: unknown): number | null {
   return null;
 }
 
-function normalizeString(value: unknown): string | null {
+function stringOrNull(value: unknown): string | null {
   return typeof value === "string" && value.length > 0 ? value : null;
 }
 

--- a/packages/sdk/src/platform/streaming/disconnectReason.ts
+++ b/packages/sdk/src/platform/streaming/disconnectReason.ts
@@ -1,4 +1,10 @@
-export type WebSocketDisconnectSource = "agent_control" | "upgrade" | "websocket_close";
+import { z } from "zod";
+
+export type WebSocketConflictPolicy = "supersede" | "reject";
+export type WebSocketDisconnectSource =
+  | "agent_control"
+  | "upgrade"
+  | "websocket_close";
 
 export interface AgentControlSupersedeDisconnectReason {
   source: "agent_control";
@@ -13,7 +19,11 @@ export interface AgentControlSupersedeDisconnectReason {
 export interface WebSocketUpgradeDisconnectReason {
   source: "upgrade";
   status: 400 | 409 | 429 | 503;
-  code: "invalid_on_conflict" | "connection_conflict" | "too_many_requests" | "tracking_failed";
+  code:
+    | "invalid_on_conflict"
+    | "connection_conflict"
+    | "too_many_requests"
+    | "tracking_failed";
   message: string;
   retryable: boolean;
   retryAfter: number | null;
@@ -34,13 +44,23 @@ export type WebSocketDisconnectReason =
   | WebSocketUpgradeDisconnectReason
   | GenericWebSocketCloseReason;
 
-type UpgradeCode = WebSocketUpgradeDisconnectReason["code"];
+const UPGRADE_CODES = [
+  "invalid_on_conflict",
+  "connection_conflict",
+  "too_many_requests",
+  "tracking_failed",
+] as const;
 
-const UPGRADE_REASONS: Record<UpgradeCode, {
-  status: WebSocketUpgradeDisconnectReason["status"];
-  message: string;
-  retryable: boolean;
-}> = {
+type UpgradeCode = (typeof UPGRADE_CODES)[number];
+
+const UPGRADE_REASONS: Record<
+  UpgradeCode,
+  {
+    status: WebSocketUpgradeDisconnectReason["status"];
+    message: string;
+    retryable: boolean;
+  }
+> = {
   invalid_on_conflict: {
     status: 400,
     message: "Invalid websocket conflict policy.",
@@ -63,6 +83,32 @@ const UPGRADE_REASONS: Record<UpgradeCode, {
   },
 };
 
+const upgradeErrorSchema = z.object({
+  status: z.number(),
+  body: z.preprocess(
+    (body) => {
+      if (typeof body !== "string") {
+        return body;
+      }
+
+      try {
+        return JSON.parse(body) as unknown;
+      } catch {
+        return null;
+      }
+    },
+    z.object({
+      error: z.object({
+        code: z.enum(UPGRADE_CODES),
+        message: z.string().optional(),
+        retry_after: z.number().nullable().optional(),
+        request_id: z.string().nullable().optional(),
+      }),
+    }),
+  ),
+  headers: z.record(z.unknown()).optional(),
+});
+
 export class WebSocketDisconnectError extends Error {
   public readonly reason: WebSocketDisconnectReason;
 
@@ -76,7 +122,10 @@ export class WebSocketDisconnectError extends Error {
 export function parseSupersedeDisconnectReason(
   payload: Record<string, unknown>,
 ): AgentControlSupersedeDisconnectReason | null {
-  if (typeof payload.reason !== "string" || typeof payload.message !== "string") {
+  if (
+    typeof payload.reason !== "string" ||
+    typeof payload.message !== "string"
+  ) {
     return null;
   }
 
@@ -85,25 +134,35 @@ export function parseSupersedeDisconnectReason(
     code: payload.reason,
     message: payload.message,
     retryable: false,
-    retryAfter: typeof payload.retry_after === "number" ? payload.retry_after : null,
-    targetSocketId: typeof payload.target_socket_id === "string" ? payload.target_socket_id : null,
-    correlationId: typeof payload.correlation_id === "string" ? payload.correlation_id : null,
+    retryAfter:
+      typeof payload.retry_after === "number" ? payload.retry_after : null,
+    targetSocketId:
+      typeof payload.target_socket_id === "string"
+        ? payload.target_socket_id
+        : null,
+    correlationId:
+      typeof payload.correlation_id === "string"
+        ? payload.correlation_id
+        : null,
   };
 }
 
-export function parseUpgradeDisconnectReason(event: unknown): WebSocketUpgradeDisconnectReason | null {
-  if (!isRecord(event)) {
+export function parseUpgradeDisconnectReason(
+  event: unknown,
+): WebSocketUpgradeDisconnectReason | null {
+  const parsed = upgradeErrorSchema.safeParse(event);
+  if (!parsed.success) {
     return null;
   }
 
-  const status = typeof event.status === "number" ? event.status : null;
-  const body = parseJsonObject(event.body);
-  const error = isRecord(body?.error) ? body.error : null;
-  if (!error || !isUpgradeCode(error.code)) {
-    return null;
-  }
-
-  const reason = UPGRADE_REASONS[error.code];
+  const { status, body, headers } = parsed.data;
+  const {
+    code,
+    message,
+    retry_after: retryAfter,
+    request_id: requestId,
+  } = body.error;
+  const reason = UPGRADE_REASONS[code];
   if (status !== reason.status) {
     return null;
   }
@@ -111,62 +170,41 @@ export function parseUpgradeDisconnectReason(event: unknown): WebSocketUpgradeDi
   return {
     source: "upgrade",
     status: reason.status,
-    code: error.code,
-    message: typeof error.message === "string" ? error.message : reason.message,
+    code,
+    message: message ?? reason.message,
     retryable: reason.retryable,
-    retryAfter: typeof error.retry_after === "number" ? error.retry_after : retryAfterFromHeaders(event.headers),
-    requestId: typeof error.request_id === "string" ? error.request_id : null,
+    retryAfter: retryAfter ?? retryAfterFromHeaders(headers),
+    requestId: requestId ?? null,
   };
 }
 
-export function genericCloseReason(event?: { code?: number; reason?: string }): GenericWebSocketCloseReason {
+export function genericCloseReason(event?: {
+  code?: number;
+  reason?: string;
+}): GenericWebSocketCloseReason {
   return {
     source: "websocket_close",
     code: "websocket.closed",
     message: "Phoenix socket closed without a platform disconnect reason.",
     retryable: true,
     closeCode: typeof event?.code === "number" ? event.code : null,
-    closeReason: typeof event?.reason === "string" && event.reason.length > 0 ? event.reason : null,
+    closeReason:
+      typeof event?.reason === "string" && event.reason.length > 0
+        ? event.reason
+        : null,
   };
 }
 
-function isUpgradeCode(value: unknown): value is UpgradeCode {
-  return typeof value === "string" && value in UPGRADE_REASONS;
-}
-
-function parseJsonObject(value: unknown): Record<string, unknown> | null {
-  if (isRecord(value)) {
+function retryAfterFromHeaders(
+  headers: Record<string, unknown> | undefined,
+): number | null {
+  const value = headers?.["retry-after"] ?? headers?.["Retry-After"];
+  if (typeof value === "number") {
     return value;
   }
-
-  if (typeof value !== "string") {
-    return null;
-  }
-
-  try {
-    const parsed = JSON.parse(value) as unknown;
-    return isRecord(parsed) ? parsed : null;
-  } catch {
-    return null;
-  }
-}
-
-function retryAfterFromHeaders(headers: unknown): number | null {
-  if (!isRecord(headers)) {
-    return null;
-  }
-
-  const retryAfter = headers["retry-after"] ?? headers["Retry-After"];
-  if (typeof retryAfter === "number") {
-    return retryAfter;
-  }
-  if (typeof retryAfter === "string" && retryAfter.trim() !== "") {
-    const seconds = Number(retryAfter);
+  if (typeof value === "string" && value.trim() !== "") {
+    const seconds = Number(value);
     return Number.isFinite(seconds) ? seconds : null;
   }
   return null;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
 }

--- a/packages/sdk/src/platform/streaming/disconnectReason.ts
+++ b/packages/sdk/src/platform/streaming/disconnectReason.ts
@@ -1,7 +1,5 @@
 export type WebSocketDisconnectSource = "agent_control" | "upgrade" | "websocket_close";
 
-type NestedPath = readonly string[];
-
 export interface AgentControlSupersedeDisconnectReason {
   source: "agent_control";
   code: string;
@@ -65,19 +63,13 @@ export function parseSupersedeDisconnectReason(
 }
 
 export function parseUpgradeDisconnectReason(event: unknown): WebSocketUpgradeDisconnectReason | null {
-  const status = normalizeStatus(readFirst(event, [
-    ["status"],
-    ["statusCode"],
-    ["response", "status"],
-    ["error", "status"],
-    ["error", "statusCode"],
-    ["error", "response", "status"],
-  ]));
+  const fields = collectUpgradeFields(event);
+  const status = normalizeStatus(firstDefined(fields.map((field) => field.status ?? field.statusCode)));
   if (status !== 400 && status !== 409 && status !== 429 && status !== 503) {
     return null;
   }
 
-  const body = parseUpgradeBody(event);
+  const body = parseUpgradeBody(fields);
   const error = isRecord(body?.error) ? body.error : null;
   if (!error) {
     return null;
@@ -94,7 +86,7 @@ export function parseUpgradeDisconnectReason(event: unknown): WebSocketUpgradeDi
     code,
     message: typeof error.message === "string" ? error.message : defaultUpgradeMessage(code),
     retryable: code === "too_many_requests" || code === "tracking_failed",
-    retryAfter: normalizeNumber(error.retry_after) ?? readRetryAfterHeader(event),
+    retryAfter: normalizeNumber(error.retry_after) ?? readRetryAfterHeader(fields),
     requestId: normalizeString(error.request_id),
   };
 }
@@ -110,36 +102,41 @@ export function genericCloseReason(event?: { code?: number; reason?: string }): 
   };
 }
 
-function parseUpgradeBody(event: unknown): Record<string, unknown> | null {
-  const body = readFirst(event, [
-    ["body"],
-    ["response", "body"],
-    ["responseText"],
-    ["response", "responseText"],
-    ["data"],
-    ["response", "data"],
-    ["error", "body"],
-    ["error", "response", "body"],
-    ["error", "responseText"],
-    ["error", "response", "responseText"],
-    ["error", "data"],
-    ["error", "response", "data"],
-  ]);
+function collectUpgradeFields(event: unknown): Array<Record<string, unknown>> {
+  const eventRecord = isRecord(event) ? event : null;
+  const errorRecord = isRecord(eventRecord?.error) ? eventRecord.error : null;
+  const records = [eventRecord, errorRecord];
+
+  for (const record of [...records]) {
+    if (isRecord(record?.response)) {
+      records.push(record.response);
+    }
+  }
+
+  return records.filter((record): record is Record<string, unknown> => record !== null);
+}
+
+function parseUpgradeBody(fields: Array<Record<string, unknown>>): Record<string, unknown> | null {
+  const body = firstDefined(fields.flatMap((field) => [
+    field.body,
+    field.responseText,
+    field.data,
+  ]));
 
   if (isRecord(body)) {
     return body;
   }
 
-  if (typeof body === "string") {
-    try {
-      const parsed = JSON.parse(body) as unknown;
-      return isRecord(parsed) ? parsed : null;
-    } catch {
-      return null;
-    }
+  if (typeof body !== "string") {
+    return null;
   }
 
-  return null;
+  try {
+    const parsed = JSON.parse(body) as unknown;
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
 }
 
 function isSupportedUpgradeCode(
@@ -165,13 +162,8 @@ function defaultUpgradeMessage(code: WebSocketUpgradeDisconnectReason["code"]): 
   }
 }
 
-function readRetryAfterHeader(event: unknown): number | null {
-  const headers = readFirst(event, [
-    ["headers"],
-    ["response", "headers"],
-    ["error", "headers"],
-    ["error", "response", "headers"],
-  ]);
+function readRetryAfterHeader(fields: Array<Record<string, unknown>>): number | null {
+  const headers = firstDefined(fields.map((field) => field.headers));
   if (!headers) {
     return null;
   }
@@ -187,25 +179,8 @@ function readRetryAfterHeader(event: unknown): number | null {
   return null;
 }
 
-function readFirst(value: unknown, paths: NestedPath[]): unknown {
-  for (const path of paths) {
-    const found = readNested(value, path);
-    if (found !== undefined) {
-      return found;
-    }
-  }
-  return undefined;
-}
-
-function readNested(value: unknown, path: NestedPath): unknown {
-  let cursor = value;
-  for (const segment of path) {
-    if (!isRecord(cursor)) {
-      return undefined;
-    }
-    cursor = cursor[segment];
-  }
-  return cursor;
+function firstDefined(values: unknown[]): unknown {
+  return values.find((value) => value !== undefined);
 }
 
 function normalizeStatus(value: unknown): number | null {

--- a/packages/sdk/src/platform/streaming/disconnectReason.ts
+++ b/packages/sdk/src/platform/streaming/disconnectReason.ts
@@ -1,0 +1,207 @@
+export type WebSocketDisconnectSource = "agent_control" | "upgrade" | "websocket_close";
+
+export interface AgentControlSupersedeDisconnectReason {
+  source: "agent_control";
+  code: string;
+  message: string;
+  retryable: false;
+  retryAfter: number | null;
+  targetSocketId: string | null;
+  correlationId: string | null;
+}
+
+export interface WebSocketUpgradeDisconnectReason {
+  source: "upgrade";
+  status: 400 | 409 | 429 | 503;
+  code: "invalid_on_conflict" | "connection_conflict" | "too_many_requests" | "tracking_failed";
+  message: string;
+  retryable: boolean;
+  retryAfter: number | null;
+  requestId: string | null;
+}
+
+export interface GenericWebSocketCloseReason {
+  source: "websocket_close";
+  code: "websocket.closed";
+  message: string;
+  retryable: boolean;
+  closeCode: number | null;
+  closeReason: string | null;
+}
+
+export type WebSocketDisconnectReason =
+  | AgentControlSupersedeDisconnectReason
+  | WebSocketUpgradeDisconnectReason
+  | GenericWebSocketCloseReason;
+
+export class WebSocketDisconnectError extends Error {
+  public readonly reason: WebSocketDisconnectReason;
+
+  public constructor(reason: WebSocketDisconnectReason) {
+    super(reason.message);
+    this.name = "WebSocketDisconnectError";
+    this.reason = reason;
+  }
+}
+
+export function parseSupersedeDisconnectReason(
+  payload: Record<string, unknown>,
+): AgentControlSupersedeDisconnectReason | null {
+  if (typeof payload.reason !== "string" || typeof payload.message !== "string") {
+    return null;
+  }
+
+  return {
+    source: "agent_control",
+    code: payload.reason,
+    message: payload.message,
+    retryable: false,
+    retryAfter: normalizeNumber(payload.retry_after),
+    targetSocketId: normalizeString(payload.target_socket_id),
+    correlationId: normalizeString(payload.correlation_id),
+  };
+}
+
+export function parseUpgradeDisconnectReason(event: unknown): WebSocketUpgradeDisconnectReason | null {
+  const status = normalizeStatus(readNested(event, ["status"]) ?? readNested(event, ["statusCode"]) ?? readNested(event, ["response", "status"]));
+  if (status !== 400 && status !== 409 && status !== 429 && status !== 503) {
+    return null;
+  }
+
+  const body = parseUpgradeBody(event);
+  const error = isRecord(body?.error) ? body.error : null;
+  if (!error) {
+    return null;
+  }
+
+  const code = typeof error.code === "string" ? error.code : null;
+  if (!isSupportedUpgradeCode(status, code)) {
+    return null;
+  }
+
+  return {
+    source: "upgrade",
+    status,
+    code,
+    message: typeof error.message === "string" ? error.message : defaultUpgradeMessage(code),
+    retryable: code === "too_many_requests" || code === "tracking_failed",
+    retryAfter: normalizeNumber(error.retry_after) ?? readRetryAfterHeader(event),
+    requestId: normalizeString(error.request_id),
+  };
+}
+
+export function genericCloseReason(event?: { code?: number; reason?: string }): GenericWebSocketCloseReason {
+  return {
+    source: "websocket_close",
+    code: "websocket.closed",
+    message: "Phoenix socket closed without a platform disconnect reason.",
+    retryable: true,
+    closeCode: typeof event?.code === "number" ? event.code : null,
+    closeReason: typeof event?.reason === "string" && event.reason.length > 0 ? event.reason : null,
+  };
+}
+
+function parseUpgradeBody(event: unknown): Record<string, unknown> | null {
+  const directBody = readNested(event, ["body"])
+    ?? readNested(event, ["response", "body"])
+    ?? readNested(event, ["responseText"])
+    ?? readNested(event, ["response", "responseText"])
+    ?? readNested(event, ["data"])
+    ?? readNested(event, ["response", "data"]);
+
+  if (isRecord(directBody)) {
+    return directBody;
+  }
+
+  if (typeof directBody === "string") {
+    try {
+      const parsed = JSON.parse(directBody) as unknown;
+      return isRecord(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+function isSupportedUpgradeCode(
+  status: number,
+  code: unknown,
+): code is WebSocketUpgradeDisconnectReason["code"] {
+  return (status === 400 && code === "invalid_on_conflict")
+    || (status === 409 && code === "connection_conflict")
+    || (status === 429 && code === "too_many_requests")
+    || (status === 503 && code === "tracking_failed");
+}
+
+function defaultUpgradeMessage(code: WebSocketUpgradeDisconnectReason["code"]): string {
+  switch (code) {
+    case "invalid_on_conflict":
+      return "Invalid websocket conflict policy.";
+    case "connection_conflict":
+      return "Websocket connection conflict.";
+    case "too_many_requests":
+      return "Too many websocket connection attempts.";
+    case "tracking_failed":
+      return "Websocket connection tracking failed.";
+  }
+}
+
+function readRetryAfterHeader(event: unknown): number | null {
+  const headers = readNested(event, ["headers"]) ?? readNested(event, ["response", "headers"]);
+  if (!headers) {
+    return null;
+  }
+
+  if (typeof (headers as { get?: unknown }).get === "function") {
+    return normalizeNumber((headers as { get: (name: string) => unknown }).get("Retry-After"));
+  }
+
+  if (isRecord(headers)) {
+    return normalizeNumber(headers["Retry-After"] ?? headers["retry-after"]);
+  }
+
+  return null;
+}
+
+function readNested(value: unknown, path: string[]): unknown {
+  let cursor = value;
+  for (const segment of path) {
+    if (!isRecord(cursor)) {
+      return undefined;
+    }
+    cursor = cursor[segment];
+  }
+  return cursor;
+}
+
+function normalizeStatus(value: unknown): number | null {
+  if (typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function normalizeNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function normalizeString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/sdk/src/platform/streaming/nodeWebSocketFactory.ts
+++ b/packages/sdk/src/platform/streaming/nodeWebSocketFactory.ts
@@ -1,0 +1,54 @@
+import type { ClientRequest, IncomingMessage } from "http";
+import { WebSocket as NodeWebSocket } from "ws";
+
+type NodeUpgradeWebSocket = InstanceType<typeof NodeWebSocket> & {
+  once(
+    event: "unexpected-response",
+    listener: (request: ClientRequest, response: IncomingMessage) => void,
+  ): NodeUpgradeWebSocket;
+  emit(event: "error", error: Error): boolean;
+  emit(event: "close", code: number, reason: Buffer): boolean;
+};
+
+export function createNodeWebSocketFactory(): typeof WebSocket {
+  return class ThenvoiNodeWebSocket extends NodeWebSocket {
+    public constructor(address: string | URL, protocols?: string | string[]) {
+      super(address, protocols);
+      const socket = this as unknown as NodeUpgradeWebSocket;
+      socket.once("unexpected-response", (request, response) => {
+        void emitUpgradeError(socket, request, response);
+      });
+    }
+  } as unknown as typeof WebSocket;
+}
+
+async function emitUpgradeError(
+  websocket: NodeUpgradeWebSocket,
+  request: ClientRequest,
+  response: IncomingMessage,
+): Promise<void> {
+  const body = await readResponseBody(response);
+  const error = new Error(
+    `Unexpected server response: ${response.statusCode ?? "unknown"}`,
+  ) as Error & {
+    status?: number;
+    body?: string;
+    headers?: IncomingMessage["headers"];
+  };
+
+  error.status = response.statusCode;
+  error.body = body;
+  error.headers = response.headers;
+
+  request.destroy();
+  websocket.emit("error", error);
+  websocket.emit("close", 1006, Buffer.alloc(0));
+}
+
+async function readResponseBody(response: IncomingMessage): Promise<string> {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of response as AsyncIterable<Uint8Array | string>) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}

--- a/packages/sdk/src/platform/streaming/nodeWebSocketFactory.ts
+++ b/packages/sdk/src/platform/streaming/nodeWebSocketFactory.ts
@@ -10,16 +10,26 @@ type NodeUpgradeWebSocket = InstanceType<typeof NodeWebSocket> & {
   emit(event: "close", code: number, reason: Buffer): boolean;
 };
 
-export function createNodeWebSocketFactory(): typeof WebSocket {
-  return class ThenvoiNodeWebSocket extends NodeWebSocket {
+type NodeWebSocketConstructor = new (
+  address: string | URL,
+  protocols?: string | string[],
+  options?: { headers?: Record<string, string> },
+) => NodeUpgradeWebSocket;
+
+export function createNodeWebSocketFactory(headers?: Record<string, string>): typeof WebSocket {
+  const Constructor = NodeWebSocket as unknown as NodeWebSocketConstructor;
+
+  class ThenvoiNodeWebSocket {
     public constructor(address: string | URL, protocols?: string | string[]) {
-      super(address, protocols);
-      const socket = this as unknown as NodeUpgradeWebSocket;
+      const socket = new Constructor(address, protocols, headers ? { headers } : undefined);
       socket.once("unexpected-response", (request, response) => {
         void emitUpgradeError(socket, request, response);
       });
+      return socket;
     }
-  } as unknown as typeof WebSocket;
+  }
+
+  return ThenvoiNodeWebSocket as unknown as typeof WebSocket;
 }
 
 async function emitUpgradeError(

--- a/packages/sdk/src/platform/streaming/transport.ts
+++ b/packages/sdk/src/platform/streaming/transport.ts
@@ -1,3 +1,5 @@
+import type { WebSocketDisconnectReason } from "./disconnectReason";
+
 export interface TopicHandlers {
   [event: string]: (payload: Record<string, unknown>) => Promise<void> | void;
 }
@@ -9,4 +11,5 @@ export interface StreamingTransport {
   leave(topic: string): Promise<void>;
   runForever(signal: AbortSignal): Promise<void>;
   isConnected(): boolean;
+  getDisconnectReason?(): WebSocketDisconnectReason | null;
 }

--- a/packages/sdk/src/platform/streaming/transport.ts
+++ b/packages/sdk/src/platform/streaming/transport.ts
@@ -1,5 +1,3 @@
-import type { WebSocketDisconnectReason } from "./disconnectReason";
-
 export interface TopicHandlers {
   [event: string]: (payload: Record<string, unknown>) => Promise<void> | void;
 }
@@ -11,5 +9,4 @@ export interface StreamingTransport {
   leave(topic: string): Promise<void>;
   runForever(signal: AbortSignal): Promise<void>;
   isConnected(): boolean;
-  getDisconnectReason?(): WebSocketDisconnectReason | null;
 }

--- a/packages/sdk/src/runtime/rooms/AgentRuntime.ts
+++ b/packages/sdk/src/runtime/rooms/AgentRuntime.ts
@@ -135,7 +135,7 @@ export class AgentRuntime {
   }
 
   public async stop(timeoutMs?: number): Promise<boolean> {
-    if (!this.running || this.stopping) {
+    if (this.stopping || (!this.running && !this.fatalError)) {
       return true;
     }
 
@@ -159,7 +159,8 @@ export class AgentRuntime {
     }
 
     for (const roomId of [...this.subscribedRooms]) {
-      await this.leaveTrackedRoom(roomId);
+      const remaining = deadline === undefined ? undefined : Math.max(0, deadline - Date.now());
+      await this.leaveTrackedRoom(roomId, remaining);
     }
 
     for (const roomId of [...this.contexts.keys()]) {
@@ -204,7 +205,14 @@ export class AgentRuntime {
 
   private async consumeLoop(signal: AbortSignal): Promise<void> {
     while (!signal.aborted) {
-      const event = await this.link.nextEvent(signal);
+      let event: PlatformEvent | null;
+      try {
+        event = await this.link.nextEvent(signal);
+      } catch (error: unknown) {
+        await this.failRuntime(error, syntheticRuntimeFailureEvent(this.agentId));
+        return;
+      }
+
       if (!event) {
         return;
       }
@@ -385,13 +393,13 @@ export class AgentRuntime {
     });
   }
 
-  private async leaveTrackedRoom(roomId: string): Promise<void> {
+  private async leaveTrackedRoom(roomId: string, timeoutMs?: number): Promise<void> {
     await trackRoomLeave({
       link: this.link,
       roomId,
       trackedRooms: this.subscribedRooms,
       onLeft: async (leftRoomId) => {
-        await this.executions.get(leftRoomId)?.stop();
+        await this.executions.get(leftRoomId)?.stop(timeoutMs);
         this.contexts.delete(leftRoomId);
         this.executions.delete(leftRoomId);
         await this.onSessionCleanup(leftRoomId);
@@ -431,6 +439,24 @@ export class AgentRuntime {
       });
     }
   }
+}
+
+function syntheticRuntimeFailureEvent(agentId: string): PlatformEvent {
+  return {
+    type: "message_created",
+    roomId: null,
+    payload: {
+      id: "runtime-failed",
+      content: "",
+      sender_id: agentId,
+      sender_type: "Agent",
+      sender_name: null,
+      message_type: "text",
+      metadata: {},
+      inserted_at: new Date(0).toISOString(),
+      updated_at: new Date(0).toISOString(),
+    },
+  };
 }
 
 function assertNever(value: never): never {

--- a/packages/sdk/tests/phoenix-channels-transport.test.ts
+++ b/packages/sdk/tests/phoenix-channels-transport.test.ts
@@ -12,7 +12,10 @@ const phoenixMock = vi.hoisted(() => {
 
   class FakeChannel {
     public readonly topic: string;
-    public readonly handlers = new Map<string, (payload: Record<string, unknown>) => void>();
+    public readonly handlers = new Map<
+      string,
+      (payload: Record<string, unknown>) => void
+    >();
     public joinOutcome: Outcome = "ok";
     public leaveOutcome: Outcome = "ok";
     private nextRef = 1;
@@ -21,7 +24,10 @@ const phoenixMock = vi.hoisted(() => {
       this.topic = topic;
     }
 
-    public on(event: string, handler: (payload: Record<string, unknown>) => void): number {
+    public on(
+      event: string,
+      handler: (payload: Record<string, unknown>) => void,
+    ): number {
       this.handlers.set(event, handler);
       return this.nextRef++;
     }
@@ -35,24 +41,35 @@ const phoenixMock = vi.hoisted(() => {
     }
 
     public join(): {
-      receive: (kind: Outcome, callback: (payload?: unknown) => void) => unknown;
+      receive: (
+        kind: Outcome,
+        callback: (payload?: unknown) => void,
+      ) => unknown;
     } {
       return this.receiver(this.joinOutcome);
     }
 
     public leave(): {
-      receive: (kind: Outcome, callback: (payload?: unknown) => void) => unknown;
+      receive: (
+        kind: Outcome,
+        callback: (payload?: unknown) => void,
+      ) => unknown;
     } {
       return this.receiver(this.leaveOutcome);
     }
 
     private receiver(outcome: Outcome): {
-      receive: (kind: Outcome, callback: (payload?: unknown) => void) => unknown;
+      receive: (
+        kind: Outcome,
+        callback: (payload?: unknown) => void,
+      ) => unknown;
     } {
       const chain = {
         receive: (kind: Outcome, callback: (payload?: unknown) => void) => {
           if (kind === outcome) {
-            queueMicrotask(() => callback(kind === "ok" ? {} : { error: kind }));
+            queueMicrotask(() =>
+              callback(kind === "ok" ? {} : { error: kind }),
+            );
           }
           return chain;
         },
@@ -89,10 +106,18 @@ const phoenixMock = vi.hoisted(() => {
     public readonly channels = new FakeChannelList();
     public disconnectCount = 0;
     private openHandler: (() => void) | null = null;
-    private closeHandler: ((event?: { code?: number; reason?: string }) => void) | null = null;
+    private closeHandler:
+      | ((event?: { code?: number; reason?: string }) => void)
+      | null = null;
     private errorHandler: ((payload: unknown) => void) | null = null;
 
-    public constructor(url: string, options: { params: Record<string, unknown>; reconnectAfterMs?: (tries: number) => number }) {
+    public constructor(
+      url: string,
+      options: {
+        params: Record<string, unknown>;
+        reconnectAfterMs?: (tries: number) => number;
+      },
+    ) {
       this.url = url;
       this.params = options.params;
       this.reconnectAfterMs = options.reconnectAfterMs;
@@ -103,7 +128,9 @@ const phoenixMock = vi.hoisted(() => {
       this.openHandler = handler;
     }
 
-    public onClose(handler: (event?: { code?: number; reason?: string }) => void): void {
+    public onClose(
+      handler: (event?: { code?: number; reason?: string }) => void,
+    ): void {
       this.closeHandler = handler;
     }
 
@@ -171,10 +198,27 @@ describe("PhoenixChannelsTransport", () => {
 
     const socket = phoenixMock.FakeSocket.instances[0];
     expect(socket?.url).toBe("wss://example.test/socket");
+    expect(socket?.params).toMatchObject({
+      api_key: "key-1",
+      agent_id: "agent-1",
+    });
 
     await transport.connect();
     await transport.connect();
     expect(transport.isConnected()).toBe(true);
+  });
+
+  it("passes explicit conflict policy as a socket param", () => {
+    new PhoenixChannelsTransport({
+      wsUrl: "wss://example.test/socket",
+      apiKey: "key-1",
+      agentId: "agent-1",
+      conflictPolicy: "reject",
+    });
+
+    expect(phoenixMock.FakeSocket.instances[0]?.params).toMatchObject({
+      on_conflict: "reject",
+    });
   });
 
   it("joins and leaves topics and dispatches topic handlers", async () => {
@@ -283,7 +327,8 @@ describe("PhoenixChannelsTransport", () => {
 
     control?.emit("supersede", {
       reason: "session.already_connected",
-      message: "This connection has been superseded by a newer session for this agent.",
+      message:
+        "This connection has been superseded by a newer session for this agent.",
       retryable: false,
       retry_after: 5,
       target_socket_id: "agent_socket:agent-1",
@@ -294,7 +339,8 @@ describe("PhoenixChannelsTransport", () => {
     expect(reason).toMatchObject({
       source: "agent_control",
       code: "session.already_connected",
-      message: "This connection has been superseded by a newer session for this agent.",
+      message:
+        "This connection has been superseded by a newer session for this agent.",
       retryable: false,
       retryAfter: 5,
       targetSocketId: "agent_socket:agent-1",
@@ -303,7 +349,9 @@ describe("PhoenixChannelsTransport", () => {
     expect(onTerminalDisconnect).toHaveBeenCalledWith(reason);
     expect(socket?.disconnectCount).toBeGreaterThan(0);
     expect(socket?.reconnectAfterMs?.(1)).toBe(Number.POSITIVE_INFINITY);
-    await expect(transport.connect()).rejects.toBeInstanceOf(WebSocketDisconnectError);
+    await expect(transport.connect()).rejects.toBeInstanceOf(
+      WebSocketDisconnectError,
+    );
   });
 
   it("rejects runForever waiters on terminal supersede", async () => {
@@ -319,7 +367,8 @@ describe("PhoenixChannelsTransport", () => {
     const socket = phoenixMock.FakeSocket.instances[0];
     socket?.channels.get("agent_control:agent-1")?.emit("supersede", {
       reason: "session.already_connected",
-      message: "This connection has been superseded by a newer session for this agent.",
+      message:
+        "This connection has been superseded by a newer session for this agent.",
     });
 
     await expect(runForever).rejects.toBeInstanceOf(WebSocketDisconnectError);
@@ -348,42 +397,48 @@ describe("PhoenixChannelsTransport", () => {
   });
 
   it.each([
-    [409, "connection_conflict", null],
-    [429, "too_many_requests", 7],
-    [400, "invalid_on_conflict", null],
-    [503, "tracking_failed", null],
-  ] as const)("parses HTTP %s upgrade error %s", async (status, code, retryAfter) => {
-    const transport = new PhoenixChannelsTransport({
-      wsUrl: "wss://example.test/socket",
-      apiKey: "key-1",
-      agentId: "agent-1",
-    });
+    [409, "connection_conflict", null, null],
+    [429, "too_many_requests", 7, "req-1"],
+    [400, "invalid_on_conflict", null, "req-1"],
+    [503, "tracking_failed", null, "req-1"],
+  ] as const)(
+    "parses HTTP %s upgrade error %s",
+    async (status, code, retryAfter, requestId) => {
+      const transport = new PhoenixChannelsTransport({
+        wsUrl: "wss://example.test/socket",
+        apiKey: "key-1",
+        agentId: "agent-1",
+      });
 
-    const connectPromise = transport.connect();
-    const socket = phoenixMock.FakeSocket.instances[0];
-    socket?.emitError({
-      status,
-      body: {
-        error: {
-          code,
-          message: `upgrade failed: ${code}`,
-          request_id: "req-1",
-          ...(retryAfter === null ? {} : { retry_after: retryAfter }),
+      const connectPromise = transport.connect();
+      const socket = phoenixMock.FakeSocket.instances[0];
+      socket?.emitError({
+        status,
+        body: {
+          error: {
+            code,
+            message: `upgrade failed: ${code}`,
+            request_id: requestId,
+            retry_after: retryAfter,
+          },
         },
-      },
-      headers: retryAfter === null ? {} : { "Retry-After": String(retryAfter) },
-    });
+        headers:
+          retryAfter === null ? {} : { "Retry-After": String(retryAfter) },
+      });
 
-    await expect(connectPromise).rejects.toBeInstanceOf(WebSocketDisconnectError);
-    expect(transport.getDisconnectReason()).toMatchObject({
-      source: "upgrade",
-      status,
-      code,
-      message: `upgrade failed: ${code}`,
-      requestId: "req-1",
-      retryAfter,
-    });
-  });
+      await expect(connectPromise).rejects.toBeInstanceOf(
+        WebSocketDisconnectError,
+      );
+      expect(transport.getDisconnectReason()).toMatchObject({
+        source: "upgrade",
+        status,
+        code,
+        message: `upgrade failed: ${code}`,
+        requestId,
+        retryAfter,
+      });
+    },
+  );
 
   it("rejects empty 403 upgrade errors without inventing a platform reason", async () => {
     const transport = new PhoenixChannelsTransport({
@@ -418,7 +473,8 @@ describe("PhoenixChannelsTransport", () => {
 
     socket?.channels.get("agent_control:agent-1")?.emit("supersede", {
       reason: "session.already_connected",
-      message: "This connection has been superseded by a newer session for this agent.",
+      message:
+        "This connection has been superseded by a newer session for this agent.",
     });
 
     await expect(runForever).rejects.toBeInstanceOf(WebSocketDisconnectError);

--- a/packages/sdk/tests/phoenix-channels-transport.test.ts
+++ b/packages/sdk/tests/phoenix-channels-transport.test.ts
@@ -199,9 +199,9 @@ describe("PhoenixChannelsTransport", () => {
     const socket = phoenixMock.FakeSocket.instances[0];
     expect(socket?.url).toBe("wss://example.test/socket");
     expect(socket?.params).toMatchObject({
-      api_key: "key-1",
       agent_id: "agent-1",
     });
+    expect(socket?.params).not.toHaveProperty("api_key");
 
     await transport.connect();
     await transport.connect();
@@ -440,9 +440,13 @@ describe("PhoenixChannelsTransport", () => {
           retryAfter === null ? {} : { "Retry-After": String(retryAfter) },
       });
 
-      await expect(connectPromise).rejects.toBeInstanceOf(
-        WebSocketDisconnectError,
-      );
+      if (status === 429 || status === 503) {
+        await expect(connectPromise).resolves.toBeUndefined();
+      } else {
+        await expect(connectPromise).rejects.toBeInstanceOf(
+          WebSocketDisconnectError,
+        );
+      }
       expect(transport.getDisconnectReason()).toMatchObject({
         source: "upgrade",
         status,
@@ -505,9 +509,7 @@ describe("PhoenixChannelsTransport", () => {
       },
     });
 
-    await expect(connectPromise).rejects.toBeInstanceOf(
-      WebSocketDisconnectError,
-    );
+    await expect(connectPromise).resolves.toBeUndefined();
     expect(socket?.reconnectAfterMs?.(1)).toBe(1000);
   });
 

--- a/packages/sdk/tests/phoenix-channels-transport.test.ts
+++ b/packages/sdk/tests/phoenix-channels-transport.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { GenericAdapter } from "../src/adapters/GenericAdapter";
 import { TransportError } from "../src/core/errors";
+import { ThenvoiLink } from "../src/platform/ThenvoiLink";
 import { WebSocketDisconnectError } from "../src/platform/streaming/disconnectReason";
+import { PlatformRuntime } from "../src/runtime/PlatformRuntime";
+import { FakeRestApi } from "./testUtils";
 
 const phoenixMock = vi.hoisted(() => {
   type Outcome = "ok" | "error" | "timeout";
@@ -57,13 +61,32 @@ const phoenixMock = vi.hoisted(() => {
     }
   }
 
+  class FakeChannelList extends Array<FakeChannel> {
+    public get(topic: string): FakeChannel | undefined {
+      return this.find((channel) => channel.topic === topic);
+    }
+
+    public has(topic: string): boolean {
+      return this.some((channel) => channel.topic === topic);
+    }
+
+    public delete(channelToDelete: FakeChannel): boolean {
+      const index = this.indexOf(channelToDelete);
+      if (index < 0) {
+        return false;
+      }
+      this.splice(index, 1);
+      return true;
+    }
+  }
+
   class FakeSocket {
     public static readonly instances: FakeSocket[] = [];
 
     public readonly url: string;
     public readonly params: Record<string, unknown>;
     public readonly reconnectAfterMs?: (tries: number) => number;
-    public readonly channels = new Map<string, FakeChannel>();
+    public readonly channels = new FakeChannelList();
     public disconnectCount = 0;
     private openHandler: (() => void) | null = null;
     private closeHandler: ((event?: { code?: number; reason?: string }) => void) | null = null;
@@ -105,8 +128,12 @@ const phoenixMock = vi.hoisted(() => {
 
     public channel(topic: string): FakeChannel {
       const channel = new FakeChannel(topic);
-      this.channels.set(topic, channel);
+      this.channels.push(channel);
       return channel;
+    }
+
+    public remove(channel: FakeChannel): void {
+      this.channels.delete(channel);
     }
 
     public emitError(payload: unknown): void {
@@ -358,17 +385,42 @@ describe("PhoenixChannelsTransport", () => {
     });
   });
 
-  it("leaves empty 403 upgrade errors generic", async () => {
+  it("rejects empty 403 upgrade errors without inventing a platform reason", async () => {
     const transport = new PhoenixChannelsTransport({
       wsUrl: "wss://example.test/socket",
       apiKey: "key-1",
       agentId: "agent-1",
     });
 
-    void transport.connect().catch(() => undefined);
+    const connectPromise = transport.connect();
     const socket = phoenixMock.FakeSocket.instances[0];
     socket?.emitError({ status: 403 });
 
+    await expect(connectPromise).rejects.toBeInstanceOf(TransportError);
     expect(transport.getDisconnectReason()).toBeNull();
+  });
+
+  it("propagates terminal supersede through the agent runtime", async () => {
+    const runtime = new PlatformRuntime({
+      agentId: "agent-1",
+      apiKey: "key-1",
+      link: new ThenvoiLink({
+        agentId: "agent-1",
+        apiKey: "key-1",
+        restApi: new FakeRestApi(),
+        wsUrl: "wss://example.test/socket",
+      }),
+    });
+
+    await runtime.start(new GenericAdapter(async () => undefined));
+    const runForever = runtime.runForever();
+    const socket = phoenixMock.FakeSocket.instances[0];
+
+    socket?.channels.get("agent_control:agent-1")?.emit("supersede", {
+      reason: "session.already_connected",
+      message: "This connection has been superseded by a newer session for this agent.",
+    });
+
+    await expect(runForever).rejects.toBeInstanceOf(WebSocketDisconnectError);
   });
 });

--- a/packages/sdk/tests/phoenix-channels-transport.test.ts
+++ b/packages/sdk/tests/phoenix-channels-transport.test.ts
@@ -581,4 +581,77 @@ describe("PhoenixChannelsTransport", () => {
 
     await expect(runForever).rejects.toBeInstanceOf(WebSocketDisconnectError);
   });
+
+  it("cleans up in-flight executions after terminal supersede", async () => {
+    const cleanupRooms: string[] = [];
+    let resolveStarted: (() => void) | undefined;
+    let releaseExecution: (() => void) | undefined;
+    const executionStarted = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+    const executionReleased = new Promise<void>((resolve) => {
+      releaseExecution = resolve;
+    });
+    const runtime = new PlatformRuntime({
+      agentId: "agent-1",
+      apiKey: "key-1",
+      link: new ThenvoiLink({
+        agentId: "agent-1",
+        apiKey: "key-1",
+        restApi: new FakeRestApi(),
+        wsUrl: "wss://example.test/socket",
+      }),
+    });
+
+    await runtime.start({
+      onStarted: vi.fn(async () => undefined),
+      onCleanup: vi.fn(async (roomId) => {
+        cleanupRooms.push(roomId);
+      }),
+      onRuntimeStop: vi.fn(async () => undefined),
+      onEvent: vi.fn(async () => {
+        resolveStarted?.();
+        await executionReleased;
+      }),
+    });
+    const runForever = runtime.runForever();
+    const socket = phoenixMock.FakeSocket.instances[0];
+
+    socket?.channels.get("agent_rooms:agent-1")?.emit("room_added", {
+      id: "room-1",
+      status: "active",
+      type: "direct",
+      title: "Room",
+      removed_at: null,
+    });
+    await vi.waitFor(() => {
+      expect(socket?.channels.has("chat_room:room-1")).toBe(true);
+    });
+
+    socket?.channels.get("chat_room:room-1")?.emit("message_created", {
+      id: "m1",
+      content: "work",
+      message_type: "text",
+      sender_id: "user-1",
+      sender_type: "User",
+      sender_name: "User",
+      metadata: {},
+      inserted_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+    await executionStarted;
+
+    socket?.channels.get("agent_control:agent-1")?.emit("supersede", {
+      reason: "session.already_connected",
+      message:
+        "This connection has been superseded by a newer session for this agent.",
+    });
+    await expect(runForever).rejects.toBeInstanceOf(WebSocketDisconnectError);
+
+    await expect(runtime.stop(0)).rejects.toBeInstanceOf(WebSocketDisconnectError);
+    expect(cleanupRooms).toEqual(["room-1"]);
+
+    releaseExecution?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
 });

--- a/packages/sdk/tests/phoenix-channels-transport.test.ts
+++ b/packages/sdk/tests/phoenix-channels-transport.test.ts
@@ -469,13 +469,9 @@ describe("PhoenixChannelsTransport", () => {
           retryAfter === null ? {} : { "Retry-After": String(retryAfter) },
       });
 
-      if (status === 429 || status === 503) {
-        await expect(connectPromise).resolves.toBeUndefined();
-      } else {
-        await expect(connectPromise).rejects.toBeInstanceOf(
-          WebSocketDisconnectError,
-        );
-      }
+      await expect(connectPromise).rejects.toBeInstanceOf(
+        WebSocketDisconnectError,
+      );
       expect(transport.getDisconnectReason()).toMatchObject({
         source: "upgrade",
         status,
@@ -538,7 +534,10 @@ describe("PhoenixChannelsTransport", () => {
       },
     });
 
-    await expect(connectPromise).resolves.toBeUndefined();
+    await expect(connectPromise).rejects.toBeInstanceOf(
+      WebSocketDisconnectError,
+    );
+    expect(socket?.disconnectCount).toBeGreaterThan(0);
     expect(socket?.reconnectAfterMs?.(1)).toBe(1000);
   });
 

--- a/packages/sdk/tests/phoenix-channels-transport.test.ts
+++ b/packages/sdk/tests/phoenix-channels-transport.test.ts
@@ -193,6 +193,51 @@ describe("PhoenixChannelsTransport", () => {
     ).rejects.toBeInstanceOf(TransportError);
   });
 
+  it("rejects connect when mandatory agent_control join fails", async () => {
+    const transport = new PhoenixChannelsTransport({
+      wsUrl: "wss://example.test/socket",
+      apiKey: "key-1",
+      agentId: "agent-1",
+    });
+
+    const socket = phoenixMock.FakeSocket.instances[0];
+    if (socket) {
+      const originalChannel = socket.channel.bind(socket);
+      socket.channel = (topic: string) => {
+        const channel = originalChannel(topic);
+        if (topic === "agent_control:agent-1") {
+          channel.joinOutcome = "error";
+        }
+        return channel;
+      };
+    }
+
+    await expect(transport.connect()).rejects.toBeInstanceOf(TransportError);
+    expect(transport.isConnected()).toBe(false);
+    expect(socket?.disconnectCount).toBeGreaterThan(0);
+  });
+
+  it("does not require agent_control when no agent id is configured", async () => {
+    const transport = new PhoenixChannelsTransport({
+      wsUrl: "wss://example.test/socket",
+      apiKey: "key-1",
+    });
+
+    const socket = phoenixMock.FakeSocket.instances[0];
+    if (socket) {
+      const originalChannel = socket.channel.bind(socket);
+      socket.channel = (topic: string) => {
+        const channel = originalChannel(topic);
+        channel.joinOutcome = "error";
+        return channel;
+      };
+    }
+
+    await expect(transport.connect()).resolves.toBeUndefined();
+    expect(transport.isConnected()).toBe(true);
+    expect(socket?.channels.has("agent_control:agent-1")).toBe(false);
+  });
+
   it("records agent_control supersede as terminal and disables reconnect", async () => {
     const onTerminalDisconnect = vi.fn();
     const transport = new PhoenixChannelsTransport({

--- a/packages/sdk/tests/phoenix-channels-transport.test.ts
+++ b/packages/sdk/tests/phoenix-channels-transport.test.ts
@@ -279,6 +279,25 @@ describe("PhoenixChannelsTransport", () => {
     await expect(transport.connect()).rejects.toBeInstanceOf(WebSocketDisconnectError);
   });
 
+  it("rejects runForever waiters on terminal supersede", async () => {
+    const transport = new PhoenixChannelsTransport({
+      wsUrl: "wss://example.test/socket",
+      apiKey: "key-1",
+      agentId: "agent-1",
+    });
+
+    await transport.connect();
+    const abortController = new AbortController();
+    const runForever = transport.runForever(abortController.signal);
+    const socket = phoenixMock.FakeSocket.instances[0];
+    socket?.channels.get("agent_control:agent-1")?.emit("supersede", {
+      reason: "session.already_connected",
+      message: "This connection has been superseded by a newer session for this agent.",
+    });
+
+    await expect(runForever).rejects.toBeInstanceOf(WebSocketDisconnectError);
+  });
+
   it("keeps a close without supersede generic and retryable", async () => {
     const transport = new PhoenixChannelsTransport({
       wsUrl: "wss://example.test/socket",

--- a/packages/sdk/tests/phoenix-channels-transport.test.ts
+++ b/packages/sdk/tests/phoenix-channels-transport.test.ts
@@ -554,6 +554,7 @@ describe("PhoenixChannelsTransport", () => {
     socket?.emitError({ status: 403 });
 
     await expect(connectPromise).rejects.toBeInstanceOf(TransportError);
+    expect(socket?.disconnectCount).toBeGreaterThan(0);
     expect(transport.getDisconnectReason()).toBeNull();
   });
 

--- a/packages/sdk/tests/phoenix-channels-transport.test.ts
+++ b/packages/sdk/tests/phoenix-channels-transport.test.ts
@@ -8,7 +8,7 @@ import { PlatformRuntime } from "../src/runtime/PlatformRuntime";
 import { FakeRestApi } from "./testUtils";
 
 const phoenixMock = vi.hoisted(() => {
-  type Outcome = "ok" | "error" | "timeout";
+  type Outcome = "ok" | "error" | "timeout" | "pending";
 
   class FakeChannel {
     public readonly topic: string;
@@ -66,7 +66,7 @@ const phoenixMock = vi.hoisted(() => {
     } {
       const chain = {
         receive: (kind: Outcome, callback: (payload?: unknown) => void) => {
-          if (kind === outcome) {
+          if (kind === outcome && kind !== "pending") {
             queueMicrotask(() =>
               callback(kind === "ok" ? {} : { error: kind }),
             );
@@ -276,6 +276,35 @@ describe("PhoenixChannelsTransport", () => {
         message: async () => {},
       }),
     ).rejects.toBeInstanceOf(TransportError);
+  });
+
+  it("does not report connected while mandatory agent_control join is pending", async () => {
+    const transport = new PhoenixChannelsTransport({
+      wsUrl: "wss://example.test/socket",
+      apiKey: "key-1",
+      agentId: "agent-1",
+    });
+
+    const socket = phoenixMock.FakeSocket.instances[0];
+    if (socket) {
+      const originalChannel = socket.channel.bind(socket);
+      socket.channel = (topic: string) => {
+        const channel = originalChannel(topic);
+        if (topic === "agent_control:agent-1") {
+          channel.joinOutcome = "pending";
+        }
+        return channel;
+      };
+    }
+
+    const connectPromise = transport.connect();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(transport.isConnected()).toBe(false);
+
+    socket?.emitError({ status: 403 });
+    await expect(connectPromise).rejects.toBeInstanceOf(TransportError);
   });
 
   it("rejects connect when mandatory agent_control join fails", async () => {

--- a/packages/sdk/tests/phoenix-channels-transport.test.ts
+++ b/packages/sdk/tests/phoenix-channels-transport.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { TransportError } from "../src/core/errors";
+import { WebSocketDisconnectError } from "../src/platform/streaming/disconnectReason";
 
 const phoenixMock = vi.hoisted(() => {
   type Outcome = "ok" | "error" | "timeout";
@@ -61,14 +62,17 @@ const phoenixMock = vi.hoisted(() => {
 
     public readonly url: string;
     public readonly params: Record<string, unknown>;
+    public readonly reconnectAfterMs?: (tries: number) => number;
     public readonly channels = new Map<string, FakeChannel>();
+    public disconnectCount = 0;
     private openHandler: (() => void) | null = null;
-    private closeHandler: (() => void) | null = null;
+    private closeHandler: ((event?: { code?: number; reason?: string }) => void) | null = null;
     private errorHandler: ((payload: unknown) => void) | null = null;
 
-    public constructor(url: string, options: { params: Record<string, unknown> }) {
+    public constructor(url: string, options: { params: Record<string, unknown>; reconnectAfterMs?: (tries: number) => number }) {
       this.url = url;
       this.params = options.params;
+      this.reconnectAfterMs = options.reconnectAfterMs;
       FakeSocket.instances.push(this);
     }
 
@@ -76,7 +80,7 @@ const phoenixMock = vi.hoisted(() => {
       this.openHandler = handler;
     }
 
-    public onClose(handler: () => void): void {
+    public onClose(handler: (event?: { code?: number; reason?: string }) => void): void {
       this.closeHandler = handler;
     }
 
@@ -91,7 +95,12 @@ const phoenixMock = vi.hoisted(() => {
     }
 
     public disconnect(): void {
+      this.disconnectCount += 1;
       this.closeHandler?.();
+    }
+
+    public emitClose(event?: { code?: number; reason?: string }): void {
+      this.closeHandler?.(event);
     }
 
     public channel(topic: string): FakeChannel {
@@ -182,5 +191,120 @@ describe("PhoenixChannelsTransport", () => {
         message: async () => {},
       }),
     ).rejects.toBeInstanceOf(TransportError);
+  });
+
+  it("records agent_control supersede as terminal and disables reconnect", async () => {
+    const onTerminalDisconnect = vi.fn();
+    const transport = new PhoenixChannelsTransport({
+      wsUrl: "wss://example.test/socket",
+      apiKey: "key-1",
+      agentId: "agent-1",
+      onTerminalDisconnect,
+    });
+
+    await transport.connect();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const socket = phoenixMock.FakeSocket.instances[0];
+    const control = socket?.channels.get("agent_control:agent-1");
+    expect(control).toBeDefined();
+
+    control?.emit("supersede", {
+      reason: "session.already_connected",
+      message: "This connection has been superseded by a newer session for this agent.",
+      retryable: false,
+      retry_after: 5,
+      target_socket_id: "agent_socket:agent-1",
+      correlation_id: "evict-1",
+    });
+
+    const reason = transport.getDisconnectReason();
+    expect(reason).toMatchObject({
+      source: "agent_control",
+      code: "session.already_connected",
+      message: "This connection has been superseded by a newer session for this agent.",
+      retryable: false,
+      retryAfter: 5,
+      targetSocketId: "agent_socket:agent-1",
+      correlationId: "evict-1",
+    });
+    expect(onTerminalDisconnect).toHaveBeenCalledWith(reason);
+    expect(socket?.disconnectCount).toBeGreaterThan(0);
+    expect(socket?.reconnectAfterMs?.(1)).toBe(Number.POSITIVE_INFINITY);
+    await expect(transport.connect()).rejects.toBeInstanceOf(WebSocketDisconnectError);
+  });
+
+  it("keeps a close without supersede generic and retryable", async () => {
+    const transport = new PhoenixChannelsTransport({
+      wsUrl: "wss://example.test/socket",
+      apiKey: "key-1",
+      agentId: "agent-1",
+    });
+
+    await transport.connect();
+    const socket = phoenixMock.FakeSocket.instances[0];
+    socket?.emitClose({ code: 1006, reason: "" });
+
+    expect(transport.getDisconnectReason()).toEqual({
+      source: "websocket_close",
+      code: "websocket.closed",
+      message: "Phoenix socket closed without a platform disconnect reason.",
+      retryable: true,
+      closeCode: 1006,
+      closeReason: null,
+    });
+    expect(socket?.reconnectAfterMs?.(1)).toBe(1000);
+  });
+
+  it.each([
+    [409, "connection_conflict", null],
+    [429, "too_many_requests", 7],
+    [400, "invalid_on_conflict", null],
+    [503, "tracking_failed", null],
+  ] as const)("parses HTTP %s upgrade error %s", async (status, code, retryAfter) => {
+    const transport = new PhoenixChannelsTransport({
+      wsUrl: "wss://example.test/socket",
+      apiKey: "key-1",
+      agentId: "agent-1",
+    });
+
+    const connectPromise = transport.connect();
+    const socket = phoenixMock.FakeSocket.instances[0];
+    socket?.emitError({
+      status,
+      body: {
+        error: {
+          code,
+          message: `upgrade failed: ${code}`,
+          request_id: "req-1",
+          ...(retryAfter === null ? {} : { retry_after: retryAfter }),
+        },
+      },
+      headers: retryAfter === null ? {} : { "Retry-After": String(retryAfter) },
+    });
+
+    await expect(connectPromise).rejects.toBeInstanceOf(WebSocketDisconnectError);
+    expect(transport.getDisconnectReason()).toMatchObject({
+      source: "upgrade",
+      status,
+      code,
+      message: `upgrade failed: ${code}`,
+      requestId: "req-1",
+      retryAfter,
+    });
+  });
+
+  it("leaves empty 403 upgrade errors generic", async () => {
+    const transport = new PhoenixChannelsTransport({
+      wsUrl: "wss://example.test/socket",
+      apiKey: "key-1",
+      agentId: "agent-1",
+    });
+
+    void transport.connect().catch(() => undefined);
+    const socket = phoenixMock.FakeSocket.instances[0];
+    socket?.emitError({ status: 403 });
+
+    expect(transport.getDisconnectReason()).toBeNull();
   });
 });

--- a/packages/sdk/tests/phoenix-channels-transport.test.ts
+++ b/packages/sdk/tests/phoenix-channels-transport.test.ts
@@ -221,6 +221,20 @@ describe("PhoenixChannelsTransport", () => {
     });
   });
 
+  it("passes ThenvoiLink conflict policy into the socket params", () => {
+    new ThenvoiLink({
+      agentId: "agent-1",
+      apiKey: "key-1",
+      restApi: new FakeRestApi(),
+      wsUrl: "wss://example.test/socket",
+      conflictPolicy: "reject",
+    });
+
+    expect(phoenixMock.FakeSocket.instances[0]?.params).toMatchObject({
+      on_conflict: "reject",
+    });
+  });
+
   it("joins and leaves topics and dispatches topic handlers", async () => {
     const onMessage = vi.fn(async () => {});
     const transport = new PhoenixChannelsTransport({
@@ -439,6 +453,63 @@ describe("PhoenixChannelsTransport", () => {
       });
     },
   );
+
+  it("treats non-retryable upgrade failures as terminal", async () => {
+    const transport = new PhoenixChannelsTransport({
+      wsUrl: "wss://example.test/socket",
+      apiKey: "key-1",
+      agentId: "agent-1",
+    });
+
+    const connectPromise = transport.connect();
+    const socket = phoenixMock.FakeSocket.instances[0];
+    socket?.emitError({
+      status: 409,
+      body: {
+        error: {
+          code: "connection_conflict",
+          message: "Connection already exists for this agent.",
+          request_id: null,
+        },
+      },
+    });
+
+    await expect(connectPromise).rejects.toBeInstanceOf(
+      WebSocketDisconnectError,
+    );
+    expect(socket?.disconnectCount).toBeGreaterThan(0);
+    expect(socket?.reconnectAfterMs?.(1)).toBe(Number.POSITIVE_INFINITY);
+    await expect(transport.connect()).rejects.toBeInstanceOf(
+      WebSocketDisconnectError,
+    );
+  });
+
+  it("keeps retryable upgrade failures non-terminal", async () => {
+    const transport = new PhoenixChannelsTransport({
+      wsUrl: "wss://example.test/socket",
+      apiKey: "key-1",
+      agentId: "agent-1",
+    });
+
+    const connectPromise = transport.connect();
+    const socket = phoenixMock.FakeSocket.instances[0];
+    socket?.emitError({
+      status: 429,
+      body: {
+        error: {
+          code: "too_many_requests",
+          message: "Too many websocket connection attempts.",
+          retry_after: 7,
+          request_id: null,
+        },
+      },
+    });
+
+    await expect(connectPromise).rejects.toBeInstanceOf(
+      WebSocketDisconnectError,
+    );
+    expect(socket?.reconnectAfterMs?.(1)).toBe(1000);
+  });
 
   it("rejects empty 403 upgrade errors without inventing a platform reason", async () => {
     const transport = new PhoenixChannelsTransport({

--- a/packages/sdk/tests/phoenix-upgrade-errors.test.ts
+++ b/packages/sdk/tests/phoenix-upgrade-errors.test.ts
@@ -8,15 +8,20 @@ import { PhoenixChannelsTransport } from "../src/platform/streaming/PhoenixChann
 const servers = new Set<ReturnType<typeof createServer>>();
 
 afterEach(async () => {
-  await Promise.all([...servers].map((server) => new Promise<void>((resolve, reject) => {
-    server.close((error) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-      resolve();
-    });
-  })));
+  await Promise.all(
+    [...servers].map(
+      (server) =>
+        new Promise<void>((resolve, reject) => {
+          server.close((error) => {
+            if (error) {
+              reject(error);
+              return;
+            }
+            resolve();
+          });
+        }),
+    ),
+  );
   servers.clear();
 });
 
@@ -25,23 +30,27 @@ describe("PhoenixChannelsTransport upgrade failures", () => {
     const server = createServer();
     servers.add(server);
     server.on("upgrade", (_request, socket) => {
-      socket.write([
-        "HTTP/1.1 409 Conflict",
-        "Content-Type: application/json",
-        "Retry-After: 7",
-        "",
-        JSON.stringify({
-          error: {
-            code: "connection_conflict",
-            message: "Connection already exists for this agent.",
-            request_id: "req-1",
-          },
-        }),
-      ].join("\r\n"));
+      socket.write(
+        [
+          "HTTP/1.1 409 Conflict",
+          "Content-Type: application/json",
+          "Retry-After: 7",
+          "",
+          JSON.stringify({
+            error: {
+              code: "connection_conflict",
+              message: "Connection already exists for this agent.",
+              request_id: "req-1",
+            },
+          }),
+        ].join("\r\n"),
+      );
       socket.end();
     });
 
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
     const { port } = server.address() as AddressInfo;
     const transport = new PhoenixChannelsTransport({
       wsUrl: `ws://127.0.0.1:${port}/socket`,
@@ -50,7 +59,9 @@ describe("PhoenixChannelsTransport upgrade failures", () => {
       reconnectAfterMs: () => 60_000,
     });
 
-    await expect(transport.connect()).rejects.toBeInstanceOf(WebSocketDisconnectError);
+    await expect(transport.connect()).rejects.toBeInstanceOf(
+      WebSocketDisconnectError,
+    );
     expect(transport.getDisconnectReason()).toMatchObject({
       source: "upgrade",
       status: 409,

--- a/packages/sdk/tests/phoenix-upgrade-errors.test.ts
+++ b/packages/sdk/tests/phoenix-upgrade-errors.test.ts
@@ -1,0 +1,63 @@
+import { createServer } from "http";
+import type { AddressInfo } from "net";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { WebSocketDisconnectError } from "../src/platform/streaming/disconnectReason";
+import { PhoenixChannelsTransport } from "../src/platform/streaming/PhoenixChannelsTransport";
+
+const servers = new Set<ReturnType<typeof createServer>>();
+
+afterEach(async () => {
+  await Promise.all([...servers].map((server) => new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  })));
+  servers.clear();
+});
+
+describe("PhoenixChannelsTransport upgrade failures", () => {
+  it("parses structured Node websocket upgrade rejection responses", async () => {
+    const server = createServer();
+    servers.add(server);
+    server.on("upgrade", (_request, socket) => {
+      socket.write([
+        "HTTP/1.1 409 Conflict",
+        "Content-Type: application/json",
+        "Retry-After: 7",
+        "",
+        JSON.stringify({
+          error: {
+            code: "connection_conflict",
+            message: "Connection already exists for this agent.",
+            request_id: "req-1",
+          },
+        }),
+      ].join("\r\n"));
+      socket.end();
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+    const transport = new PhoenixChannelsTransport({
+      wsUrl: `ws://127.0.0.1:${port}/socket`,
+      apiKey: "key-1",
+      agentId: "agent-1",
+      reconnectAfterMs: () => 60_000,
+    });
+
+    await expect(transport.connect()).rejects.toBeInstanceOf(WebSocketDisconnectError);
+    expect(transport.getDisconnectReason()).toMatchObject({
+      source: "upgrade",
+      status: 409,
+      code: "connection_conflict",
+      message: "Connection already exists for this agent.",
+      requestId: "req-1",
+      retryAfter: 7,
+    });
+  });
+});

--- a/packages/sdk/tests/root-import-boundary.test.ts
+++ b/packages/sdk/tests/root-import-boundary.test.ts
@@ -7,15 +7,24 @@ describe("root import boundary", () => {
       throw new Error("ACP SDK should not be imported by @thenvoi/sdk");
     });
     vi.doMock("@anthropic-ai/claude-agent-sdk", () => {
-      throw new Error("Claude Agent SDK should not be imported by @thenvoi/sdk");
+      throw new Error(
+        "Claude Agent SDK should not be imported by @thenvoi/sdk",
+      );
     });
 
     const sdk = await import("../src/index");
 
     expect(typeof sdk.Agent).toBe("function");
     expect(typeof sdk.ThenvoiLink).toBe("function");
+    expect(typeof sdk.WebSocketDisconnectError).toBe("function");
     expect(typeof sdk.AgentRuntime).toBe("function");
     expect(typeof sdk.GenericAdapter).toBe("function");
     expect(typeof sdk.ClaudeSDKAdapter).toBe("function");
+  });
+
+  it("exposes websocket disconnect errors from the core entrypoint", async () => {
+    const core = await import("../src/core");
+
+    expect(typeof core.WebSocketDisconnectError).toBe("function");
   });
 });

--- a/packages/sdk/tests/thenvoi-link.test.ts
+++ b/packages/sdk/tests/thenvoi-link.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import { ThenvoiLink } from "../src/platform/ThenvoiLink";
 import type { PlatformEvent } from "../src/platform/events";
+import {
+  WebSocketDisconnectError,
+  type WebSocketDisconnectReason,
+} from "../src/platform/streaming/disconnectReason";
 import type { StreamingTransport } from "../src/platform/streaming/transport";
 import { UnsupportedFeatureError } from "../src/core/errors";
 import { FakeRestApi } from "./testUtils";
@@ -21,7 +25,43 @@ class FakeTransport implements StreamingTransport {
   }
 }
 
+class RejectingTransport extends FakeTransport {
+  public constructor(private readonly reason: WebSocketDisconnectReason) {
+    super();
+  }
+
+  public override async connect() {
+    throw new WebSocketDisconnectError(this.reason);
+  }
+}
+
 describe("ThenvoiLink event waiting", () => {
+  it("does not poison runForever after a retryable websocket disconnect", async () => {
+    const retryableReason = {
+      source: "upgrade",
+      status: 429,
+      code: "too_many_requests",
+      message: "Too many websocket connection attempts.",
+      retryable: true,
+      retryAfter: 7,
+      requestId: null,
+    } satisfies WebSocketDisconnectReason;
+    const link = new ThenvoiLink({
+      agentId: "agent-1",
+      apiKey: "key",
+      restApi: new FakeRestApi(),
+      transport: new RejectingTransport(retryableReason),
+    });
+
+    await expect(link.connect()).rejects.toBeInstanceOf(
+      WebSocketDisconnectError,
+    );
+    expect(link.getDisconnectReason()).toBe(retryableReason);
+    await expect(
+      link.runForever(new AbortController().signal),
+    ).resolves.toBeUndefined();
+  });
+
   it("removes abort listeners when waiter resolves from queued events", async () => {
     const link = new ThenvoiLink({
       agentId: "agent-1",
@@ -36,11 +76,17 @@ describe("ThenvoiLink event waiting", () => {
 
     const signal = {
       aborted: false,
-      addEventListener: (_type: string, listener: EventListenerOrEventListenerObject) => {
+      addEventListener: (
+        _type: string,
+        listener: EventListenerOrEventListenerObject,
+      ) => {
         addCalls += 1;
         listeners.add(listener);
       },
-      removeEventListener: (_type: string, listener: EventListenerOrEventListenerObject) => {
+      removeEventListener: (
+        _type: string,
+        listener: EventListenerOrEventListenerObject,
+      ) => {
         removeCalls += 1;
         listeners.delete(listener);
       },
@@ -72,7 +118,9 @@ describe("ThenvoiLink event waiting", () => {
       capabilities: { contacts: false },
     });
 
-    await expect(link.subscribeAgentContacts()).rejects.toBeInstanceOf(UnsupportedFeatureError);
+    await expect(link.subscribeAgentContacts()).rejects.toBeInstanceOf(
+      UnsupportedFeatureError,
+    );
   });
 
   it("allows contact subscriptions when contact capability is enabled", async () => {
@@ -101,7 +149,9 @@ describe("ThenvoiLink event waiting", () => {
       transport: new FakeTransport(),
     });
 
-    await expect(link.markProcessed("room-1", "message-1")).rejects.toThrow("mark failed");
+    await expect(link.markProcessed("room-1", "message-1")).rejects.toThrow(
+      "mark failed",
+    );
   });
 
   it("supports explicit best-effort marking", async () => {
@@ -116,7 +166,9 @@ describe("ThenvoiLink event waiting", () => {
       transport: new FakeTransport(),
     });
 
-    await expect(link.markProcessed("room-1", "message-1", { bestEffort: true })).resolves.toBeUndefined();
+    await expect(
+      link.markProcessed("room-1", "message-1", { bestEffort: true }),
+    ).resolves.toBeUndefined();
   });
 
   it("exposes request-first chat listing semantics via listChats", async () => {
@@ -139,10 +191,7 @@ describe("ThenvoiLink event waiting", () => {
     });
 
     await expect(
-      link.listChats(
-        { page: 2, pageSize: 25 },
-        { headers: { "x-test": "1" } },
-      ),
+      link.listChats({ page: 2, pageSize: 25 }, { headers: { "x-test": "1" } }),
     ).resolves.toEqual({
       data: [{ id: "room-1" }],
       metadata: { page: 2, pageSize: 25 },
@@ -160,12 +209,17 @@ describe("ThenvoiLink event waiting", () => {
       restApi: new FakeRestApi({
         listChats: async (request) => {
           requests.push(request);
-          const pageData = request.page === 1
-            ? [{ id: "room-1" }, { id: "room-2" }]
-            : [{ id: "room-3" }];
+          const pageData =
+            request.page === 1
+              ? [{ id: "room-1" }, { id: "room-2" }]
+              : [{ id: "room-3" }];
           return {
             data: pageData,
-            metadata: { totalPages: 2, page: request.page, pageSize: request.pageSize },
+            metadata: {
+              totalPages: 2,
+              page: request.page,
+              pageSize: request.pageSize,
+            },
           };
         },
       }),


### PR DESCRIPTION
## Summary
- Adds structured websocket disconnect reasons to the TypeScript SDK.
- Subscribes each agent socket to `agent_control:{agent_id}` so the SDK can detect when a newer connection supersedes the current one.
- Surfaces platform disconnects as `WebSocketDisconnectError` and exposes the last reason through `ThenvoiLink.getDisconnectReason()`.
- Parses structured websocket upgrade failures like connection conflicts, rate limits, and tracking failures.
- Adds `conflictPolicy` so callers can choose whether a new websocket should supersede an existing connection or fail with a structured conflict error.
- Keeps connection state accurate by only reporting connected after the required control channel joins.

## Test plan
- `pnpm --dir packages/sdk exec tsc --noEmit --pretty false`
- `pnpm --dir packages/sdk exec eslint .`
- `pnpm --dir packages/sdk exec vitest run --reporter=dot`
- `pnpm --dir packages/sdk exec vitest run tests/phoenix-channels-transport.test.ts tests/phoenix-upgrade-errors.test.ts tests/thenvoi-link.test.ts tests/root-import-boundary.test.ts --reporter=dot`
- Verified against production websocket conflict behavior with a temporary agent.