### PR TITLE
fix(websocket): move Phoenix auth to x-api-key header

### DIFF
--- a/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
+++ b/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
@@ -15,6 +15,16 @@ interface PhoenixChannelsTransportOptions {
   websocketFactory?: typeof WebSocket;
 }
 
+type HeaderWebSocketConstructor = new (
+  url: string | URL,
+  protocols?: string | string[],
+  options?: { headers: Record<string, string> },
+) => WebSocket;
+
+const PHOENIX_WEBSOCKET_SUFFIX = "/websocket";
+const API_KEY_PARAM = "api_key";
+const API_KEY_HEADER = "x-api-key";
+
 export class PhoenixChannelsTransport implements StreamingTransport {
   private readonly socket: Socket;
   private readonly channels = new Map<string, Channel>();
@@ -29,22 +39,12 @@ export class PhoenixChannelsTransport implements StreamingTransport {
   public constructor(options: PhoenixChannelsTransportOptions) {
     this.logger = options.logger ?? new NoopLogger();
 
-    // The phoenix JS library appends /websocket to the endpoint URL.
-    // Strip it if the user-provided URL already includes it.
-    let wsUrl = options.wsUrl;
-    if (wsUrl.endsWith("/websocket")) {
-      wsUrl = wsUrl.slice(0, -"/websocket".length);
-    }
-
-    this.socket = new Socket(wsUrl, {
-      params: {
-        api_key: options.apiKey,
-        agent_id: options.agentId,
-      },
+    this.socket = new Socket(normalizePhoenixEndpoint(options.wsUrl), {
+      params: buildPhoenixParams(options.agentId),
       heartbeatIntervalMs: options.heartbeatIntervalMs,
       reconnectAfterMs: options.reconnectAfterMs ??
         ((tries: number) => [1_000, 2_000, 5_000, 10_000, 30_000][tries - 1] ?? 30_000),
-      transport: options.websocketFactory ?? resolveWebSocketFactory(),
+      transport: createApiKeyHeaderWebSocketFactory(options.apiKey, options.websocketFactory),
     });
 
     this.socket.onOpen(() => {
@@ -231,12 +231,60 @@ export class PhoenixChannelsTransport implements StreamingTransport {
   }
 }
 
-function resolveWebSocketFactory(): typeof WebSocket {
-  if (typeof process !== "undefined" && process.versions?.node) {
-    return NodeWebSocket as unknown as typeof WebSocket;
+function buildPhoenixParams(agentId: string | undefined): Record<string, string> {
+  return agentId ? { agent_id: agentId } : {};
+}
+
+function normalizePhoenixEndpoint(wsUrl: string): string {
+  try {
+    const parsed = new URL(wsUrl);
+    parsed.searchParams.delete(API_KEY_PARAM);
+    if (parsed.pathname.endsWith(PHOENIX_WEBSOCKET_SUFFIX)) {
+      parsed.pathname = parsed.pathname.slice(0, -PHOENIX_WEBSOCKET_SUFFIX.length);
+    }
+    return parsed.toString();
+  } catch {
+    const [withoutFragment, fragment = ""] = wsUrl.split("#", 2);
+    const [path, query = ""] = withoutFragment.split("?", 2);
+    const normalizedPath = path.endsWith(PHOENIX_WEBSOCKET_SUFFIX)
+      ? path.slice(0, -PHOENIX_WEBSOCKET_SUFFIX.length)
+      : path;
+    const filteredQuery = new URLSearchParams(query);
+    filteredQuery.delete(API_KEY_PARAM);
+    const queryString = filteredQuery.toString();
+    return `${normalizedPath}${queryString ? `?${queryString}` : ""}${fragment ? `#${fragment}` : ""}`;
+  }
+}
+
+function createApiKeyHeaderWebSocketFactory(
+  apiKey: string,
+  websocketFactory?: typeof WebSocket,
+): typeof WebSocket {
+  const WebSocketConstructor = websocketFactory
+    ? (websocketFactory as unknown as HeaderWebSocketConstructor)
+    : getNodeWebSocketConstructor();
+
+  class ApiKeyHeaderWebSocket {
+    public constructor(url: string | URL, protocols?: string | string[]) {
+      return new WebSocketConstructor(url, protocols, {
+        headers: {
+          [API_KEY_HEADER]: apiKey,
+        },
+      });
+    }
   }
 
-  return WebSocket;
+  return ApiKeyHeaderWebSocket as unknown as typeof WebSocket;
+}
+
+function getNodeWebSocketConstructor(): HeaderWebSocketConstructor {
+  if (!(typeof process !== "undefined" && process.versions?.node)) {
+    throw new TransportError(
+      "Phoenix WebSocket API-key auth requires a WebSocket transport that can set handshake headers.",
+    );
+  }
+
+  return NodeWebSocket as unknown as HeaderWebSocketConstructor;
 }
 
 function removeSocketChannel(socket: Socket, channel: Channel): void {

--- a/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
+++ b/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
@@ -12,6 +12,11 @@ interface PhoenixChannelsTransportOptions {
   logger?: Logger;
   heartbeatIntervalMs?: number;
   reconnectAfterMs?: (tries: number) => number;
+  /**
+   * Optional WebSocket implementation. Phoenix authentication is sent in the
+   * x-api-key handshake header, so browser WebSocket constructors are not
+   * sufficient; pass a Node-compatible constructor that accepts headers.
+   */
   websocketFactory?: typeof WebSocket;
 }
 

--- a/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
+++ b/packages/sdk/src/platform/streaming/PhoenixChannelsTransport.ts
@@ -17,7 +17,7 @@ interface PhoenixChannelsTransportOptions {
    * x-api-key handshake header, so browser WebSocket constructors are not
    * sufficient; pass a Node-compatible constructor that accepts headers.
    */
-  websocketFactory?: typeof WebSocket;
+  websocketFactory?: HeaderWebSocketConstructor;
 }
 
 type HeaderWebSocketConstructor = new (
@@ -263,11 +263,9 @@ function normalizePhoenixEndpoint(wsUrl: string): string {
 
 function createApiKeyHeaderWebSocketFactory(
   apiKey: string,
-  websocketFactory?: typeof WebSocket,
+  websocketFactory?: HeaderWebSocketConstructor,
 ): typeof WebSocket {
-  const WebSocketConstructor = websocketFactory
-    ? (websocketFactory as unknown as HeaderWebSocketConstructor)
-    : getNodeWebSocketConstructor();
+  const WebSocketConstructor = websocketFactory ?? getNodeWebSocketConstructor();
 
   class ApiKeyHeaderWebSocket {
     public constructor(url: string | URL, protocols?: string | string[]) {

--- a/packages/sdk/tests/phoenix-channels-transport.test.ts
+++ b/packages/sdk/tests/phoenix-channels-transport.test.ts
@@ -2,8 +2,50 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { TransportError } from "../src/core/errors";
 
+const wsMock = vi.hoisted(() => {
+  interface FakeNodeWebSocketOptions {
+    headers?: Record<string, string>;
+  }
+
+  class FakeNodeWebSocket {
+    public static readonly instances: FakeNodeWebSocket[] = [];
+
+    public readonly url: string | URL;
+    public readonly protocols?: string | string[];
+    public readonly options?: FakeNodeWebSocketOptions;
+
+    public constructor(
+      url: string | URL,
+      protocols?: string | string[],
+      options?: FakeNodeWebSocketOptions,
+    ) {
+      this.url = url;
+      this.protocols = protocols;
+      this.options = options;
+      FakeNodeWebSocket.instances.push(this);
+    }
+  }
+
+  return {
+    FakeNodeWebSocket,
+    reset: () => {
+      FakeNodeWebSocket.instances.splice(0, FakeNodeWebSocket.instances.length);
+    },
+  };
+});
+
 const phoenixMock = vi.hoisted(() => {
   type Outcome = "ok" | "error" | "timeout";
+
+  interface FakeSocketOptions {
+    params?: Record<string, unknown>;
+    heartbeatIntervalMs?: number;
+    reconnectAfterMs?: (tries: number) => number;
+    transport?: typeof WebSocket;
+  }
+
+  const PHOENIX_WEBSOCKET_SUFFIX = "/websocket";
+  const PHOENIX_VSN = "2.0.0";
 
   class FakeChannel {
     public readonly topic: string;
@@ -60,15 +102,15 @@ const phoenixMock = vi.hoisted(() => {
     public static readonly instances: FakeSocket[] = [];
 
     public readonly url: string;
-    public readonly params: Record<string, unknown>;
+    public readonly options: FakeSocketOptions;
     public readonly channels = new Map<string, FakeChannel>();
     private openHandler: (() => void) | null = null;
     private closeHandler: (() => void) | null = null;
     private errorHandler: ((payload: unknown) => void) | null = null;
 
-    public constructor(url: string, options: { params: Record<string, unknown> }) {
+    public constructor(url: string, options: FakeSocketOptions) {
       this.url = url;
-      this.params = options.params;
+      this.options = options;
       FakeSocket.instances.push(this);
     }
 
@@ -85,6 +127,11 @@ const phoenixMock = vi.hoisted(() => {
     }
 
     public connect(): void {
+      const WebSocketTransport = this.options.transport;
+      if (WebSocketTransport) {
+        new WebSocketTransport(this.buildWebSocketUrl(), ["phoenix"]);
+      }
+
       queueMicrotask(() => {
         this.openHandler?.();
       });
@@ -103,6 +150,18 @@ const phoenixMock = vi.hoisted(() => {
     public emitError(payload: unknown): void {
       this.errorHandler?.(payload);
     }
+
+    private buildWebSocketUrl(): string {
+      const parsed = new URL(this.url);
+      if (!parsed.pathname.endsWith(PHOENIX_WEBSOCKET_SUFFIX)) {
+        parsed.pathname = `${parsed.pathname}${PHOENIX_WEBSOCKET_SUFFIX}`;
+      }
+      for (const [key, value] of Object.entries(this.options.params ?? {})) {
+        parsed.searchParams.set(key, String(value));
+      }
+      parsed.searchParams.set("vsn", PHOENIX_VSN);
+      return parsed.toString();
+    }
   }
 
   return {
@@ -114,6 +173,10 @@ const phoenixMock = vi.hoisted(() => {
   };
 });
 
+vi.mock("ws", () => ({
+  WebSocket: wsMock.FakeNodeWebSocket,
+}));
+
 vi.mock("phoenix", () => ({
   Channel: phoenixMock.FakeChannel,
   Socket: phoenixMock.FakeSocket,
@@ -124,6 +187,7 @@ import { PhoenixChannelsTransport } from "../src/platform/streaming/PhoenixChann
 describe("PhoenixChannelsTransport", () => {
   beforeEach(() => {
     phoenixMock.reset();
+    wsMock.reset();
   });
 
   it("normalizes websocket URL and connects once", async () => {
@@ -139,6 +203,99 @@ describe("PhoenixChannelsTransport", () => {
     await transport.connect();
     await transport.connect();
     expect(transport.isConnected()).toBe(true);
+  });
+
+  it("omits agent_id params when no agent id is configured", async () => {
+    const transport = new PhoenixChannelsTransport({
+      wsUrl: "wss://example.test/socket",
+      apiKey: "key-1",
+    });
+
+    await transport.connect();
+
+    const socket = phoenixMock.FakeSocket.instances[0];
+    expect(socket?.options.params).toEqual({});
+    const websocket = wsMock.FakeNodeWebSocket.instances[0];
+    expect(String(websocket?.url)).toBe("wss://example.test/socket/websocket?vsn=2.0.0");
+    expect(String(websocket?.url)).not.toContain("agent_id=undefined");
+  });
+
+  it("sends API keys with x-api-key headers instead of Phoenix params", async () => {
+    const transport = new PhoenixChannelsTransport({
+      wsUrl: "wss://example.test/socket/websocket?api_key=stale-key&debug=true",
+      apiKey: "key-1",
+      agentId: "agent-1",
+    });
+
+    await transport.connect();
+
+    const socket = phoenixMock.FakeSocket.instances[0];
+    expect(socket?.url).toBe("wss://example.test/socket?debug=true");
+    expect(socket?.options.params).toEqual({ agent_id: "agent-1" });
+    expect(socket?.options.params).not.toHaveProperty("api_key");
+
+    const websocket = wsMock.FakeNodeWebSocket.instances[0];
+    expect(String(websocket?.url)).toBe(
+      "wss://example.test/socket/websocket?debug=true&agent_id=agent-1&vsn=2.0.0",
+    );
+    expect(String(websocket?.url)).not.toMatch(/[?&]api_key=/);
+    expect(websocket?.options?.headers).toEqual({ "x-api-key": "key-1" });
+  });
+
+  it("keeps reconnect handshakes header-authenticated", async () => {
+    const transport = new PhoenixChannelsTransport({
+      wsUrl: "wss://example.test/socket?api_key=stale-key",
+      apiKey: "key-1",
+      agentId: "agent-1",
+    });
+
+    await transport.connect();
+    phoenixMock.FakeSocket.instances[0]?.disconnect();
+    await transport.connect();
+
+    expect(wsMock.FakeNodeWebSocket.instances).toHaveLength(2);
+    for (const websocket of wsMock.FakeNodeWebSocket.instances) {
+      expect(String(websocket.url)).not.toMatch(/[?&]api_key=/);
+      expect(websocket.options?.headers).toEqual({ "x-api-key": "key-1" });
+    }
+  });
+
+  it("wraps custom websocket factories with x-api-key headers", async () => {
+    interface CustomWebSocketOptions {
+      headers?: Record<string, string>;
+    }
+
+    class CustomWebSocket {
+      public static readonly instances: CustomWebSocket[] = [];
+      public readonly url: string | URL;
+      public readonly options?: CustomWebSocketOptions;
+
+      public constructor(
+        url: string | URL,
+        _protocols?: string | string[],
+        options?: CustomWebSocketOptions,
+      ) {
+        this.url = url;
+        this.options = options;
+        CustomWebSocket.instances.push(this);
+      }
+    }
+
+    const transport = new PhoenixChannelsTransport({
+      wsUrl: "wss://example.test/socket",
+      apiKey: "key-1",
+      agentId: "agent-1",
+      websocketFactory: CustomWebSocket as unknown as typeof WebSocket,
+    });
+
+    await transport.connect();
+
+    const socket = phoenixMock.FakeSocket.instances[0];
+    expect(socket?.options.params).toEqual({ agent_id: "agent-1" });
+    expect(socket?.options.params).not.toHaveProperty("api_key");
+    expect(CustomWebSocket.instances[0]?.options?.headers).toEqual({
+      "x-api-key": "key-1",
+    });
   });
 
   it("joins and leaves topics and dispatches topic handlers", async () => {


### PR DESCRIPTION
## Summary
- Stop sending Phoenix WebSocket API keys as `api_key` query params from the TypeScript SDK transport.
- Strip stale `api_key` values from configured socket URLs and send auth through the `x-api-key` WebSocket handshake header.
- Avoid serializing an absent `agent_id` as `agent_id=undefined`, which production rejects.

## Validation
- `pnpm --filter @thenvoi/sdk test -- phoenix-channels-transport` — passed.
- `pnpm --filter @thenvoi/sdk typecheck` — passed.
- `pnpm --filter @thenvoi/sdk lint` — passed with existing warnings.
- Production smoke: connected the Phoenix transport with a configured stale `api_key` in the URL; the client connected successfully with header auth and no `api_key` or `agent_id=undefined` in the generated socket URL.

## Notes
- Platform support already accepts `x-api-key` from WebSocket handshake headers and keeps the legacy `api_key` param fallback for older clients.
- This is a draft so we can review the SDK/API compatibility tradeoff before marking ready.