### PR TITLE
feat(openclaw): add NemoClaw integration demo

### DIFF
--- a/packages/openclaw/examples/nemoclaw/README.md
+++ b/packages/openclaw/examples/nemoclaw/README.md
@@ -1,0 +1,225 @@
+# Set up Band on NemoClaw
+
+This guide walks through running a Band-connected OpenClaw agent inside a NemoClaw sandbox. After setup, you add the Band agent to a Band chat room and talk to it like any other Band participant.
+
+The integration uses the `@thenvoi/openclaw-channel-thenvoi` OpenClaw channel package. The setup script generates a NemoClaw custom-image build context that installs the plugin at `/sandbox/.openclaw/extensions/openclaw-channel-thenvoi`, adds the OpenClaw plugin config, and writes a Band egress policy for the configured Band host.
+
+Do not use `nemoclaw <sandbox> skill install` for this package. NemoClaw skills and OpenClaw plugins are different install surfaces; this package must be installed as an OpenClaw plugin inside the NemoClaw image.
+
+## What you need
+
+- Node and pnpm installed for this repo.
+- NemoClaw CLI installed and on `PATH`.
+- A NemoClaw-compatible sandbox base image or Dockerfile.
+- A Band agent with integration credentials:
+  - `THENVOI_API_KEY`
+  - `THENVOI_AGENT_ID`
+- A model provider configured for NemoClaw.
+- Optional Band operator metadata if your workflow needs it:
+  - `THENVOI_OPERATOR_ID` when the agent should know which Band user operates it
+
+For a quick public setup, sign up for NVIDIA AI, create an API key, and use an NVIDIA-hosted model such as `nvidia/nvidia-nemotron-nano-9b-v2`. NemoClaw can route OpenClaw's model traffic through the NVIDIA endpoint while the Band plugin handles chat connectivity.
+
+## 1. Build the Band OpenClaw channel
+
+From the TypeScript SDK workspace:
+
+```sh
+pnpm --filter @thenvoi/openclaw-channel-thenvoi build
+pnpm --filter @thenvoi/openclaw-channel-thenvoi test
+pnpm --filter @thenvoi/openclaw-channel-thenvoi typecheck
+pnpm --filter @thenvoi/openclaw-channel-thenvoi lint
+```
+
+The setup command copies the built `dist/index.js`, `dist/index.d.ts`, and `openclaw.plugin.json` files into the generated NemoClaw build context.
+
+## 2. Generate the NemoClaw build context
+
+Use a NemoClaw/OpenClaw sandbox base image:
+
+```sh
+pnpm --filter @thenvoi/openclaw-channel-thenvoi run nemoclaw:integration:setup -- \
+  --sandbox band-integration \
+  --base-image ghcr.io/nvidia/nemoclaw/sandbox-base:latest \
+  --yes
+```
+
+Or use your own NemoClaw-compatible Dockerfile:
+
+```sh
+pnpm --filter @thenvoi/openclaw-channel-thenvoi run nemoclaw:integration:setup -- \
+  --sandbox band-integration \
+  --from /path/to/NemoClaw/Dockerfile \
+  --yes
+```
+
+The generated context is written to:
+
+```text
+packages/openclaw/dist/nemoclaw-integration/band-integration/
+```
+
+Review these generated files before onboarding:
+
+- `Dockerfile`
+- `band-egress-policy.yaml`
+- `openclaw-channel-thenvoi.openclaw-config.json`
+- `openclaw-channel-thenvoi.config.example.json`
+- `openclaw-channel-thenvoi.patch-openclaw-config.cjs`
+- `openclaw-channel-thenvoi/openclaw.plugin.json`
+
+Do not bake real Band credentials into the image unless you are creating a disposable local sandbox. The supported path keeps the Band API key behind the `${THENVOI_API_KEY}` runtime placeholder; the post-onboard configure helper writes only non-secret account metadata with NemoClaw's host-side config command.
+
+## 3. Configure a NemoClaw model provider
+
+NemoClaw needs a model before OpenClaw can answer Band messages. If you use NVIDIA AI, create an NVIDIA API key and use `nvidia/nvidia-nemotron-nano-9b-v2`.
+
+For non-interactive onboarding with NemoClaw's NVIDIA Build path, set the provider and credential before `nemoclaw onboard`:
+
+```sh
+export NEMOCLAW_PROVIDER=build
+export NEMOCLAW_MODEL=nvidia/nvidia-nemotron-nano-9b-v2
+export NVIDIA_API_KEY=<your-nvidia-api-key>
+```
+
+If you intentionally use the generic OpenAI-compatible provider instead, keep the NVIDIA Build endpoint and credential explicit:
+
+```sh
+export NEMOCLAW_PROVIDER=custom
+export NEMOCLAW_ENDPOINT_URL=https://integrate.api.nvidia.com/v1
+export NEMOCLAW_MODEL=nvidia/nvidia-nemotron-nano-9b-v2
+export COMPATIBLE_API_KEY=<your-nvidia-api-key>
+```
+
+NemoClaw's current `custom` non-interactive path requires `NEMOCLAW_ENDPOINT_URL`. Without it, onboarding exits with `Endpoint URL is required for Other OpenAI-compatible endpoint`, and sandbox status can only report `Endpoint URL is not known; skipping reachability check.` The `build` provider path is the preferred one for this integration.
+
+## 4. Onboard the sandbox
+
+The setup script prints the exact command. It has this shape:
+
+```sh
+nemoclaw onboard --from /absolute/path/to/packages/openclaw/dist/nemoclaw-integration/band-integration/Dockerfile --name band-integration
+```
+
+For non-interactive onboarding with the environment variables above:
+
+```sh
+nemoclaw onboard --non-interactive --yes \
+  --from /absolute/path/to/packages/openclaw/dist/nemoclaw-integration/band-integration/Dockerfile \
+  --name band-integration
+```
+
+After onboarding, confirm NemoClaw sees the sandbox and model:
+
+```sh
+nemoclaw list --json
+nemoclaw band-integration status
+```
+
+`nemoclaw band-integration status` should show the sandbox as ready and should not report missing model endpoint configuration.
+
+## 5. Apply the Band egress policy
+
+After onboarding, apply the generated Band policy preset:
+
+```sh
+nemoclaw band-integration policy-add --from-file /absolute/path/to/packages/openclaw/dist/nemoclaw-integration/band-integration/band-egress-policy.yaml --yes
+```
+
+The policy allows Node-based OpenClaw plugin traffic to reach the configured Band REST and WebSocket host. REST access is scoped to `/api/v1/**`; the WebSocket entry uses `access: full` with `tls: skip` because OpenShell's REST TLS termination does not work for WSS tunnel traffic. By default the host is `app.band.ai`.
+
+## 6. Configure Band credentials
+
+Create or choose a Band agent, then get its integration API key and agent ID from Band. Export them locally without committing them:
+
+```sh
+export THENVOI_API_KEY=<your-band-api-key>
+export THENVOI_AGENT_ID=<your-band-agent-id>
+```
+
+If the Band agent has a human/operator owner that should be visible to the plugin, export that user's Band ID too:
+
+```sh
+export THENVOI_OPERATOR_ID=<band-user-id>
+```
+
+Optional contact handling is separate from normal room chat. If you want the agent to evaluate Band contact requests through a hub room, set these before running the configure helper:
+
+```sh
+export THENVOI_CONTACT_STRATEGY=hub_room
+export THENVOI_CONTACT_HUB_TASK_ID=<hub-room-id>
+```
+
+Write the non-secret account settings into the running NemoClaw sandbox:
+
+```sh
+pnpm --filter @thenvoi/openclaw-channel-thenvoi run nemoclaw:integration:configure -- \
+  --sandbox band-integration
+```
+
+`nemoclaw:integration:configure` writes `restUrl`, `wsUrl`, `agentId`, and optional `operatorId` into `/sandbox/.openclaw/openclaw.json` with `nemoclaw band-integration config set`, then restarts the sandbox agent process. It deliberately leaves `apiKey` as the literal `${THENVOI_API_KEY}` placeholder instead of passing the secret through `--value`, because the current NemoClaw CLI does not offer a stdin or file-based secret setter for arbitrary plugin credentials.
+
+Make sure the OpenClaw process receives `THENVOI_API_KEY` at runtime through your NemoClaw/OpenClaw secret injection path. If that is not available in the target NemoClaw version, the setup script's `--embed-credentials-from-env` fallback is only for disposable local sandboxes because it writes the key into generated configuration/image material.
+
+Contact request automation is intentionally off by default. The normal room-chat setup does not need a dedicated hub room, `THENVOI_CONTACT_STRATEGY`, or `THENVOI_OPERATOR_ID`; those are optional knobs for workflows that need contact-request handling or operator metadata.
+
+## 7. Talk to the agent in Band
+
+Open Band, add the configured Band agent to a chat room, and mention it in the message. Band rooms are mention-driven: humans can see the whole room, but an agent normally wakes up when it is explicitly mentioned as a room participant.
+
+The expected user experience is simple: your mentioned message appears in Band, OpenClaw inside NemoClaw receives it, the configured model generates an answer, and the Band agent replies in the same room. The agent should reply with normal text; it should not call `thenvoi_send_message` unless it needs to address a different participant.
+
+Use the verifier when you want a scripted smoke test, not as the normal product flow:
+
+```sh
+pnpm --filter @thenvoi/openclaw-channel-thenvoi run nemoclaw:integration:verify -- \
+  --sandbox band-integration \
+  --room <room-id>
+```
+
+The verifier checks generated files, `nemoclaw list --json`, `nemoclaw <sandbox> status`, Band REST `getAgentMe`, Band WebSocket presence, and whether the configured agent can reply in a Band room. When it prints the nonce prompt, send it as a Band message that explicitly @mentions the configured agent; an unmentioned message will not wake the agent. Normal users do not need to run it after every setup.
+
+## Optional preflight checks
+
+Run context-only preflight before NemoClaw is installed or before the sandbox exists:
+
+```sh
+pnpm --filter @thenvoi/openclaw-channel-thenvoi run nemoclaw:integration:preflight -- \
+  --sandbox band-integration \
+  --context-only
+```
+
+Run full offline preflight after the sandbox exists:
+
+```sh
+pnpm --filter @thenvoi/openclaw-channel-thenvoi run nemoclaw:integration:preflight -- \
+  --sandbox band-integration
+```
+
+This checks the generated context, plugin manifest tool declarations, Band policy/config templates, `nemoclaw list --json`, and `nemoclaw band-integration status`.
+
+## Troubleshooting
+
+| Symptom | Likely layer | First check |
+|---|---|---|
+| `nemoclaw` not found | Host setup | Install NemoClaw CLI and rerun preflight |
+| Docker build cannot find plugin files | Generated context | Rerun `pnpm build`, then `nemoclaw:integration:setup -- --yes` |
+| NemoClaw reports missing endpoint URL | Model setup | Set `NEMOCLAW_ENDPOINT_URL` before non-interactive onboarding |
+| NemoClaw inference is unhealthy | Model setup | Check the model ID, provider endpoint, and provider API key |
+| OpenClaw does not list Band tools | Plugin install | Check `openclaw.plugin.json` contains all 12 `thenvoi_*` tools |
+| REST/WebSocket cannot reach Band | NemoClaw policy | Apply or review `band-egress-policy.yaml` |
+| Credential error | Band config | Verify `THENVOI_API_KEY` and `THENVOI_AGENT_ID` |
+| Agent is in the room but does not answer | Runtime dispatch | Check `nemoclaw band-integration logs` for Band/OpenClaw dispatch errors |
+| Reply exists in logs but not in Band | Band REST reply path | Check `createChatMessage` errors and redacted gateway logs |
+
+## Support artifact
+
+When validating a new environment or reporting setup issues, capture:
+
+- generated context directory listing;
+- `nemoclaw:integration:preflight` JSON output;
+- `nemoclaw band-integration status` output;
+- OpenClaw tool list showing all 12 `thenvoi_*` tools;
+- a Band room transcript showing a normal message to the agent and its reply.
+
+Keep credentials out of screenshots and logs.

--- a/packages/openclaw/openclaw.plugin.json
+++ b/packages/openclaw/openclaw.plugin.json
@@ -25,6 +25,23 @@
     "defaultChoice": false
   },
 
+  "contracts": {
+    "tools": [
+      "thenvoi_lookup_peers",
+      "thenvoi_add_participant",
+      "thenvoi_remove_participant",
+      "thenvoi_get_participants",
+      "thenvoi_create_chatroom",
+      "thenvoi_send_event",
+      "thenvoi_send_message",
+      "thenvoi_list_contacts",
+      "thenvoi_add_contact",
+      "thenvoi_remove_contact",
+      "thenvoi_list_contact_requests",
+      "thenvoi_respond_contact_request"
+    ]
+  },
+
   "capabilities": {
     "channel": {
       "chatTypes": ["direct", "group"],

--- a/packages/openclaw/openclaw.plugin.json
+++ b/packages/openclaw/openclaw.plugin.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://openclaw.ai/schemas/plugin.json",
   "id": "openclaw-channel-thenvoi",
-  "name": "Thenvoi",
+  "name": "Band",
   "version": "0.1.5",
-  "description": "Connect OpenClaw to the Thenvoi AI agent collaboration platform",
-  "author": "Thenvoi",
+  "description": "Connect OpenClaw to the Band AI agent collaboration platform",
+  "author": "Band",
   "license": "MIT",
   "repository": "https://github.com/thenvoi/thenvoi-sdk-typescript",
   "entry": "dist/index.js",
@@ -12,10 +12,10 @@
 
   "openclaw.channel": {
     "id": "openclaw-channel-thenvoi",
-    "label": "Thenvoi",
-    "selectionLabel": "Thenvoi (AI Collaboration)",
+    "label": "Band",
+    "selectionLabel": "Band (AI Collaboration)",
     "docsPath": "/channels/thenvoi",
-    "blurb": "Connect to the Thenvoi AI agent collaboration platform.",
+    "blurb": "Connect to the Band AI agent collaboration platform.",
     "order": 100,
     "aliases": ["thenvoi"]
   },
@@ -23,23 +23,6 @@
   "openclaw.install": {
     "githubRepo": "thenvoi/thenvoi-sdk-typescript",
     "defaultChoice": false
-  },
-
-  "contracts": {
-    "tools": [
-      "thenvoi_lookup_peers",
-      "thenvoi_add_participant",
-      "thenvoi_remove_participant",
-      "thenvoi_get_participants",
-      "thenvoi_create_chatroom",
-      "thenvoi_send_event",
-      "thenvoi_send_message",
-      "thenvoi_list_contacts",
-      "thenvoi_add_contact",
-      "thenvoi_remove_contact",
-      "thenvoi_list_contact_requests",
-      "thenvoi_respond_contact_request"
-    ]
   },
 
   "capabilities": {
@@ -79,21 +62,21 @@
             },
             "apiKey": {
               "type": "string",
-              "description": "Thenvoi API key (or use THENVOI_API_KEY env var)"
+              "description": "Band API key (or use THENVOI_API_KEY env var)"
             },
             "agentId": {
               "type": "string",
-              "description": "Thenvoi agent ID (or use THENVOI_AGENT_ID env var)"
+              "description": "Band agent ID (or use THENVOI_AGENT_ID env var)"
             },
             "wsUrl": {
               "type": "string",
-              "default": "wss://app.thenvoi.com/api/v1/socket",
-              "description": "Thenvoi WebSocket URL"
+              "default": "wss://app.band.ai/api/v1/socket",
+              "description": "Band WebSocket URL"
             },
             "restUrl": {
               "type": "string",
-              "default": "https://app.thenvoi.com",
-              "description": "Thenvoi REST API URL"
+              "default": "https://app.band.ai",
+              "description": "Band REST API URL"
             },
             "stateDir": {
               "type": "string",
@@ -115,32 +98,32 @@
       "placeholder": "agent-uuid-here"
     },
     "wsUrl": {
-      "placeholder": "wss://app.thenvoi.com/api/v1/socket"
+      "placeholder": "wss://app.band.ai/api/v1/socket"
     },
     "restUrl": {
-      "placeholder": "https://app.thenvoi.com"
+      "placeholder": "https://app.band.ai"
     }
   },
 
   "environment": {
     "THENVOI_API_KEY": {
-      "description": "API key for Thenvoi platform authentication",
-      "required": true,
+      "description": "API key for Band platform authentication. Required when starting a Band account; not required for plugin discovery.",
+      "required": false,
       "sensitive": true
     },
     "THENVOI_AGENT_ID": {
-      "description": "Agent identifier on Thenvoi platform",
-      "required": true
+      "description": "Agent identifier on Band platform. Required when starting a Band account; not required for plugin discovery.",
+      "required": false
     },
     "THENVOI_WS_URL": {
-      "description": "Thenvoi WebSocket endpoint",
+      "description": "Band WebSocket endpoint",
       "required": false,
-      "default": "wss://app.thenvoi.com/api/v1/socket"
+      "default": "wss://app.band.ai/api/v1/socket"
     },
     "THENVOI_REST_URL": {
-      "description": "Thenvoi REST API endpoint",
+      "description": "Band REST API endpoint",
       "required": false,
-      "default": "https://app.thenvoi.com"
+      "default": "https://app.band.ai"
     }
   }
 }

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -20,7 +20,10 @@
   },
   "files": [
     "dist",
-    "openclaw.plugin.json"
+    "!dist/nemoclaw-integration/**",
+    "openclaw.plugin.json",
+    "examples/nemoclaw/README.md",
+    "scripts/nemoclaw-integration-*.js"
   ],
   "scripts": {
     "build": "pnpm --filter @thenvoi/sdk build && tsup && node scripts/sync-plugin-version.js",
@@ -31,6 +34,10 @@
     "test:watch": "vitest",
     "test:coverage": "pnpm --filter @thenvoi/sdk build && vitest run --coverage",
     "test:e2e": "pnpm --filter @thenvoi/sdk build && node --env-file=.env node_modules/vitest/vitest.mjs run --config vitest.config.e2e.ts",
+    "nemoclaw:integration:setup": "node scripts/nemoclaw-integration-setup.js",
+    "nemoclaw:integration:configure": "node scripts/nemoclaw-integration-configure.js",
+    "nemoclaw:integration:preflight": "node scripts/nemoclaw-integration-preflight.js",
+    "nemoclaw:integration:verify": "node scripts/nemoclaw-integration-verify.js",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/packages/openclaw/scripts/nemoclaw-integration-common.js
+++ b/packages/openclaw/scripts/nemoclaw-integration-common.js
@@ -1,0 +1,140 @@
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export const packageRoot = resolve(__dirname, "..");
+export const DEFAULT_SANDBOX = "band-integration";
+export const DEFAULT_REST_URL = "https://app.band.ai";
+export const DEFAULT_WS_URL = "wss://app.band.ai/api/v1/socket";
+export const PLUGIN_CONTEXT_DIR = "openclaw-channel-thenvoi";
+export const PLUGIN_FILES = ["dist/index.js", "dist/index.d.ts", "openclaw.plugin.json"];
+export const GENERATED_CONTEXT_MARKER = ".nemoclaw-integration-context";
+export const GENERATED_CONTEXT_FILES = [
+  GENERATED_CONTEXT_MARKER,
+  "Dockerfile",
+  "band-egress-policy.yaml",
+  "openclaw-channel-thenvoi.config.example.json",
+  "openclaw-channel-thenvoi.openclaw-config.json",
+  "openclaw-channel-thenvoi.patch-openclaw-config.cjs",
+  `${PLUGIN_CONTEXT_DIR}/package.json`,
+  ...PLUGIN_FILES.map((file) => `${PLUGIN_CONTEXT_DIR}/${file}`),
+];
+
+const PREFIXED_REDACTION_PATTERNS = [
+  /\b(Bearer\s+)[A-Za-z0-9._~+/=-]{8,}/gi,
+  /\b(gateway[-_ ]?token["'\s:=]+)[A-Za-z0-9._~+/=-]{8,}/gi,
+  /\b(api[-_ ]?key["'\s:=]+)[A-Za-z0-9._~+/=-]{8,}/gi,
+  /\b(thenvoi[-_ ]?api[-_ ]?key["'\s:=]+)[A-Za-z0-9._~+/=-]{8,}/gi,
+  /\b(authorization["'\s:=]+)[A-Za-z0-9._~+/=-]{8,}/gi,
+  /\b(x-api-key["'\s:=]+)[A-Za-z0-9._~+/=-]{8,}/gi,
+  /([?&](?:api_?key|token|gateway_?token)=)[^\s&]+/gi,
+];
+
+const TOKEN_REDACTION_PATTERNS = [
+  /\btv_[A-Za-z0-9_-]{8,}\b/g,
+  /\bthnv_(?:a_|u_)?[A-Za-z0-9_-]{8,}\b/g,
+  /\bband_(?:a_|u_)[A-Za-z0-9_-]{8,}\b/g,
+  /\bsk-[A-Za-z0-9_-]{8,}\b/g,
+  /\bnvapi-[A-Za-z0-9_-]{8,}\b/g,
+  /\bhf_[A-Za-z0-9_-]{8,}\b/g,
+];
+
+export function requireValue(argv, index, flag) {
+  const value = argv[index];
+  if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value`);
+  return value;
+}
+
+export function contextDir(opts) {
+  return resolve(packageRoot, opts.context ?? `dist/nemoclaw-integration/${opts.sandbox}`);
+}
+
+export function checkGeneratedContext(opts) {
+  const dir = contextDir(opts);
+  const missing = GENERATED_CONTEXT_FILES.filter((file) => !existsSync(resolve(dir, file)));
+  if (missing.length > 0) throw new Error(`missing generated files in ${dir}: ${missing.join(", ")}`);
+  return { dir };
+}
+
+export function endpointFromUrl(raw, label) {
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "https:" && url.protocol !== "wss:") throw new Error("unsupported protocol");
+    return { host: url.hostname, port: Number(url.port || 443), protocol: url.protocol };
+  } catch {
+    throw new Error(`${label} must be an https:// or wss:// URL`);
+  }
+}
+
+export function hostFromUrl(raw, label) {
+  return endpointFromUrl(raw, label).host;
+}
+
+export function redact(value) {
+  let text = String(value instanceof Error ? value.message : value);
+  for (const pattern of PREFIXED_REDACTION_PATTERNS) {
+    text = text.replace(pattern, (_match, prefix) => `${prefix}[REDACTED]`);
+  }
+  for (const pattern of TOKEN_REDACTION_PATTERNS) {
+    text = text.replace(pattern, "[REDACTED]");
+  }
+  return text;
+}
+
+export function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+export function readRootManifestTools() {
+  return readManifestTools(resolve(packageRoot, "openclaw.plugin.json"));
+}
+
+export function readContextManifestTools(dir) {
+  return readManifestTools(resolve(dir, PLUGIN_CONTEXT_DIR, "openclaw.plugin.json"));
+}
+
+export function checkContextManifestTools(dir) {
+  const expected = readRootManifestTools();
+  const actual = readContextManifestTools(dir);
+  const missing = expected.filter((tool) => !actual.includes(tool));
+  const extra = actual.filter((tool) => !expected.includes(tool));
+  const errors = [];
+
+  if (missing.length > 0) errors.push(`missing tools: ${missing.join(", ")}`);
+  if (extra.length > 0) errors.push(`unexpected tools: ${extra.join(", ")}`);
+  if (errors.length > 0) throw new Error(errors.join("; "));
+
+  return { tools: actual.length };
+}
+
+export function checkNemoclawList() {
+  const result = runNemoclaw(["list", "--json"], "nemoclaw list --json");
+  JSON.parse(result.stdout);
+  return { command: "nemoclaw list --json" };
+}
+
+export function checkNemoclawStatus(sandbox) {
+  runNemoclaw([sandbox, "status"], `nemoclaw ${sandbox} status`);
+  return { command: `nemoclaw ${sandbox} status` };
+}
+
+export function checkNemoclawSandbox(sandbox) {
+  checkNemoclawList();
+  checkNemoclawStatus(sandbox);
+  return { commands: ["nemoclaw list --json", `nemoclaw ${sandbox} status`] };
+}
+
+function readManifestTools(path) {
+  const manifest = readJson(path);
+  return manifest.capabilities?.mcp?.tools ?? [];
+}
+
+function runNemoclaw(args, label) {
+  const result = spawnSync("nemoclaw", args, { encoding: "utf-8" });
+  if (result.error) throw new Error("nemoclaw CLI is not installed or not on PATH");
+  if (result.status !== 0) throw new Error(`${label} failed: ${redact(result.stderr || result.stdout)}`);
+  return result;
+}

--- a/packages/openclaw/scripts/nemoclaw-integration-configure.js
+++ b/packages/openclaw/scripts/nemoclaw-integration-configure.js
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import {
+  DEFAULT_REST_URL,
+  DEFAULT_SANDBOX,
+  DEFAULT_WS_URL,
+  endpointFromUrl,
+  redact,
+  requireValue,
+} from "./nemoclaw-integration-common.js";
+
+function parseArgs(argv) {
+  const opts = {
+    sandbox: DEFAULT_SANDBOX,
+    restUrl: process.env.THENVOI_REST_URL ?? DEFAULT_REST_URL,
+    wsUrl: process.env.THENVOI_WS_URL ?? DEFAULT_WS_URL,
+    restart: true,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--") continue;
+    if (arg === "--sandbox") opts.sandbox = requireValue(argv, ++i, arg);
+    else if (arg === "--rest-url") opts.restUrl = requireValue(argv, ++i, arg);
+    else if (arg === "--ws-url") opts.wsUrl = requireValue(argv, ++i, arg);
+    else if (arg === "--no-restart") opts.restart = false;
+    else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  endpointFromUrl(opts.restUrl, "--rest-url");
+  endpointFromUrl(opts.wsUrl, "--ws-url");
+  return opts;
+}
+
+function printHelp() {
+  console.log(`Usage: pnpm run nemoclaw:integration:configure -- --sandbox band-integration [--no-restart]\n\nWrites non-secret Band account settings into the running NemoClaw sandbox OpenClaw config with nemoclaw <sandbox> config set. The Band API key is kept as the \${THENVOI_API_KEY} runtime placeholder so it is not exposed in the config command argv.`);
+}
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function configSetArgs(sandbox, key, value, restart) {
+  const args = [
+    sandbox,
+    "config",
+    "set",
+    "--key",
+    key,
+    "--value",
+    value,
+    "--config-accept-new-path",
+  ];
+  if (restart) args.push("--restart");
+  return args;
+}
+
+function runConfigSet(args) {
+  const result = spawnSync("nemoclaw", args, {
+    encoding: "utf-8",
+    env: { ...process.env, NEMOCLAW_CONFIG_ACCEPT_NEW_PATH: "1" },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error) throw new Error("nemoclaw CLI is not installed or not on PATH");
+  if (result.status !== 0) {
+    throw new Error(redact(result.stderr || result.stdout || `nemoclaw ${args.slice(0, 3).join(" ")} failed`));
+  }
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const account = {
+    enabled: true,
+    restUrl: opts.restUrl,
+    wsUrl: opts.wsUrl,
+    agentId: requireEnv("THENVOI_AGENT_ID"),
+    apiKey: "${THENVOI_API_KEY}",
+  };
+
+  if (process.env.THENVOI_OPERATOR_ID) {
+    account.operatorId = process.env.THENVOI_OPERATOR_ID;
+  }
+
+  if (process.env.THENVOI_CONTACT_STRATEGY) {
+    account.contactConfig = {
+      strategy: process.env.THENVOI_CONTACT_STRATEGY,
+      broadcastChanges: true,
+      ...(process.env.THENVOI_CONTACT_HUB_TASK_ID ? { hubTaskId: process.env.THENVOI_CONTACT_HUB_TASK_ID } : {}),
+    };
+  }
+
+  runConfigSet(configSetArgs(
+    opts.sandbox,
+    "plugins.entries.openclaw-channel-thenvoi.config.accounts.default",
+    JSON.stringify(account),
+    opts.restart,
+  ));
+
+  console.log(`Configured Band account metadata for NemoClaw sandbox '${opts.sandbox}'. The apiKey config remains the \${THENVOI_API_KEY} runtime placeholder; no Band API key was passed to nemoclaw config set.`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(redact(error));
+  process.exit(1);
+}

--- a/packages/openclaw/scripts/nemoclaw-integration-preflight.js
+++ b/packages/openclaw/scripts/nemoclaw-integration-preflight.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  DEFAULT_SANDBOX,
+  checkContextManifestTools,
+  checkGeneratedContext,
+  checkNemoclawList,
+  checkNemoclawStatus,
+  contextDir,
+  endpointFromUrl,
+  readJson,
+  redact,
+  requireValue,
+} from "./nemoclaw-integration-common.js";
+
+function parseArgs(argv) {
+  const opts = { sandbox: DEFAULT_SANDBOX, context: undefined, contextOnly: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--") continue;
+    if (arg === "--sandbox") opts.sandbox = requireValue(argv, ++i, arg);
+    else if (arg === "--context") opts.context = requireValue(argv, ++i, arg);
+    else if (arg === "--context-only") opts.contextOnly = true;
+    else if (arg === "--help" || arg === "-h") {
+      console.log("Usage: pnpm run nemoclaw:integration:preflight -- --sandbox band-integration [--context path] [--context-only]");
+      process.exit(0);
+    } else throw new Error(`Unknown argument: ${arg}`);
+  }
+  return opts;
+}
+
+function layer(name, fn) {
+  try {
+    const evidence = fn();
+    return { layer: name, status: "pass", evidence };
+  } catch (error) {
+    return { layer: name, status: "fail", message: redact(error) };
+  }
+}
+
+function checkTools(opts) {
+  const dir = contextDir(opts);
+  const evidence = checkContextManifestTools(dir);
+  const manifest = readJson(resolve(dir, "openclaw-channel-thenvoi/openclaw.plugin.json"));
+  if (typeof manifest.entry !== "string" || !manifest.entry) throw new Error("plugin manifest missing entry");
+  if (!existsSync(resolve(dir, "openclaw-channel-thenvoi", manifest.entry))) {
+    throw new Error(`plugin manifest entry does not exist in generated context: ${manifest.entry}`);
+  }
+  const packageJson = readJson(resolve(dir, "openclaw-channel-thenvoi/package.json"));
+  const extensions = packageJson.openclaw?.extensions ?? [];
+  if (!Array.isArray(extensions) || !extensions.includes(`./${manifest.entry}`)) {
+    throw new Error(`plugin package.json must declare openclaw.extensions entry ./${manifest.entry}`);
+  }
+  return { ...evidence, entry: manifest.entry, packageExtensions: extensions.length };
+}
+
+function checkPolicy(opts) {
+  const dir = contextDir(opts);
+  const policy = readFileSync(resolve(dir, "band-egress-policy.yaml"), "utf-8");
+  const config = readJson(resolve(dir, "openclaw-channel-thenvoi.config.example.json"));
+  const account = config.plugins?.entries?.["openclaw-channel-thenvoi"]?.config?.accounts?.default;
+  const endpoints = [endpointFromUrl(account?.restUrl, "config template restUrl"), endpointFromUrl(account?.wsUrl, "config template wsUrl")];
+  const hosts = endpoints.map((endpoint) => endpoint.host);
+  if (!policy.includes("preset:")) throw new Error("policy missing preset metadata root");
+  if (!policy.includes("name: band-openclaw-channel")) throw new Error("policy preset.name must be the lowercase NemoClaw preset id");
+  if (!policy.includes("network_policies:")) throw new Error("policy missing network_policies root");
+  for (const endpoint of new Map(endpoints.map((value) => [`${value.host}:${value.port}`, value])).values()) {
+    if (!policy.includes(`host: ${endpoint.host}`)) throw new Error(`policy missing ${endpoint.host} host`);
+    if (!policy.includes(`port: ${endpoint.port}`)) throw new Error(`policy missing ${endpoint.host}:${endpoint.port} port`);
+  }
+  if (policy.includes("host: *") || policy.includes("host: \"*\"")) throw new Error("policy must not use wildcard egress");
+  if (policy.includes("{ path: /** }")) throw new Error("policy must not allow every sandbox binary");
+  if (!policy.includes("protocol: rest") || !policy.includes("enforcement: enforce")) {
+    throw new Error("policy missing enforced REST rules for Band API access");
+  }
+  if (!policy.includes('path: "/api/v1/**"')) throw new Error("policy must scope REST access to /api/v1/**");
+  if (!policy.includes("access: full") || !policy.includes("tls: skip")) {
+    throw new Error("policy missing Band WebSocket CONNECT tunnel allowance");
+  }
+  if (!policy.includes("path: /usr/local/bin/node") || !policy.includes("path: /usr/bin/node")) {
+    throw new Error("policy must restrict Band egress to Node runtime binaries");
+  }
+  return { file: "band-egress-policy.yaml", hosts: [...new Set(hosts)] };
+}
+
+function checkConfigTemplate(opts) {
+  const dir = contextDir(opts);
+  const realKeyPattern = /(?:tv_|thnv_(?:a_|u_)?|band_(?:a_|u_))[A-Za-z0-9_-]{8,}/;
+  const config = readFileSync(resolve(dir, "openclaw-channel-thenvoi.config.example.json"), "utf-8");
+  if (!config.includes("${THENVOI_API_KEY}")) throw new Error("config template missing THENVOI_API_KEY placeholder");
+  if (!config.includes("${THENVOI_AGENT_ID}")) throw new Error("config template missing THENVOI_AGENT_ID placeholder");
+  if (realKeyPattern.test(config)) throw new Error("config template contains a real-looking Band API key");
+
+  const runtimeConfigRaw = readFileSync(resolve(dir, "openclaw-channel-thenvoi.openclaw-config.json"), "utf-8");
+  if (realKeyPattern.test(runtimeConfigRaw)) throw new Error("runtime config contains a real-looking Band API key");
+  const runtimeConfig = JSON.parse(runtimeConfigRaw);
+  const account = runtimeConfig.plugins?.entries?.["openclaw-channel-thenvoi"]?.config?.accounts?.default;
+  if (account?.enabled !== true) throw new Error("runtime OpenClaw config must enable the default Band account");
+  if (!account.restUrl || !account.wsUrl) throw new Error("runtime OpenClaw config missing Band REST/WebSocket URLs");
+
+  return {
+    files: ["openclaw-channel-thenvoi.config.example.json", "openclaw-channel-thenvoi.openclaw-config.json"],
+    placeholders: ["THENVOI_API_KEY", "THENVOI_AGENT_ID"],
+  };
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const results = [
+    layer("build_context", () => checkGeneratedContext(opts)),
+    layer("manifest_tools", () => checkTools(opts)),
+    layer("band_egress_policy", () => checkPolicy(opts)),
+    layer("band_config_template", () => checkConfigTemplate(opts)),
+  ];
+  if (!opts.contextOnly) {
+    results.push(layer("nemoclaw_cli", checkNemoclawList), layer("sandbox_status", () => checkNemoclawStatus(opts.sandbox)));
+  }
+  console.log(JSON.stringify({ mode: opts.contextOnly ? "context" : "offline", sandbox: opts.sandbox, results }, null, 2));
+  if (results.some((result) => result.status === "fail")) process.exit(1);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(redact(error));
+  process.exit(1);
+}

--- a/packages/openclaw/scripts/nemoclaw-integration-setup.js
+++ b/packages/openclaw/scripts/nemoclaw-integration-setup.js
@@ -1,0 +1,361 @@
+#!/usr/bin/env node
+import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import {
+  DEFAULT_REST_URL,
+  DEFAULT_SANDBOX,
+  DEFAULT_WS_URL,
+  GENERATED_CONTEXT_FILES,
+  GENERATED_CONTEXT_MARKER,
+  PLUGIN_CONTEXT_DIR,
+  PLUGIN_FILES,
+  endpointFromUrl,
+  packageRoot,
+  redact,
+  requireValue,
+} from "./nemoclaw-integration-common.js";
+
+const DEFAULT_MODEL = "nvidia/nvidia-nemotron-nano-9b-v2";
+const DEFAULT_PROVIDER_KEY = "inference";
+const DEFAULT_PRIMARY_MODEL_REF = `${DEFAULT_PROVIDER_KEY}/${DEFAULT_MODEL}`;
+const DEFAULT_INFERENCE_BASE_URL = "https://inference.local/v1";
+const DEFAULT_CHAT_UI_URL = "http://127.0.0.1:18789";
+const OPENCLAW_CONFIG_PATH = "/sandbox/.openclaw/openclaw.json";
+const OPENCLAW_CONFIG_DIR = "/sandbox/.openclaw";
+const PLUGIN_PATH = "/sandbox/.openclaw/extensions/openclaw-channel-thenvoi";
+const PLUGIN_CONFIG_PATCH_PATH = "/tmp/openclaw-channel-thenvoi.openclaw-config.json";
+const PLUGIN_PATCH_SCRIPT_FILE = "openclaw-channel-thenvoi.patch-openclaw-config.cjs";
+const PLUGIN_PATCH_SCRIPT_PATH = `/tmp/${PLUGIN_PATCH_SCRIPT_FILE}`;
+
+const PLUGIN_PACKAGE_JSON = JSON.stringify({
+  name: "openclaw-channel-thenvoi-nemoclaw",
+  version: "0.0.0",
+  type: "module",
+  private: true,
+  openclaw: {
+    extensions: ["./dist/index.js"],
+  },
+}, null, 2);
+
+const DOCKER_ARG_DEFAULTS = [
+  ["NEMOCLAW_MODEL", DEFAULT_MODEL],
+  ["NEMOCLAW_PROVIDER_KEY", DEFAULT_PROVIDER_KEY],
+  ["NEMOCLAW_PRIMARY_MODEL_REF", DEFAULT_PRIMARY_MODEL_REF],
+  ["NEMOCLAW_INFERENCE_BASE_URL", DEFAULT_INFERENCE_BASE_URL],
+  ["NEMOCLAW_INFERENCE_API", "openai-completions"],
+  ["NEMOCLAW_CONTEXT_WINDOW", "131072"],
+  ["NEMOCLAW_MAX_TOKENS", "4096"],
+  ["NEMOCLAW_REASONING", "false"],
+  ["NEMOCLAW_INFERENCE_INPUTS", "text"],
+  ["NEMOCLAW_AGENT_TIMEOUT", "600"],
+  ["NEMOCLAW_AGENT_HEARTBEAT_EVERY", ""],
+  ["NEMOCLAW_INFERENCE_COMPAT_B64", "e30="],
+  ["CHAT_UI_URL", DEFAULT_CHAT_UI_URL],
+  ["NEMOCLAW_DISABLE_DEVICE_AUTH", "0"],
+];
+
+function parseArgs(argv) {
+  const opts = {
+    sandbox: DEFAULT_SANDBOX,
+    restUrl: DEFAULT_REST_URL,
+    wsUrl: DEFAULT_WS_URL,
+    dryRun: false,
+    yes: false,
+    embedCredentialsFromEnv: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--") continue;
+    if (arg === "--sandbox") opts.sandbox = requireValue(argv, ++i, arg);
+    else if (arg === "--from") opts.from = requireValue(argv, ++i, arg);
+    else if (arg === "--base-image") opts.baseImage = requireValue(argv, ++i, arg);
+    else if (arg === "--output") opts.output = requireValue(argv, ++i, arg);
+    else if (arg === "--rest-url") opts.restUrl = requireValue(argv, ++i, arg);
+    else if (arg === "--ws-url") opts.wsUrl = requireValue(argv, ++i, arg);
+    else if (arg === "--dry-run") opts.dryRun = true;
+    else if (arg === "--embed-credentials-from-env") opts.embedCredentialsFromEnv = true;
+    else if (arg === "--yes") opts.yes = true;
+    else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return opts;
+}
+
+function printHelp() {
+  console.log(`Usage: pnpm run nemoclaw:integration:setup -- --sandbox band-integration (--from Dockerfile | --base-image image) [--dry-run] [--embed-credentials-from-env] [--yes]\n\nGenerates a NemoClaw custom-image build context for the Band OpenClaw channel. --embed-credentials-from-env is only for disposable local sandboxes because it writes Band credentials into generated config material.`);
+}
+
+function assertBuildOutput() {
+  const missing = PLUGIN_FILES.filter((path) => !existsSync(resolve(packageRoot, path)));
+  if (missing.length > 0) {
+    throw new Error(`Missing build artifacts: ${missing.join(", ")}. Run pnpm --filter @thenvoi/openclaw-channel-thenvoi build first.`);
+  }
+}
+
+function dockerArgs() {
+  return DOCKER_ARG_DEFAULTS.map(([name, value]) => `ARG ${name}=${value}`).join("\n");
+}
+
+function openClawConfigPatchScript() {
+  return [
+    "const fs = require(\"node:fs\");",
+    `const cfgPath = ${JSON.stringify(OPENCLAW_CONFIG_PATH)};`,
+    `const cfgDir = ${JSON.stringify(OPENCLAW_CONFIG_DIR)};`,
+    `const pluginPath = ${JSON.stringify(PLUGIN_PATH)};`,
+    `const patchPath = ${JSON.stringify(PLUGIN_CONFIG_PATCH_PATH)};`,
+    `const defaultModel = ${JSON.stringify(DEFAULT_MODEL)};`,
+    `const defaultProviderKey = ${JSON.stringify(DEFAULT_PROVIDER_KEY)};`,
+    `const defaultPrimaryModelRef = ${JSON.stringify(DEFAULT_PRIMARY_MODEL_REF)};`,
+    `const defaultInferenceBaseUrl = ${JSON.stringify(DEFAULT_INFERENCE_BASE_URL)};`,
+    `const defaultChatUiUrl = ${JSON.stringify(DEFAULT_CHAT_UI_URL)};`,
+    "const env = process.env;",
+    "function readJson(path, fallback) {",
+    "try { return JSON.parse(fs.readFileSync(path, \"utf8\")); }",
+    "catch { return fallback; }",
+    "}",
+    "function asInt(value, fallback) {",
+    "const parsed = Number(value);",
+    "return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;",
+    "}",
+    "function asBool(value) {",
+    "return String(value || \"\").toLowerCase() === \"true\";",
+    "}",
+    "function readCompat() {",
+    "try {",
+    "return JSON.parse(Buffer.from(env.NEMOCLAW_INFERENCE_COMPAT_B64 || \"e30=\", \"base64\").toString(\"utf8\") || \"{}\");",
+    "} catch { return {}; }",
+    "}",
+    "const cfg = readJson(cfgPath, {});",
+    "const patch = readJson(patchPath, {});",
+    "const compat = readCompat();",
+    "const providerKey = env.NEMOCLAW_PROVIDER_KEY || defaultProviderKey;",
+    "const model = env.NEMOCLAW_MODEL || defaultModel;",
+    "const primary = env.NEMOCLAW_PRIMARY_MODEL_REF || providerKey + \"/\" + model;",
+    "const provider = {",
+    "baseUrl: env.NEMOCLAW_INFERENCE_BASE_URL || defaultInferenceBaseUrl,",
+    "apiKey: \"unused\",",
+    "api: env.NEMOCLAW_INFERENCE_API || \"openai-completions\",",
+    "models: [{",
+    "...(Object.keys(compat).length ? { compat } : {}),",
+    "id: model,",
+    "name: primary,",
+    "reasoning: asBool(env.NEMOCLAW_REASONING),",
+    "input: String(env.NEMOCLAW_INFERENCE_INPUTS || \"text\").split(\",\").map(function (value) { return value.trim(); }).filter(Boolean),",
+    "cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },",
+    "contextWindow: asInt(env.NEMOCLAW_CONTEXT_WINDOW, 131072),",
+    "maxTokens: asInt(env.NEMOCLAW_MAX_TOKENS, 4096),",
+    "}]",
+    "};",
+    "const currentModels = cfg.models || {};",
+    "cfg.models = {",
+    "...currentModels,",
+    "mode: \"merge\",",
+    "providers: { ...(currentModels.providers || {}), [providerKey]: provider },",
+    "};",
+    "const currentAgents = cfg.agents || {};",
+    "cfg.agents = {",
+    "...currentAgents,",
+    "defaults: {",
+    "...(currentAgents.defaults || {}),",
+    "model: { primary },",
+    "timeoutSeconds: asInt(env.NEMOCLAW_AGENT_TIMEOUT, 600),",
+    "skipBootstrap: true,",
+    "thinkingDefault: \"off\",",
+    "},",
+    "};",
+    "const currentPlugins = cfg.plugins || {};",
+    "const currentPluginLoad = currentPlugins.load || {};",
+    "const patchPlugins = patch.plugins || {};",
+    "const entries = {",
+    "acpx: { enabled: false },",
+    "bonjour: { enabled: false },",
+    "qqbot: { enabled: false },",
+    "...(currentPlugins.entries || {}),",
+    "...(patchPlugins.entries || {}),",
+    "};",
+    "const loadPaths = [...new Set([...(currentPluginLoad.paths || []), pluginPath])];",
+    "cfg.plugins = {",
+    "...currentPlugins,",
+    "load: { ...currentPluginLoad, paths: loadPaths },",
+    "entries,",
+    "};",
+    "const currentGateway = cfg.gateway || {};",
+    "const currentControlUi = currentGateway.controlUi || {};",
+    "const chatUiUrl = env.CHAT_UI_URL || defaultChatUiUrl;",
+    "cfg.gateway = {",
+    "...currentGateway,",
+    "mode: \"local\",",
+    "controlUi: {",
+    "...currentControlUi,",
+    "allowInsecureAuth: String(chatUiUrl).startsWith(\"http://\"),",
+    "dangerouslyDisableDeviceAuth: String(env.NEMOCLAW_DISABLE_DEVICE_AUTH || \"\") === \"1\",",
+    "allowedOrigins: [chatUiUrl],",
+    "},",
+    "trustedProxies: [\"127.0.0.1\", \"::1\"],",
+    "auth: { ...(currentGateway.auth || {}), token: \"\" },",
+    "};",
+    "cfg.update = { ...(cfg.update || {}), checkOnStart: false };",
+    "fs.mkdirSync(cfgDir, { recursive: true });",
+    "fs.writeFileSync(cfgPath, JSON.stringify(cfg, null, 2));",
+  ].join("\n");
+}
+
+function pluginDockerfileLayer(prefix = "") {
+  return `${prefix}${dockerArgs()}
+
+RUN mkdir -p /sandbox/.openclaw/extensions
+COPY openclaw-channel-thenvoi /sandbox/.openclaw/extensions/openclaw-channel-thenvoi
+RUN openclaw doctor --fix || true
+COPY openclaw-channel-thenvoi.config.example.json /sandbox/.openclaw/openclaw-channel-thenvoi.config.example.json
+COPY openclaw-channel-thenvoi.openclaw-config.json ${PLUGIN_CONFIG_PATCH_PATH}
+COPY ${PLUGIN_PATCH_SCRIPT_FILE} ${PLUGIN_PATCH_SCRIPT_PATH}
+RUN node ${PLUGIN_PATCH_SCRIPT_PATH}
+`;
+}
+
+function dockerfile(opts) {
+  if (opts.baseImage) {
+    return `ARG SANDBOX_BASE=${opts.baseImage}\nFROM \${SANDBOX_BASE}\n\n${pluginDockerfileLayer()}`;
+  }
+  if (opts.from) {
+    const baseDockerfile = readFileSync(resolve(opts.from), "utf-8");
+    return `${baseDockerfile}\n\n# Added by Band NemoClaw integration setup.\n${pluginDockerfileLayer()}`;
+  }
+  throw new Error("Pass --base-image <image> or --from <nemoclaw-compatible-Dockerfile>. The setup command will not guess a NemoClaw base image.");
+}
+
+function policyYaml(restEndpoint, wsEndpoint) {
+  const policyName = `band-${restEndpoint.host}-${restEndpoint.port}`.replace(/[^a-z0-9-]/gi, "-").toLowerCase();
+  const endpoints = [
+    `      - host: ${restEndpoint.host}\n        port: ${restEndpoint.port}\n        protocol: rest\n        enforcement: enforce\n        rules:\n          - allow: { method: GET, path: "/api/v1/**" }\n          - allow: { method: POST, path: "/api/v1/**" }\n          - allow: { method: PUT, path: "/api/v1/**" }\n          - allow: { method: PATCH, path: "/api/v1/**" }\n          - allow: { method: DELETE, path: "/api/v1/**" }`,
+    `      # Band Phoenix WebSocket. OpenShell terminates REST TLS, but WSS needs\n      # tunnel passthrough just like Slack/Discord gateway presets.\n      - host: ${wsEndpoint.host}\n        port: ${wsEndpoint.port}\n        access: full\n        tls: skip`,
+  ].join("\n");
+  return `# Generated Band egress policy preset for NemoClaw integration.\n# Apply after onboarding with: nemoclaw <sandbox> policy-add --from-file band-egress-policy.yaml --yes\npreset:\n  name: band-openclaw-channel\n  description: Allow the OpenClaw sandbox to reach the configured Band REST API and WebSocket host.\n  version: "1.0.0"\n\nnetwork_policies:\n  ${policyName}:\n    name: ${policyName}\n    endpoints:\n${endpoints}\n    binaries:\n      - { path: /usr/local/bin/node }\n      - { path: /usr/bin/node }\n`;
+}
+
+function configJson(opts, { includeCredentialPlaceholders, includeCredentialValues }) {
+  const account = {
+    enabled: true,
+    restUrl: opts.restUrl,
+    wsUrl: opts.wsUrl,
+  };
+  if (includeCredentialValues) {
+    account.apiKey = requireEnv("THENVOI_API_KEY");
+    account.agentId = requireEnv("THENVOI_AGENT_ID");
+    if (process.env.THENVOI_OPERATOR_ID) account.operatorId = process.env.THENVOI_OPERATOR_ID;
+    if (process.env.THENVOI_CONTACT_STRATEGY) {
+      account.contactConfig = {
+        strategy: process.env.THENVOI_CONTACT_STRATEGY,
+        ...(process.env.THENVOI_CONTACT_HUB_TASK_ID ? { hubTaskId: process.env.THENVOI_CONTACT_HUB_TASK_ID } : {}),
+        broadcastChanges: true,
+      };
+    }
+  } else if (includeCredentialPlaceholders) {
+    account.apiKey = "${THENVOI_API_KEY}";
+    account.agentId = "${THENVOI_AGENT_ID}";
+    account.operatorId = "${THENVOI_OPERATOR_ID}";
+  }
+  return JSON.stringify({
+    plugins: {
+      entries: {
+        "openclaw-channel-thenvoi": {
+          enabled: true,
+          config: {
+            accounts: {
+              default: account,
+            },
+          },
+        },
+      },
+    },
+  }, null, 2);
+}
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required when --embed-credentials-from-env is set`);
+  return value;
+}
+
+function outputDir(opts) {
+  return resolve(packageRoot, opts.output ?? `dist/nemoclaw-integration/${opts.sandbox}`);
+}
+
+function assertGeneratedContext(out) {
+  if (!existsSync(resolve(out, GENERATED_CONTEXT_MARKER))) {
+    throw new Error(`Refusing to replace ${out}: missing ${GENERATED_CONTEXT_MARKER}. Choose an empty --output directory or remove it manually.`);
+  }
+}
+
+function removeGeneratedFiles(out) {
+  for (const file of [...GENERATED_CONTEXT_FILES, "README.md"]) {
+    rmSync(resolve(out, file), { recursive: true, force: true });
+  }
+  rmSync(resolve(out, PLUGIN_CONTEXT_DIR), { recursive: true, force: true });
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  assertBuildOutput();
+  const restEndpoint = endpointFromUrl(opts.restUrl, "--rest-url");
+  const wsEndpoint = endpointFromUrl(opts.wsUrl, "--ws-url");
+  const out = outputDir(opts);
+  const files = {
+    "Dockerfile": dockerfile(opts),
+    "openclaw-channel-thenvoi.config.example.json": configJson(opts, { includeCredentialPlaceholders: true, includeCredentialValues: false }),
+    "openclaw-channel-thenvoi.openclaw-config.json": configJson(opts, {
+      includeCredentialPlaceholders: false,
+      includeCredentialValues: opts.embedCredentialsFromEnv,
+    }),
+    [PLUGIN_PATCH_SCRIPT_FILE]: openClawConfigPatchScript(),
+    "band-egress-policy.yaml": policyYaml(restEndpoint, wsEndpoint),
+    [`${PLUGIN_CONTEXT_DIR}/package.json`]: PLUGIN_PACKAGE_JSON,
+  };
+
+  console.log(`Band/NemoClaw integration setup for sandbox: ${opts.sandbox}`);
+  console.log(`Output directory: ${out}`);
+  console.log(`Band REST endpoint: ${restEndpoint.host}:${restEndpoint.port}`);
+  console.log(`Band WS endpoint: ${wsEndpoint.host}:${wsEndpoint.port}`);
+
+  if (opts.dryRun) {
+    console.log("Dry run: would write files:");
+    for (const name of [...Object.keys(files), `${PLUGIN_CONTEXT_DIR}/openclaw.plugin.json`, `${PLUGIN_CONTEXT_DIR}/dist/*`]) console.log(`- ${name}`);
+    console.log(`Next: nemoclaw onboard --from ${resolve(out, "Dockerfile")} --name ${opts.sandbox}`);
+    return;
+  }
+
+  if (existsSync(out)) {
+    if (!opts.yes) throw new Error(`Output directory already exists: ${out}. Pass --yes to replace generated integration files.`);
+    assertGeneratedContext(out);
+    removeGeneratedFiles(out);
+  }
+
+  mkdirSync(resolve(out, PLUGIN_CONTEXT_DIR), { recursive: true });
+  writeFileSync(resolve(out, GENERATED_CONTEXT_MARKER), "generated by nemoclaw:integration:setup\n");
+  for (const [name, content] of Object.entries(files)) {
+    const target = resolve(out, name);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, content);
+  }
+  copyFileSync(resolve(packageRoot, "openclaw.plugin.json"), resolve(out, PLUGIN_CONTEXT_DIR, "openclaw.plugin.json"));
+  for (const entry of readdirSync(resolve(packageRoot, "dist"), { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+    const target = resolve(out, PLUGIN_CONTEXT_DIR, "dist", entry.name);
+    mkdirSync(dirname(target), { recursive: true });
+    copyFileSync(resolve(packageRoot, "dist", entry.name), target);
+  }
+
+  console.log(`Wrote ${readdirSync(out).length} top-level entries.`);
+  console.log(`Next: nemoclaw onboard --from ${resolve(out, "Dockerfile")} --name ${opts.sandbox}`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(redact(error));
+  process.exit(1);
+}

--- a/packages/openclaw/scripts/nemoclaw-integration-verify.js
+++ b/packages/openclaw/scripts/nemoclaw-integration-verify.js
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+import { ThenvoiLink } from "@thenvoi/sdk";
+import { RoomPresence } from "@thenvoi/sdk/runtime";
+import {
+  DEFAULT_REST_URL,
+  DEFAULT_SANDBOX,
+  DEFAULT_WS_URL,
+  checkContextManifestTools,
+  checkGeneratedContext,
+  checkNemoclawSandbox,
+  contextDir,
+  redact,
+  requireValue,
+} from "./nemoclaw-integration-common.js";
+
+function parseArgs(argv) {
+  const opts = {
+    sandbox: DEFAULT_SANDBOX,
+    context: undefined,
+    room: undefined,
+    timeoutMs: 120_000,
+    intervalMs: 2_000,
+    skipNemoclaw: false,
+    skipRoom: false,
+    restUrl: process.env.THENVOI_REST_URL ?? DEFAULT_REST_URL,
+    wsUrl: process.env.THENVOI_WS_URL ?? DEFAULT_WS_URL,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--") continue;
+    if (arg === "--sandbox") opts.sandbox = requireValue(argv, ++i, arg);
+    else if (arg === "--context") opts.context = requireValue(argv, ++i, arg);
+    else if (arg === "--room") opts.room = requireValue(argv, ++i, arg);
+    else if (arg === "--timeout-ms") opts.timeoutMs = Number(requireValue(argv, ++i, arg));
+    else if (arg === "--interval-ms") opts.intervalMs = Number(requireValue(argv, ++i, arg));
+    else if (arg === "--rest-url") opts.restUrl = requireValue(argv, ++i, arg);
+    else if (arg === "--ws-url") opts.wsUrl = requireValue(argv, ++i, arg);
+    else if (arg === "--skip-nemoclaw") opts.skipNemoclaw = true;
+    else if (arg === "--skip-room") opts.skipRoom = true;
+    else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!Number.isFinite(opts.timeoutMs) || opts.timeoutMs < 1_000) throw new Error("--timeout-ms must be at least 1000");
+  if (!Number.isFinite(opts.intervalMs) || opts.intervalMs < 250) throw new Error("--interval-ms must be at least 250");
+  return opts;
+}
+
+function printHelp() {
+  console.log(`Usage: pnpm run nemoclaw:integration:verify -- --sandbox band-integration --room <room-id> [--skip-room]\n\nVerifies the credentialed Band/NemoClaw integration path. For full room proof, start this command, send the printed nonce prompt in the Band room with an explicit @mention of the configured agent, and wait for the verifier to observe an agent reply that includes the nonce.`);
+}
+
+async function layer(name, fn) {
+  const startedAt = Date.now();
+  try {
+    const evidence = await fn();
+    return { layer: name, status: "pass", durationMs: Date.now() - startedAt, evidence };
+  } catch (error) {
+    return { layer: name, status: "fail", durationMs: Date.now() - startedAt, message: redact(error) };
+  }
+}
+
+function blockedLayer(name, reason) {
+  return { layer: name, status: "blocked", durationMs: 0, message: reason };
+}
+
+function checkEnv() {
+  const missing = ["THENVOI_API_KEY", "THENVOI_AGENT_ID"].filter((name) => !process.env[name]);
+  if (missing.length > 0) throw new Error(`missing environment variables: ${missing.join(", ")}`);
+  return { required: ["THENVOI_API_KEY", "THENVOI_AGENT_ID"] };
+}
+
+function checkManifestTools(opts) {
+  return checkContextManifestTools(contextDir(opts));
+}
+
+function checkNemoclaw(opts) {
+  if (opts.skipNemoclaw) return { skipped: true, reason: "--skip-nemoclaw" };
+  return checkNemoclawSandbox(opts.sandbox);
+}
+
+function createLink(opts) {
+  return new ThenvoiLink({
+    agentId: process.env.THENVOI_AGENT_ID,
+    apiKey: process.env.THENVOI_API_KEY,
+    restUrl: opts.restUrl,
+    wsUrl: opts.wsUrl,
+  });
+}
+
+async function checkRest(link) {
+  const agent = await link.rest.getAgentMe();
+  return { agentId: agent.id, agentName: agent.name ?? null, agentHandle: agent.handle ?? null };
+}
+
+async function checkPresence(opts) {
+  const link = createLink(opts);
+  const presence = new RoomPresence({ link, autoSubscribeExistingRooms: true });
+  try {
+    await link.connect();
+    await presence.start();
+    await delay(Math.min(2_000, opts.timeoutMs));
+    return { connected: link.isConnected(), rooms: presence.rooms?.size ?? 0 };
+  } finally {
+    await presence.stop().catch(() => undefined);
+    await link.disconnect().catch(() => undefined);
+  }
+}
+
+async function checkRoomReply(opts, agent) {
+  if (opts.skipRoom) return { skipped: true, reason: "--skip-room" };
+  if (!opts.room) throw new Error("--room is required unless --skip-room is set");
+
+  const link = createLink(opts);
+  const seenBefore = await listMessageIds(link, opts.room);
+  const nonce = `band-nemoclaw-integration-${Date.now()}`;
+  const deadline = Date.now() + opts.timeoutMs;
+  const mention = agent.agentHandle ? `@${String(agent.agentHandle).replace(/^@/, "")}` : "<mention the configured Band agent>";
+
+  console.error(
+    `Waiting for a new Band-visible agent reply in room ${opts.room}. In Band, send a message that mentions the agent, for example: ${mention} Reply with ${nonce}`,
+  );
+  while (Date.now() < deadline) {
+    const messages = await listMessages(link, opts.room);
+    const reply = messages.find((message) => {
+      const id = String(message.id ?? "");
+      const senderId = String(message.sender_id ?? message.senderId ?? "");
+      const content = String(message.content ?? "");
+      return id && !seenBefore.has(id) && senderId === agent.agentId && content.includes(nonce);
+    });
+    if (reply) return { room: opts.room, replyMessageId: reply.id, senderId: agent.agentId, nonceMatched: true };
+    await delay(opts.intervalMs);
+  }
+
+  throw new Error(
+    `timed out after ${opts.timeoutMs}ms waiting for a new agent reply in room ${opts.room} containing the nonce ${nonce}; make sure the Band message explicitly @mentions the configured agent`,
+  );
+}
+
+async function listMessageIds(link, room) {
+  const messages = await listMessages(link, room);
+  return new Set(messages.map((message) => String(message.id ?? "")).filter(Boolean));
+}
+
+async function listMessages(link, room) {
+  if (typeof link.rest.listMessages !== "function") throw new Error("Band REST adapter does not expose listMessages");
+  const response = await link.rest.listMessages({ chatId: room, page: 1, pageSize: 50 });
+  return Array.isArray(response.data) ? response.data : [];
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const results = [];
+  results.push(await layer("generated_context", () => checkGeneratedContext(opts)));
+  results.push(await layer("manifest_tools", () => checkManifestTools(opts)));
+  results.push(await layer("nemoclaw_status", () => checkNemoclaw(opts)));
+
+  const credentialResult = await layer("band_credentials", () => checkEnv());
+  results.push(credentialResult);
+  if (credentialResult.status === "pass") {
+    const link = createLink(opts);
+    const restResult = await layer("band_rest_getAgentMe", () => checkRest(link));
+    results.push(restResult);
+    results.push(await layer("band_websocket_presence", () => checkPresence(opts)));
+    if (restResult.status === "pass") {
+      results.push(await layer("band_room_reply", () => checkRoomReply(opts, restResult.evidence)));
+    } else {
+      results.push(blockedLayer("band_room_reply", "Band agent identity is required before the room reply check can run"));
+    }
+  } else {
+    const reason = "Band credentials are required before live Band REST, WebSocket, or room checks can run";
+    results.push(blockedLayer("band_rest_getAgentMe", reason));
+    results.push(blockedLayer("band_websocket_presence", reason));
+    results.push(blockedLayer("band_room_reply", reason));
+  }
+
+  const report = { mode: "live", sandbox: opts.sandbox, room: opts.room ?? null, results };
+  console.log(JSON.stringify(report, null, 2));
+  if (results.some((result) => result.status === "fail" || result.status === "blocked")) process.exit(1);
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(redact(error));
+  process.exit(1);
+}

--- a/packages/openclaw/src/bounded-string-set.ts
+++ b/packages/openclaw/src/bounded-string-set.ts
@@ -11,8 +11,27 @@ export class BoundedStringSet {
     this.values.delete(value);
     if (this.values.size >= this.maxSize) {
       const oldest = this.values.keys().next().value;
-      if (oldest) this.values.delete(oldest);
+      if (oldest !== undefined) this.values.delete(oldest);
     }
     this.values.add(value);
+  }
+}
+
+export class BoundedStringMap<Value> {
+  private readonly values = new Map<string, Value>();
+
+  public constructor(private readonly maxSize: number) {}
+
+  public get(key: string): Value | undefined {
+    return this.values.get(key);
+  }
+
+  public set(key: string, value: Value): void {
+    this.values.delete(key);
+    if (this.values.size >= this.maxSize) {
+      const oldest = this.values.keys().next().value;
+      if (oldest !== undefined) this.values.delete(oldest);
+    }
+    this.values.set(key, value);
   }
 }

--- a/packages/openclaw/src/bounded-string-set.ts
+++ b/packages/openclaw/src/bounded-string-set.ts
@@ -1,0 +1,18 @@
+export class BoundedStringSet {
+  private readonly values = new Set<string>();
+
+  public constructor(private readonly maxSize: number) {}
+
+  public has(value: string): boolean {
+    return this.values.has(value);
+  }
+
+  public add(value: string): void {
+    this.values.delete(value);
+    if (this.values.size >= this.maxSize) {
+      const oldest = this.values.keys().next().value;
+      if (oldest) this.values.delete(oldest);
+    }
+    this.values.add(value);
+  }
+}

--- a/packages/openclaw/src/channel.ts
+++ b/packages/openclaw/src/channel.ts
@@ -1,39 +1,33 @@
 /**
- * Thenvoi Channel Plugin for OpenClaw.
+ * Band Channel Plugin for OpenClaw.
  *
- * Registers the Thenvoi channel with OpenClaw Gateway,
- * enabling bidirectional communication with the Thenvoi platform.
+ * Registers the Band channel with OpenClaw Gateway,
+ * enabling bidirectional communication with Band.
  *
  * Uses @thenvoi/sdk for all platform communication (WebSocket + REST).
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
 import { ThenvoiLink } from "@thenvoi/sdk";
-import { RoomPresence, ContactEventHandler } from "@thenvoi/sdk/runtime";
-import type { ContactEventConfig, ContactEvent, PlatformEvent } from "@thenvoi/sdk";
+import type { RoomPresence } from "@thenvoi/sdk/runtime";
+import { BoundedStringSet } from "./bounded-string-set.js";
+import {
+  listAccountIds,
+  resolveAccount,
+  resolveAccountCredentials,
+  type PluginConfig,
+  type ThenvoiAccountConfig,
+} from "./config.js";
+import { createGatewayHelpers, type GatewayContext, type GatewayHelpers } from "./gateway.js";
+import type { OpenClawInboundMessage } from "./message-utils.js";
+import { resolveOpenClawRuntimeDispatch, type OpenClawRuntimeDispatch } from "./openclaw-runtime.js";
+import { redactSecrets } from "./redaction.js";
+
+export type { OpenClawInboundMessage } from "./message-utils.js";
 
 // =============================================================================
 // OpenClaw-Specific Types
 // =============================================================================
-
-export interface ThenvoiAccountConfig {
-  enabled?: boolean;
-  apiKey?: string;
-  agentId?: string;
-  wsUrl?: string;
-  restUrl?: string;
-  contactConfig?: ContactEventConfig;
-}
-
-export interface OpenClawInboundMessage {
-  channelId: "thenvoi";
-  threadId: string;
-  senderId: string;
-  senderType: string;
-  senderName: string;
-  text: string;
-  timestamp: string;
-  metadata?: Record<string, unknown>;
-}
 
 // =============================================================================
 // Types for OpenClaw Plugin API
@@ -106,18 +100,6 @@ interface ValidationResult {
   errors?: string[];
 }
 
-interface GatewayContext {
-  cfg: unknown;
-  accountId: string;
-  account: ThenvoiAccountConfig;
-  abortSignal: AbortSignal;
-}
-
-interface GatewayHelpers {
-  startAccount: (ctx: GatewayContext) => Promise<void>;
-  stopAccount: (ctx: GatewayContext) => Promise<void>;
-}
-
 interface ThreadingHelpers {
   extractThreadId: (message: OpenClawInboundMessage) => string;
   formatThreadContext?: (threadId: string) => string;
@@ -130,56 +112,6 @@ interface MessagingHelpers {
     hint?: string;
   };
 }
-
-interface PluginConfig {
-  channels?: {
-    thenvoi?: {
-      accounts?: Record<string, ThenvoiAccountConfig>;
-    };
-    "openclaw-channel-thenvoi"?: {
-      accounts?: Record<string, ThenvoiAccountConfig>;
-    };
-  };
-  plugins?: {
-    entries?: {
-      thenvoi?: {
-        config?: {
-          accounts?: Record<string, ThenvoiAccountConfig>;
-        };
-      };
-      "openclaw-channel-thenvoi"?: {
-        config?: {
-          accounts?: Record<string, ThenvoiAccountConfig>;
-        };
-      };
-    };
-  };
-}
-
-// =============================================================================
-// Minimal type for the OpenClaw runtime methods we access
-// =============================================================================
-
-interface OpenClawRuntimeRef {
-  channel?: {
-    reply?: {
-      dispatchReplyFromConfig?: (args: {
-        ctx: Record<string, unknown>;
-        cfg: unknown;
-        dispatcher: Record<string, unknown>;
-      }) => Promise<void>;
-    };
-  };
-  config?: {
-    loadConfig: () => unknown;
-  };
-}
-
-// =============================================================================
-// Virtual thread ID for contact events (dispatched to LLM for evaluation)
-// =============================================================================
-
-const CONTACTS_THREAD_ID = "__thenvoi_contacts__";
 
 // =============================================================================
 // Channel State
@@ -211,13 +143,22 @@ function resolvePackageVersion(): string {
 }
 const PKG_VERSION: string = resolvePackageVersion();
 const GATEWAY_REGISTRY_KEY = `__thenvoi_gateway_registry_v${PKG_VERSION}__`;
+const toolEventContext = new AsyncLocalStorage<BandToolEventContext>();
+export interface BandToolEventContext {
+  accountId: string;
+  roomId: string;
+  sentMessage?: boolean;
+}
+
 interface GatewayRegistry {
   links: Map<string, ThenvoiLink>;
   presences: Map<string, RoomPresence>;
   startingAccounts: Set<string>;
-  lastSenderByThread: Map<string, { senderId: string; senderName: string }>;
+  lastSenderByThread: Map<string, { senderId: string; senderName: string; senderType?: string }>;
+  replyOwnerByThread: Map<string, { senderId: string; senderName: string }>;
+  processedMessageIds: BoundedStringSet;
   deliverInbound: ((message: OpenClawInboundMessage) => void) | null;
-  openclawRuntime: OpenClawRuntimeRef | null;
+  openclawRuntime: OpenClawRuntimeDispatch | null;
 }
 
 function getGatewayRegistry(): GatewayRegistry {
@@ -228,6 +169,8 @@ function getGatewayRegistry(): GatewayRegistry {
       presences: new Map(),
       startingAccounts: new Set(),
       lastSenderByThread: new Map(),
+      replyOwnerByThread: new Map(),
+      processedMessageIds: new BoundedStringSet(MAX_MESSAGE_DEDUPE_CACHE),
       deliverInbound: null,
       openclawRuntime: null,
     };
@@ -247,15 +190,55 @@ export function resetGatewayRegistry(): void {
 // Convenience accessors that always read from the current registry.
 // These MUST be functions (not module-level consts) so that
 // resetGatewayRegistry() properly invalidates cached state.
-function registry() { return getGatewayRegistry(); }
-function links() { return getGatewayRegistry().links; }
-function presences() { return getGatewayRegistry().presences; }
+function registry(): GatewayRegistry { return getGatewayRegistry(); }
+function links(): Map<string, ThenvoiLink> { return getGatewayRegistry().links; }
+function presences(): Map<string, RoomPresence> { return getGatewayRegistry().presences; }
+
+export function getBandToolEventContext(): BandToolEventContext | undefined {
+  return toolEventContext.getStore();
+}
+
+export function recordBandMessageSentForCurrentTurn(): void {
+  const context = toolEventContext.getStore();
+  if (context) context.sentMessage = true;
+}
+
+function runWithBandToolEventContext<T>(context: BandToolEventContext, fn: () => Promise<T>): Promise<T> {
+  return toolEventContext.run(context, fn);
+}
+
+function formatLogContext(context?: Record<string, unknown>): string {
+  if (!context) return "";
+  try {
+    return ` ${redactSecrets(JSON.stringify(context))}`;
+  } catch {
+    return ` ${redactSecrets(context)}`;
+  }
+}
+
+function createChannelLogger(accountId: string) {
+  return {
+    debug: (message: string, context?: Record<string, unknown>): void => {
+      console.debug(`[thenvoi:${accountId}] ${message}${formatLogContext(context)}`);
+    },
+    info: (message: string, context?: Record<string, unknown>): void => {
+      console.log(`[thenvoi:${accountId}] ${message}${formatLogContext(context)}`);
+    },
+    warn: (message: string, context?: Record<string, unknown>): void => {
+      console.warn(`[thenvoi:${accountId}] ${message}${formatLogContext(context)}`);
+    },
+    error: (message: string, context?: Record<string, unknown>): void => {
+      console.error(`[thenvoi:${accountId}] ${message}${formatLogContext(context)}`);
+    },
+  };
+}
 
 // Track last sender per thread for auto-mention fallback
 // Key: threadId, Value: { senderId, senderName }
 const MAX_SENDER_CACHE = 500;
+const MAX_MESSAGE_DEDUPE_CACHE = 2_000;
 
-function trackSender(accountId: string, threadId: string, senderId: string, senderName: string): void {
+function trackSender(accountId: string, threadId: string, senderId: string, senderName: string, senderType?: string): void {
   const lastSenderByThread = registry().lastSenderByThread;
   const cacheKey = `${accountId}:${threadId}`;
   // Delete-and-reinsert to move the entry to the end (LRU eviction order)
@@ -265,35 +248,17 @@ function trackSender(accountId: string, threadId: string, senderId: string, send
     const oldest = lastSenderByThread.keys().next().value;
     if (oldest) lastSenderByThread.delete(oldest);
   }
-  lastSenderByThread.set(cacheKey, { senderId, senderName });
-}
+  lastSenderByThread.set(cacheKey, { senderId, senderName, senderType });
 
-/**
- * Check if a value has the shape of an OpenClawRuntimeRef.
- */
-function isOpenClawRuntimeRef(value: unknown): value is OpenClawRuntimeRef {
-  if (value == null || typeof value !== "object") return false;
-  const obj = value as Record<string, unknown>;
-
-  const hasLoadConfig =
-    obj.config != null &&
-    typeof obj.config === "object" &&
-    typeof (obj.config as Record<string, unknown>).loadConfig === "function";
-
-  const hasDispatch =
-    obj.channel != null &&
-    typeof obj.channel === "object" &&
-    (obj.channel as Record<string, unknown>).reply != null &&
-    typeof (obj.channel as Record<string, unknown>).reply === "object" &&
-    typeof ((obj.channel as Record<string, unknown>).reply as Record<string, unknown>).dispatchReplyFromConfig === "function";
-
-  if (hasLoadConfig || hasDispatch) {
-    if (hasLoadConfig && !hasDispatch) {
-      console.warn("[thenvoi] Runtime has config.loadConfig but missing channel.reply.dispatchReplyFromConfig — message dispatch will fall back to deliverMessage");
+  if (senderType?.toLowerCase() !== "agent") {
+    const replyOwnerByThread = registry().replyOwnerByThread;
+    replyOwnerByThread.delete(cacheKey);
+    if (replyOwnerByThread.size >= MAX_SENDER_CACHE) {
+      const oldest = replyOwnerByThread.keys().next().value;
+      if (oldest) replyOwnerByThread.delete(oldest);
     }
-    return true;
+    replyOwnerByThread.set(cacheKey, { senderId, senderName });
   }
-  return false;
 }
 
 /**
@@ -301,13 +266,13 @@ function isOpenClawRuntimeRef(value: unknown): value is OpenClawRuntimeRef {
  * Called by the plugin entry point.
  */
 export function setOpenClawRuntime(runtime: unknown): void {
-  if (!isOpenClawRuntimeRef(runtime)) {
-    console.warn("[thenvoi] setOpenClawRuntime called with invalid runtime object, ignoring");
-    return;
-  }
-  registry().openclawRuntime = runtime;
-  if (runtime.channel?.reply) {
+  const resolution = resolveOpenClawRuntimeDispatch(runtime);
+  registry().openclawRuntime = resolution.dispatch;
+
+  if (resolution.dispatch) {
     console.log("[thenvoi] OpenClaw dispatch methods available");
+  } else {
+    console.warn(`[thenvoi] OpenClaw dispatch unavailable: ${resolution.reason ?? "unknown runtime shape"}`);
   }
 }
 
@@ -328,7 +293,7 @@ export function setInboundCallback(
 export function deliverMessage(message: OpenClawInboundMessage, accountId: string = "default"): void {
   // Track the sender for auto-mention fallback when responding
   if (message.threadId && message.senderId && message.senderName) {
-    trackSender(accountId, message.threadId, message.senderId, message.senderName);
+    trackSender(accountId, message.threadId, message.senderId, message.senderName, message.senderType);
   }
 
   const deliver = registry().deliverInbound;
@@ -342,22 +307,6 @@ export function deliverMessage(message: OpenClawInboundMessage, accountId: strin
 // =============================================================================
 // Configuration Helpers
 // =============================================================================
-
-function resolveConfig(account: ThenvoiAccountConfig): { apiKey: string; agentId: string; wsUrl: string; restUrl: string } {
-  const apiKey = account.apiKey ?? process.env.THENVOI_API_KEY;
-  const agentId = account.agentId ?? process.env.THENVOI_AGENT_ID;
-  const wsUrl = account.wsUrl ?? process.env.THENVOI_WS_URL ?? "wss://app.thenvoi.com/api/v1/socket";
-  const restUrl = account.restUrl ?? process.env.THENVOI_REST_URL ?? "https://app.thenvoi.com";
-
-  if (!apiKey) {
-    throw new Error("THENVOI_API_KEY is required");
-  }
-  if (!agentId) {
-    throw new Error("THENVOI_AGENT_ID is required");
-  }
-
-  return { apiKey, agentId, wsUrl, restUrl };
-}
 
 // =============================================================================
 // Mention Resolution
@@ -412,59 +361,49 @@ async function resolveMentions(
 // Reply Helper
 // =============================================================================
 
-/**
- * Send a reply back to Thenvoi using the SDK's REST API.
- * Throws on failure so callers (e.g. the dispatcher) can track and surface delivery errors.
- */
-async function sendReplyToThenvoi(rest: ThenvoiLink["rest"], agentId: string, accountId: string, roomId: string, payload: unknown): Promise<void> {
-  const text = typeof payload === "string" ? payload : (payload as { text?: string })?.text;
-  if (!text) {
-    throw new Error(`[thenvoi] No text in reply payload (room=${roomId})`);
+async function resolveFinalReplyMentions(
+  rest: ThenvoiLink["rest"],
+  agentId: string,
+  accountId: string,
+  roomId: string,
+): Promise<Mention[]> {
+  const participants = await rest.listChatParticipants(roomId);
+  const cacheKey = `${accountId}:${roomId}`;
+
+  const replyOwner = registry().replyOwnerByThread.get(cacheKey);
+  if (replyOwner) {
+    const participant = participants.find((p) => p.id === replyOwner.senderId && p.id !== agentId);
+    if (participant) return [{ id: participant.id, name: participant.name }];
   }
 
-  const resolved = await resolveMentions(rest, agentId, accountId, roomId, text);
-  if (!resolved) {
-    throw new Error(
-      `[thenvoi] Reply dropped: no other participants in room to mention (room=${roomId}, text=${text.substring(0, 80)})`,
-    );
+  const ownerLikeParticipant = participants.find((p) => p.id !== agentId && p.type?.toLowerCase() !== "agent");
+  if (ownerLikeParticipant) return [{ id: ownerLikeParticipant.id, name: ownerLikeParticipant.name }];
+
+  const lastSender = registry().lastSenderByThread.get(cacheKey);
+  if (lastSender) {
+    const participant = participants.find((p) => p.id === lastSender.senderId && p.id !== agentId);
+    if (participant) return [{ id: participant.id, name: participant.name }];
   }
-  await rest.createChatMessage(roomId, { content: text, mentions: resolved.mentions });
-  console.log(`[thenvoi] Reply sent: ${text.length > 50 ? text.substring(0, 50) + "..." : text}`);
+
+  const otherParticipant = participants.find((p) => p.id !== agentId);
+  if (otherParticipant) return [{ id: otherParticipant.id, name: otherParticipant.name }];
+
+  throw new Error("Cannot send final reply: no other participant is available to mention");
 }
 
-// =============================================================================
-// Event to Message Conversion
-// =============================================================================
-
-/**
- * Convert a SDK PlatformEvent (message_created) to OpenClawInboundMessage.
- */
-function platformEventToInboundMessage(event: PlatformEvent): OpenClawInboundMessage | null {
-  if (event.type !== "message_created") return null;
-  const payload = event.payload;
-  const roomId = event.roomId ?? payload.chat_room_id;
-  if (!roomId) return null;
-
-  // Only process text messages, not events
-  if (payload.message_type !== "text") {
-    console.log(`[thenvoi] Skipping non-text message (type=${payload.message_type}, room=${roomId})`);
-    return null;
-  }
-
-  return {
-    channelId: "thenvoi",
-    threadId: roomId,
-    senderId: payload.sender_id,
-    senderType: payload.sender_type,
-    senderName: payload.sender_name ?? "Unknown",
-    text: payload.content,
-    timestamp: payload.inserted_at,
-    metadata: {
-      messageId: payload.id,
-      messageType: payload.message_type,
-      mentions: payload.metadata?.mentions,
-    },
-  };
+function gatewayHelpers(): GatewayHelpers {
+  return createGatewayHelpers({
+    links: links(),
+    presences: presences(),
+    startingAccounts: registry().startingAccounts,
+    processedMessageIds: registry().processedMessageIds,
+    getOpenClawRuntime: () => registry().openclawRuntime,
+    createLogger: createChannelLogger,
+    deliverMessage,
+    trackSender,
+    resolveFinalReplyMentions,
+    runWithBandToolEventContext,
+  });
 }
 
 // =============================================================================
@@ -472,7 +411,7 @@ function platformEventToInboundMessage(event: PlatformEvent): OpenClawInboundMes
 // =============================================================================
 
 /**
- * Shared logic for sending an outbound message (text or media) to Thenvoi.
+ * Shared logic for sending an outbound message (text or media) to Band.
  */
 async function sendOutbound(ctx: OutboundContext): Promise<OutboundDeliveryResult> {
   const { text, to, accountId } = ctx;
@@ -484,7 +423,7 @@ async function sendOutbound(ctx: OutboundContext): Promise<OutboundDeliveryResul
 
   const link = links().get(accountId ?? "default");
   if (!link) {
-    throw new Error("Thenvoi link not initialized");
+    throw new Error("Band link not initialized");
   }
 
   const resolved = await resolveMentions(link.rest, link.agentId, accountId ?? "default", roomId, text);
@@ -510,10 +449,10 @@ export const thenvoiChannel: OpenClawChannel = {
 
   meta: {
     id: "openclaw-channel-thenvoi",
-    label: "Thenvoi",
-    selectionLabel: "Thenvoi (AI Collaboration)",
+    label: "Band",
+    selectionLabel: "Band (AI Collaboration)",
     docsPath: "/channels/thenvoi",
-    blurb: "Connect to the Thenvoi AI agent collaboration platform.",
+    blurb: "Connect to the Band AI agent collaboration platform.",
     aliases: ["thenvoi", "openclaw-channel-thenvoi"],
   },
 
@@ -523,27 +462,8 @@ export const thenvoiChannel: OpenClawChannel = {
   },
 
   config: {
-    listAccountIds: (config: PluginConfig): string[] => {
-      const pluginAccounts = config.plugins?.entries?.["openclaw-channel-thenvoi"]?.config?.accounts
-        ?? config.plugins?.entries?.thenvoi?.config?.accounts ?? {};
-      const channelAccounts = config.channels?.["openclaw-channel-thenvoi"]?.accounts
-        ?? config.channels?.thenvoi?.accounts ?? {};
-      const accounts = { ...pluginAccounts, ...channelAccounts };
-      return Object.keys(accounts);
-    },
-
-    resolveAccount: (
-      config: PluginConfig,
-      accountId?: string,
-    ): ThenvoiAccountConfig => {
-      const pluginAccounts = config.plugins?.entries?.["openclaw-channel-thenvoi"]?.config?.accounts
-        ?? config.plugins?.entries?.thenvoi?.config?.accounts ?? {};
-      const channelAccounts = config.channels?.["openclaw-channel-thenvoi"]?.accounts
-        ?? config.channels?.thenvoi?.accounts ?? {};
-      const accounts = { ...pluginAccounts, ...channelAccounts };
-      const account = accounts[accountId ?? "default"] ?? { enabled: true };
-      return account;
-    },
+    listAccountIds,
+    resolveAccount,
   },
 
   outbound: {
@@ -552,7 +472,7 @@ export const thenvoiChannel: OpenClawChannel = {
     resolveTarget: (params: { to?: string; allowFrom?: string[]; mode?: string }) => {
       const target = params.to?.trim() ?? "";
       if (!target) {
-        return { ok: false, error: new Error("Thenvoi requires a room_id as target") };
+        return { ok: false, error: new Error("Band requires a room_id as target") };
       }
       return { ok: true, to: target };
     },
@@ -573,7 +493,7 @@ export const thenvoiChannel: OpenClawChannel = {
     ): Promise<ValidationResult> => {
       let testLink: ThenvoiLink | null = null;
       try {
-        const resolved = resolveConfig(config);
+        const resolved = resolveAccountCredentials(config);
 
         // Test connection by creating a temporary link and fetching agent metadata
         testLink = new ThenvoiLink({
@@ -586,8 +506,7 @@ export const thenvoiChannel: OpenClawChannel = {
 
         return { valid: true };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        return { valid: false, errors: [message] };
+        return { valid: false, errors: [redactSecrets(error)] };
       } finally {
         if (testLink) {
           try { await testLink.disconnect(); } catch { /* ignore cleanup errors */ }
@@ -597,244 +516,8 @@ export const thenvoiChannel: OpenClawChannel = {
   },
 
   gateway: {
-    startAccount: async (ctx: GatewayContext): Promise<void> => {
-      const { accountId, account: accountConfig } = ctx;
-
-      // Prevent concurrent startAccount calls for the same account
-      if (registry().startingAccounts.has(accountId)) {
-        console.warn(`[thenvoi:${accountId}] startAccount already in progress, skipping`);
-        return;
-      }
-      registry().startingAccounts.add(accountId);
-
-      try {
-        console.log(`[thenvoi:${accountId}] Starting gateway...`);
-
-        // Disconnect any existing connection to prevent orphaned connections on reload
-        if (links().has(accountId)) {
-          console.log(`[thenvoi:${accountId}] Disconnecting previous connection before restart...`);
-          const existingPresence = presences().get(accountId);
-          if (existingPresence) {
-            await existingPresence.stop();
-            presences().delete(accountId);
-          }
-          const existingLink = links().get(accountId);
-          if (existingLink) {
-            await existingLink.disconnect();
-          }
-          links().delete(accountId);
-        }
-
-        const config = resolveConfig(accountConfig);
-
-        // Create ThenvoiLink (combines WebSocket + REST)
-        const link = new ThenvoiLink({
-          agentId: config.agentId,
-          apiKey: config.apiKey,
-          wsUrl: config.wsUrl,
-          restUrl: config.restUrl,
-        });
-        links().set(accountId, link);
-        console.log(`[thenvoi:${accountId}] Link created`);
-
-        // Connect WebSocket
-        await link.connect();
-        console.log(`[thenvoi:${accountId}] WebSocket connected`);
-
-        // Create RoomPresence for automatic room subscription management
-        const presence = new RoomPresence({
-          link,
-          autoSubscribeExistingRooms: true,
-        });
-
-        // Set up room event handlers
-        presence.onRoomJoined = async (roomId: string, payload: Record<string, unknown>) => {
-          const title = (payload.title as string) ?? roomId;
-          console.log(`[thenvoi:${accountId}] Joined room: ${title} (${roomId})`);
-        };
-
-        presence.onRoomLeft = async (roomId: string) => {
-          console.log(`[thenvoi:${accountId}] Left room: ${roomId}`);
-        };
-
-        // Handle room events (messages, participant changes)
-        presence.onRoomEvent = async (_roomId: string, event: PlatformEvent) => {
-          // Only process message_created events
-          if (event.type !== "message_created") return;
-
-          // Skip messages from our own agent
-          if (event.payload.sender_id === config.agentId) return;
-
-          const message = platformEventToInboundMessage(event);
-          if (!message) return;
-
-          // Try OpenClaw dispatch first
-          const rt = registry().openclawRuntime;
-          const dispatchFn = rt?.channel?.reply?.dispatchReplyFromConfig;
-          if (rt?.config && dispatchFn) {
-            try {
-              // Track sender before dispatch — needed for auto-mention fallback
-              // in sendReplyToThenvoi (deliverMessage owns tracking for the other path)
-              if (message.threadId && message.senderId && message.senderName) {
-                trackSender(accountId, message.threadId, message.senderId, message.senderName);
-              }
-
-              const inboundCtx = {
-                Body: message.text,
-                RawBody: message.text,
-                BodyForCommands: message.text,
-                CommandBody: message.text,
-                From: message.senderId,
-                SenderId: message.senderId,
-                SenderName: message.senderName,
-                To: message.threadId,
-                SessionKey: `thenvoi:${message.threadId}`,
-                Surface: "thenvoi",
-                Provider: "thenvoi",
-                MessageSid: (message.metadata as Record<string, unknown>)?.messageId,
-                Timestamp: message.timestamp ? new Date(message.timestamp).getTime() : Date.now(),
-                ChatType: "group",
-                CommandAuthorized: true,
-              };
-
-              // Contact events use a virtual thread — don't try to send to Thenvoi
-              const isContactThread = message.threadId === CONTACTS_THREAD_ID;
-
-              const threadId = message.threadId;
-
-              // For contact threads, use a no-op dispatcher — no replies to send
-              const noopSend = (): boolean => true;
-              const dispatcher = isContactThread
-                ? {
-                    sendToolResult: noopSend,
-                    sendBlockReply: noopSend,
-                    sendFinalReply: noopSend,
-                    waitForIdle: async (): Promise<void> => {},
-                    getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),
-                  }
-                : (() => {
-                    // Track pending reply promises so waitForIdle can await them
-                    const pendingReplies: Promise<void>[] = [];
-                    const deliveryErrors: Error[] = [];
-
-                    function enqueueReply(payload: unknown): void {
-                      pendingReplies.push(
-                        sendReplyToThenvoi(link.rest, config.agentId, accountId, threadId, payload).catch((err: unknown) => {
-                          const error = err instanceof Error ? err : new Error(String(err));
-                          deliveryErrors.push(error);
-                          console.error(`[thenvoi:${accountId}] Reply delivery failed (room=${threadId}):`, error.message);
-                        }),
-                      );
-                    }
-
-                    return {
-                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                      sendToolResult: (payload: any): boolean => { enqueueReply(payload); return true; },
-                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                      sendBlockReply: (payload: any): boolean => { enqueueReply(payload); return true; },
-                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                      sendFinalReply: (payload: any): boolean => { enqueueReply(payload); return true; },
-                      waitForIdle: async (): Promise<void> => {
-                        await Promise.allSettled(pendingReplies);
-                        if (deliveryErrors.length > 0) {
-                          const summary = deliveryErrors.map((e) => e.message).join("; ");
-                          console.error(
-                            `[thenvoi:${accountId}] ${deliveryErrors.length}/${pendingReplies.length} replies failed to deliver (room=${message.threadId}): ${summary}`,
-                          );
-                        }
-                      },
-                      getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),
-                    };
-                  })();
-
-              console.log(`[thenvoi:${accountId}] Dispatching message to OpenClaw agent...`);
-              const cfg = rt.config.loadConfig();
-              await dispatchFn({
-                ctx: inboundCtx,
-                cfg,
-                dispatcher,
-              });
-              console.log(`[thenvoi:${accountId}] Message dispatched successfully`);
-            } catch (error) {
-              console.error(`[thenvoi:${accountId}] Failed to dispatch message:`, error);
-            }
-          } else {
-            // deliverMessage handles sender tracking and warns if no callback is set
-            deliverMessage(message, accountId);
-          }
-
-          // Mark message as processed
-          const messageId = event.payload.id;
-          const roomId = event.roomId ?? event.payload.chat_room_id;
-          if (roomId && messageId) {
-            try {
-              await link.markProcessed(roomId, messageId, { bestEffort: true });
-            } catch {
-              // Best effort - don't fail if marking fails
-            }
-          }
-        };
-
-        // Create a singleton ContactEventHandler for this account
-        // (maintains dedup state, hub room ID, and request cache across events)
-        const contactHandler = new ContactEventHandler({
-          config: { strategy: "hub_room", broadcastChanges: true },
-          rest: link.rest,
-          onBroadcast: (msg: string) => {
-            console.log(`[thenvoi:${accountId}] Contact broadcast: ${msg}`);
-          },
-        });
-
-        // Handle contact events
-        presence.onContactEvent = async (event: ContactEvent) => {
-          try {
-            console.log(`[thenvoi:${accountId}] Contact event: ${event.type}`);
-            await contactHandler.handle(event);
-          } catch (error) {
-            console.error(`[thenvoi:${accountId}] Failed to handle contact event:`, error);
-          }
-        };
-
-        presences().set(accountId, presence);
-
-        // Start the event loop
-        await presence.start();
-
-        console.log(`[thenvoi:${accountId}] Connected to Thenvoi platform`);
-
-        // Block until OpenClaw signals shutdown — startAccount must stay
-        // alive for the lifetime of the connection, otherwise OpenClaw
-        // treats the exit as a failure and triggers auto-restart.
-        if (!ctx.abortSignal.aborted) {
-          await new Promise<void>((resolve) => {
-            ctx.abortSignal.addEventListener("abort", () => resolve(), { once: true });
-          });
-        }
-
-        console.log(`[thenvoi:${accountId}] Shutdown signal received`);
-      } finally {
-        registry().startingAccounts.delete(accountId);
-      }
-    },
-
-    stopAccount: async (ctx: GatewayContext): Promise<void> => {
-      const { accountId } = ctx;
-      registry().startingAccounts.delete(accountId);
-
-      const presence = presences().get(accountId);
-      if (presence) {
-        await presence.stop();
-        presences().delete(accountId);
-      }
-
-      const link = links().get(accountId);
-      if (link) {
-        await link.disconnect();
-        links().delete(accountId);
-      }
-
-      console.log(`[thenvoi:${accountId}] Disconnected from Thenvoi platform`);
-    },
+    startAccount: (ctx: GatewayContext) => gatewayHelpers().startAccount(ctx),
+    stopAccount: (ctx: GatewayContext) => gatewayHelpers().stopAccount(ctx),
   },
 
   threading: {
@@ -843,18 +526,18 @@ export const thenvoiChannel: OpenClawChannel = {
     },
 
     formatThreadContext: (threadId: string): string => {
-      return `[Thenvoi Room: ${threadId}]`;
+      return `[Band Room: ${threadId}]`;
     },
   },
 
   messaging: {
     targetResolver: {
-      // UUID pattern for Thenvoi room IDs
+      // UUID pattern for Band room IDs
       looksLikeId: (raw: string): boolean => {
         const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
         return uuidPattern.test(raw.trim());
       },
-      hint: "Provide a Thenvoi room_id (UUID format)",
+      hint: "Provide a Band room_id (UUID format)",
     },
   },
 };
@@ -864,7 +547,7 @@ export const thenvoiChannel: OpenClawChannel = {
 // =============================================================================
 
 /**
- * Register the Thenvoi channel with OpenClaw.
+ * Register the Band channel with OpenClaw.
  */
 export function registerChannel(api: OpenClawChannelApi): void {
   api.registerChannel({ plugin: thenvoiChannel });

--- a/packages/openclaw/src/channel.ts
+++ b/packages/openclaw/src/channel.ts
@@ -10,7 +10,7 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { ThenvoiLink } from "@thenvoi/sdk";
 import type { RoomPresence } from "@thenvoi/sdk/runtime";
-import { BoundedStringSet } from "./bounded-string-set.js";
+import { BoundedStringMap, BoundedStringSet } from "./bounded-string-set.js";
 import {
   listAccountIds,
   resolveAccount,
@@ -24,14 +24,6 @@ import { resolveOpenClawRuntimeDispatch, type OpenClawRuntimeDispatch } from "./
 import { redactSecrets } from "./redaction.js";
 
 export type { OpenClawInboundMessage } from "./message-utils.js";
-
-// =============================================================================
-// OpenClaw-Specific Types
-// =============================================================================
-
-// =============================================================================
-// Types for OpenClaw Plugin API
-// =============================================================================
 
 interface OpenClawChannelApi {
   registerChannel: (options: { plugin: OpenClawChannel }) => void;
@@ -113,10 +105,6 @@ interface MessagingHelpers {
   };
 }
 
-// =============================================================================
-// Channel State
-// =============================================================================
-
 // Global registry to track gateway state across module reloads.
 // All mutable state lives here so it survives Jiti reloading the module.
 // The key is versioned so that two different package versions loaded in
@@ -147,15 +135,14 @@ const toolEventContext = new AsyncLocalStorage<BandToolEventContext>();
 export interface BandToolEventContext {
   accountId: string;
   roomId: string;
-  sentMessage?: boolean;
 }
 
 interface GatewayRegistry {
   links: Map<string, ThenvoiLink>;
   presences: Map<string, RoomPresence>;
   startingAccounts: Set<string>;
-  lastSenderByThread: Map<string, { senderId: string; senderName: string; senderType?: string }>;
-  replyOwnerByThread: Map<string, { senderId: string; senderName: string }>;
+  lastSenderByThread: BoundedStringMap<{ senderId: string; senderName: string; senderType?: string }>;
+  replyOwnerByThread: BoundedStringMap<{ senderId: string; senderName: string }>;
   processedMessageIds: BoundedStringSet;
   deliverInbound: ((message: OpenClawInboundMessage) => void) | null;
   openclawRuntime: OpenClawRuntimeDispatch | null;
@@ -168,8 +155,8 @@ function getGatewayRegistry(): GatewayRegistry {
       links: new Map(),
       presences: new Map(),
       startingAccounts: new Set(),
-      lastSenderByThread: new Map(),
-      replyOwnerByThread: new Map(),
+      lastSenderByThread: new BoundedStringMap(MAX_SENDER_CACHE),
+      replyOwnerByThread: new BoundedStringMap(MAX_SENDER_CACHE),
       processedMessageIds: new BoundedStringSet(MAX_MESSAGE_DEDUPE_CACHE),
       deliverInbound: null,
       openclawRuntime: null,
@@ -196,11 +183,6 @@ function presences(): Map<string, RoomPresence> { return getGatewayRegistry().pr
 
 export function getBandToolEventContext(): BandToolEventContext | undefined {
   return toolEventContext.getStore();
-}
-
-export function recordBandMessageSentForCurrentTurn(): void {
-  const context = toolEventContext.getStore();
-  if (context) context.sentMessage = true;
 }
 
 function runWithBandToolEventContext<T>(context: BandToolEventContext, fn: () => Promise<T>): Promise<T> {
@@ -233,38 +215,18 @@ function createChannelLogger(accountId: string) {
   };
 }
 
-// Track last sender per thread for auto-mention fallback
-// Key: threadId, Value: { senderId, senderName }
 const MAX_SENDER_CACHE = 500;
 const MAX_MESSAGE_DEDUPE_CACHE = 2_000;
 
 function trackSender(accountId: string, threadId: string, senderId: string, senderName: string, senderType?: string): void {
-  const lastSenderByThread = registry().lastSenderByThread;
   const cacheKey = `${accountId}:${threadId}`;
-  // Delete-and-reinsert to move the entry to the end (LRU eviction order)
-  lastSenderByThread.delete(cacheKey);
-  if (lastSenderByThread.size >= MAX_SENDER_CACHE) {
-    // Evict least-recently-used entry (first key in Map insertion order)
-    const oldest = lastSenderByThread.keys().next().value;
-    if (oldest) lastSenderByThread.delete(oldest);
-  }
-  lastSenderByThread.set(cacheKey, { senderId, senderName, senderType });
+  registry().lastSenderByThread.set(cacheKey, { senderId, senderName, senderType });
 
   if (senderType?.toLowerCase() !== "agent") {
-    const replyOwnerByThread = registry().replyOwnerByThread;
-    replyOwnerByThread.delete(cacheKey);
-    if (replyOwnerByThread.size >= MAX_SENDER_CACHE) {
-      const oldest = replyOwnerByThread.keys().next().value;
-      if (oldest) replyOwnerByThread.delete(oldest);
-    }
-    replyOwnerByThread.set(cacheKey, { senderId, senderName });
+    registry().replyOwnerByThread.set(cacheKey, { senderId, senderName });
   }
 }
 
-/**
- * Set the OpenClaw runtime reference for message dispatch.
- * Called by the plugin entry point.
- */
 export function setOpenClawRuntime(runtime: unknown): void {
   const resolution = resolveOpenClawRuntimeDispatch(runtime);
   registry().openclawRuntime = resolution.dispatch;
@@ -276,22 +238,13 @@ export function setOpenClawRuntime(runtime: unknown): void {
   }
 }
 
-/**
- * Set the gateway callback for delivering inbound messages.
- * Called by OpenClaw when the channel is started.
- */
 export function setInboundCallback(
   callback: (message: OpenClawInboundMessage) => void,
 ): void {
   registry().deliverInbound = callback;
 }
 
-/**
- * Deliver an inbound message to OpenClaw.
- * Used by the service and runtime to send received messages to OpenClaw.
- */
 export function deliverMessage(message: OpenClawInboundMessage, accountId: string = "default"): void {
-  // Track the sender for auto-mention fallback when responding
   if (message.threadId && message.senderId && message.senderName) {
     trackSender(accountId, message.threadId, message.senderId, message.senderName, message.senderType);
   }
@@ -304,20 +257,8 @@ export function deliverMessage(message: OpenClawInboundMessage, accountId: strin
   }
 }
 
-// =============================================================================
-// Configuration Helpers
-// =============================================================================
-
-// =============================================================================
-// Mention Resolution
-// =============================================================================
-
 type Mention = { id: string; name?: string };
 
-/**
- * Resolve mentions for a message: find @Name in text, fall back to last sender, then any participant.
- * Returns null if no participants are available to mention (caller decides how to handle).
- */
 async function resolveMentions(
   rest: ThenvoiLink["rest"],
   agentId: string,
@@ -356,10 +297,6 @@ async function resolveMentions(
 
   return null;
 }
-
-// =============================================================================
-// Reply Helper
-// =============================================================================
 
 async function resolveFinalReplyMentions(
   rest: ThenvoiLink["rest"],
@@ -406,13 +343,6 @@ function gatewayHelpers(): GatewayHelpers {
   });
 }
 
-// =============================================================================
-// Outbound Send Helper
-// =============================================================================
-
-/**
- * Shared logic for sending an outbound message (text or media) to Band.
- */
 async function sendOutbound(ctx: OutboundContext): Promise<OutboundDeliveryResult> {
   const { text, to, accountId } = ctx;
   const roomId = to;
@@ -439,10 +369,6 @@ async function sendOutbound(ctx: OutboundContext): Promise<OutboundDeliveryResul
     roomId,
   };
 }
-
-// =============================================================================
-// Channel Definition
-// =============================================================================
 
 export const thenvoiChannel: OpenClawChannel = {
   id: "openclaw-channel-thenvoi",
@@ -532,7 +458,6 @@ export const thenvoiChannel: OpenClawChannel = {
 
   messaging: {
     targetResolver: {
-      // UUID pattern for Band room IDs
       looksLikeId: (raw: string): boolean => {
         const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
         return uuidPattern.test(raw.trim());
@@ -542,32 +467,15 @@ export const thenvoiChannel: OpenClawChannel = {
   },
 };
 
-// =============================================================================
-// Plugin Registration
-// =============================================================================
-
-/**
- * Register the Band channel with OpenClaw.
- */
 export function registerChannel(api: OpenClawChannelApi): void {
   api.registerChannel({ plugin: thenvoiChannel });
   console.log("[thenvoi] Channel registered");
 }
 
-// =============================================================================
-// Utility Exports (for MCP tools)
-// =============================================================================
-
-/**
- * Get the ThenvoiLink for an account.
- */
 export function getLink(accountId: string = "default"): ThenvoiLink | undefined {
   return links().get(accountId);
 }
 
-/**
- * Get the current agent's ID (UUID).
- */
 export function getAgentId(accountId: string = "default"): string | undefined {
   return links().get(accountId)?.agentId;
 }

--- a/packages/openclaw/src/config.ts
+++ b/packages/openclaw/src/config.ts
@@ -1,0 +1,80 @@
+import type { ContactEventConfig } from "@thenvoi/sdk";
+
+export interface ThenvoiAccountConfig {
+  enabled?: boolean;
+  apiKey?: string;
+  agentId?: string;
+  wsUrl?: string;
+  restUrl?: string;
+  contactConfig?: ContactEventConfig;
+  operatorId?: string;
+}
+
+export interface PluginConfig {
+  channels?: {
+    thenvoi?: {
+      accounts?: Record<string, ThenvoiAccountConfig>;
+    };
+    "openclaw-channel-thenvoi"?: {
+      accounts?: Record<string, ThenvoiAccountConfig>;
+    };
+  };
+  plugins?: {
+    entries?: {
+      thenvoi?: {
+        config?: {
+          accounts?: Record<string, ThenvoiAccountConfig>;
+        };
+      };
+      "openclaw-channel-thenvoi"?: {
+        config?: {
+          accounts?: Record<string, ThenvoiAccountConfig>;
+        };
+      };
+    };
+  };
+}
+
+export interface ResolvedThenvoiAccountConfig {
+  apiKey: string;
+  agentId: string;
+  wsUrl: string;
+  restUrl: string;
+}
+
+function configuredAccounts(config: PluginConfig): Record<string, ThenvoiAccountConfig> {
+  const pluginAccounts = config.plugins?.entries?.["openclaw-channel-thenvoi"]?.config?.accounts
+    ?? config.plugins?.entries?.thenvoi?.config?.accounts ?? {};
+  const channelAccounts = config.channels?.["openclaw-channel-thenvoi"]?.accounts
+    ?? config.channels?.thenvoi?.accounts ?? {};
+
+  return { ...pluginAccounts, ...channelAccounts };
+}
+
+function resolveEnvBackedValue(value: string | undefined, envName: string): string | undefined {
+  return value && value !== `\${${envName}}` ? value : process.env[envName];
+}
+
+export function listAccountIds(config: PluginConfig): string[] {
+  return Object.keys(configuredAccounts(config));
+}
+
+export function resolveAccount(config: PluginConfig, accountId?: string): ThenvoiAccountConfig {
+  return configuredAccounts(config)[accountId ?? "default"] ?? { enabled: true };
+}
+
+export function resolveAccountCredentials(account: ThenvoiAccountConfig): ResolvedThenvoiAccountConfig {
+  const apiKey = resolveEnvBackedValue(account.apiKey, "THENVOI_API_KEY");
+  const agentId = resolveEnvBackedValue(account.agentId, "THENVOI_AGENT_ID");
+  const wsUrl = resolveEnvBackedValue(account.wsUrl, "THENVOI_WS_URL") ?? "wss://app.band.ai/api/v1/socket";
+  const restUrl = resolveEnvBackedValue(account.restUrl, "THENVOI_REST_URL") ?? "https://app.band.ai";
+
+  if (!apiKey) {
+    throw new Error("THENVOI_API_KEY is required");
+  }
+  if (!agentId) {
+    throw new Error("THENVOI_AGENT_ID is required");
+  }
+
+  return { apiKey, agentId, wsUrl, restUrl };
+}

--- a/packages/openclaw/src/gateway.ts
+++ b/packages/openclaw/src/gateway.ts
@@ -112,7 +112,6 @@ export function createGatewayHelpers(options: GatewayRuntimeOptions): GatewayHel
           const roomId = event.roomId ?? event.payload.chat_room_id;
           const dedupeKey = roomId && messageId ? `${accountId}:${roomId}:${messageId}` : undefined;
           if (dedupeKey && options.processedMessageIds.has(dedupeKey)) return;
-          if (dedupeKey) options.processedMessageIds.add(dedupeKey);
 
           const message = platformEventToInboundMessage(event);
           if (!message) return;
@@ -125,6 +124,8 @@ export function createGatewayHelpers(options: GatewayRuntimeOptions): GatewayHel
             }
           }
 
+          let handled = false;
+          let failure: unknown;
           const dispatch = options.getOpenClawRuntime();
           if (dispatch) {
             try {
@@ -172,19 +173,31 @@ export function createGatewayHelpers(options: GatewayRuntimeOptions): GatewayHel
                 dispatcher,
               }));
               await dispatcher.waitForIdle();
+              handled = true;
               console.log(`[thenvoi:${accountId}] Message dispatched successfully`);
             } catch (error) {
+              failure = error;
               console.error(`[thenvoi:${accountId}] Failed to dispatch message: ${redactSecrets(error)}`);
             }
           } else {
             options.deliverMessage(message, accountId);
+            handled = true;
           }
 
           if (roomId && messageId) {
-            try {
-              await link.markProcessed(roomId, messageId, { bestEffort: true });
-            } catch {
-              // Best effort - don't fail if marking fails
+            if (handled) {
+              try {
+                await link.markProcessed(roomId, messageId, { bestEffort: true });
+              } catch {
+                // Best effort - don't fail if marking fails
+              }
+              if (dedupeKey) options.processedMessageIds.add(dedupeKey);
+            } else {
+              try {
+                await link.markFailed(roomId, messageId, redactSecrets(failure), { bestEffort: true });
+              } catch {
+                // Best effort - don't fail if marking fails
+              }
             }
           }
         }
@@ -197,9 +210,7 @@ export function createGatewayHelpers(options: GatewayRuntimeOptions): GatewayHel
               try {
                 next = await link.rest.getNextMessage({ chatId: roomId });
               } catch (error) {
-                console.warn(`[thenvoi:${accountId}] Failed to fetch pending message for room ${roomId}; pruning room from local tracking: ${redactSecrets(error)}`);
-                presence.rooms.delete(roomId);
-                try { await link.unsubscribeRoom(roomId); } catch { /* best effort */ }
+                console.warn(`[thenvoi:${accountId}] Failed to fetch pending message for room ${roomId}; retrying on the next recovery sweep: ${redactSecrets(error)}`);
                 return;
               }
               if (!next) break;
@@ -299,14 +310,16 @@ export function createGatewayHelpers(options: GatewayRuntimeOptions): GatewayHel
                 return;
               }
 
+              const hubTurnContext: BandToolEventContext = { accountId, roomId: hubRoomId };
               const dispatcher = createBandReplyDispatcher(
                 link,
                 accountId,
                 hubRoomId,
                 () => options.resolveFinalReplyMentions(link.rest, link.agentId, accountId, hubRoomId),
+                hubTurnContext,
               );
               const cfg = dispatch.loadConfig();
-              await options.runWithBandToolEventContext({ accountId, roomId: hubRoomId }, async () => dispatch.dispatchReplyFromConfig({
+              await options.runWithBandToolEventContext(hubTurnContext, async () => dispatch.dispatchReplyFromConfig({
                 ctx: {
                   Body: message.text,
                   RawBody: message.text,

--- a/packages/openclaw/src/gateway.ts
+++ b/packages/openclaw/src/gateway.ts
@@ -1,0 +1,382 @@
+import { ThenvoiLink } from "@thenvoi/sdk";
+import {
+  ContactEventHandler,
+  HUB_ROOM_SYSTEM_PROMPT,
+  RoomPresence,
+} from "@thenvoi/sdk/runtime";
+import type { ContactEvent, PlatformEvent } from "@thenvoi/sdk";
+import type { BoundedStringSet } from "./bounded-string-set.js";
+import { resolveAccountCredentials, type ThenvoiAccountConfig } from "./config.js";
+import {
+  buildOpenClawBody,
+  messageInsertedAt,
+  messageMentionsAgent,
+  platformEventToInboundMessage,
+  type OpenClawInboundMessage,
+} from "./message-utils.js";
+import type { OpenClawRuntimeDispatch } from "./openclaw-runtime.js";
+import { createBandReplyDispatcher, createNoopReplyDispatcher } from "./reply-dispatcher.js";
+import { redactSecrets } from "./redaction.js";
+
+const CONTACTS_THREAD_ID = "__thenvoi_contacts__";
+const ROOM_RECOVERY_SWEEP_INTERVAL_MS = 10_000;
+const STARTUP_MESSAGE_GRACE_MS = 5_000;
+
+export interface GatewayContext {
+  cfg: unknown;
+  accountId: string;
+  account: ThenvoiAccountConfig;
+  abortSignal: AbortSignal;
+}
+
+export interface GatewayHelpers {
+  startAccount: (ctx: GatewayContext) => Promise<void>;
+  stopAccount: (ctx: GatewayContext) => Promise<void>;
+}
+
+interface BandToolEventContext {
+  accountId: string;
+  roomId: string;
+  sentMessage?: boolean;
+}
+
+interface GatewayRuntimeOptions {
+  links: Map<string, ThenvoiLink>;
+  presences: Map<string, RoomPresence>;
+  startingAccounts: Set<string>;
+  processedMessageIds: BoundedStringSet;
+  getOpenClawRuntime: () => OpenClawRuntimeDispatch | null;
+  createLogger: (accountId: string) => ConstructorParameters<typeof RoomPresence>[0]["logger"];
+  deliverMessage: (message: OpenClawInboundMessage, accountId?: string) => void;
+  trackSender: (accountId: string, threadId: string, senderId: string, senderName: string, senderType?: string) => void;
+  resolveFinalReplyMentions: (rest: ThenvoiLink["rest"], agentId: string, accountId: string, roomId: string) => Promise<Array<{ id: string; name?: string }>>;
+  runWithBandToolEventContext: <T>(context: BandToolEventContext, fn: () => Promise<T>) => Promise<T>;
+}
+
+export function createGatewayHelpers(options: GatewayRuntimeOptions): GatewayHelpers {
+  return {
+    startAccount: async (ctx: GatewayContext): Promise<void> => {
+      const { accountId, account: accountConfig } = ctx;
+
+      if (options.startingAccounts.has(accountId)) {
+        console.warn(`[thenvoi:${accountId}] startAccount already in progress, skipping`);
+        return;
+      }
+      options.startingAccounts.add(accountId);
+
+      try {
+        console.log(`[thenvoi:${accountId}] Starting gateway...`);
+        const accountStartedAt = Date.now();
+
+        if (options.links.has(accountId)) {
+          console.log(`[thenvoi:${accountId}] Disconnecting previous connection before restart...`);
+          const existingPresence = options.presences.get(accountId);
+          if (existingPresence) {
+            await existingPresence.stop();
+            options.presences.delete(accountId);
+          }
+          const existingLink = options.links.get(accountId);
+          if (existingLink) {
+            await existingLink.disconnect();
+          }
+          options.links.delete(accountId);
+        }
+
+        const config = resolveAccountCredentials(accountConfig);
+        const logger = options.createLogger(accountId);
+        const link = new ThenvoiLink({
+          agentId: config.agentId,
+          apiKey: config.apiKey,
+          wsUrl: config.wsUrl,
+          restUrl: config.restUrl,
+          logger,
+        });
+        options.links.set(accountId, link);
+        console.log(`[thenvoi:${accountId}] Link created`);
+
+        await link.connect();
+        console.log(`[thenvoi:${accountId}] WebSocket connected`);
+
+        const presence = new RoomPresence({
+          link,
+          autoSubscribeExistingRooms: true,
+          recoverySweepIntervalMs: ROOM_RECOVERY_SWEEP_INTERVAL_MS,
+          logger,
+        });
+
+        async function handleMessageEvent(event: PlatformEvent): Promise<void> {
+          if (event.type !== "message_created") return;
+          if (event.payload.sender_id === config.agentId) return;
+
+          const messageId = event.payload.id;
+          const roomId = event.roomId ?? event.payload.chat_room_id;
+          const dedupeKey = roomId && messageId ? `${accountId}:${roomId}:${messageId}` : undefined;
+          if (dedupeKey && options.processedMessageIds.has(dedupeKey)) return;
+          if (dedupeKey) options.processedMessageIds.add(dedupeKey);
+
+          const message = platformEventToInboundMessage(event);
+          if (!message) return;
+
+          if (roomId && messageId) {
+            try {
+              await link.markProcessing(roomId, messageId, { bestEffort: true });
+            } catch {
+              // Best effort - don't fail if marking fails
+            }
+          }
+
+          const dispatch = options.getOpenClawRuntime();
+          if (dispatch) {
+            try {
+              if (message.threadId && message.senderId && message.senderName) {
+                options.trackSender(accountId, message.threadId, message.senderId, message.senderName, message.senderType);
+              }
+
+              const body = buildOpenClawBody(message);
+              const inboundCtx = {
+                Body: body,
+                RawBody: body,
+                BodyForCommands: body,
+                CommandBody: body,
+                From: message.senderId,
+                SenderId: message.senderId,
+                SenderName: message.senderName,
+                SenderType: message.senderType,
+                To: message.threadId,
+                SessionKey: `thenvoi:${message.threadId}`,
+                Surface: "thenvoi",
+                Provider: "thenvoi",
+                MessageSid: (message.metadata as Record<string, unknown>)?.messageId,
+                Timestamp: message.timestamp ? new Date(message.timestamp).getTime() : Date.now(),
+                ChatType: "group",
+                CommandAuthorized: true,
+                BandOperatorId: accountConfig.operatorId,
+              };
+
+              const bandTurnContext: BandToolEventContext = { accountId, roomId: message.threadId };
+              const dispatcher = message.threadId === CONTACTS_THREAD_ID
+                ? createNoopReplyDispatcher()
+                : createBandReplyDispatcher(
+                  link,
+                  accountId,
+                  message.threadId,
+                  () => options.resolveFinalReplyMentions(link.rest, link.agentId, accountId, message.threadId),
+                  bandTurnContext,
+                );
+
+              console.log(`[thenvoi:${accountId}] Dispatching message to OpenClaw agent...`);
+              const cfg = dispatch.loadConfig();
+              await options.runWithBandToolEventContext(bandTurnContext, async () => dispatch.dispatchReplyFromConfig({
+                ctx: inboundCtx,
+                cfg,
+                dispatcher,
+              }));
+              await dispatcher.waitForIdle();
+              console.log(`[thenvoi:${accountId}] Message dispatched successfully`);
+            } catch (error) {
+              console.error(`[thenvoi:${accountId}] Failed to dispatch message: ${redactSecrets(error)}`);
+            }
+          } else {
+            options.deliverMessage(message, accountId);
+          }
+
+          if (roomId && messageId) {
+            try {
+              await link.markProcessed(roomId, messageId, { bestEffort: true });
+            } catch {
+              // Best effort - don't fail if marking fails
+            }
+          }
+        }
+
+        async function catchUpMentionedMessages(roomId: string): Promise<void> {
+          if (typeof link.rest.getNextMessage === "function") {
+            const seenPendingIds = new Set<string>();
+            for (let drained = 0; drained < 25; drained += 1) {
+              let next;
+              try {
+                next = await link.rest.getNextMessage({ chatId: roomId });
+              } catch (error) {
+                console.warn(`[thenvoi:${accountId}] Failed to fetch pending message for room ${roomId}; pruning room from local tracking: ${redactSecrets(error)}`);
+                presence.rooms.delete(roomId);
+                try { await link.unsubscribeRoom(roomId); } catch { /* best effort */ }
+                return;
+              }
+              if (!next) break;
+              if (seenPendingIds.has(next.id)) {
+                console.warn(`[thenvoi:${accountId}] Pending message ${next.id} repeated for room ${roomId}; stopping catch-up drain`);
+                break;
+              }
+              seenPendingIds.add(next.id);
+
+              const insertedAt = messageInsertedAt(next as unknown as Record<string, unknown>);
+              if (!insertedAt || insertedAt < accountStartedAt - STARTUP_MESSAGE_GRACE_MS) {
+                console.log(`[thenvoi:${accountId}] Skipping stale pending message in room ${roomId}`);
+                try { await link.markProcessing(roomId, next.id, { bestEffort: true }); } catch { /* best effort */ }
+                try { await link.markProcessed(roomId, next.id, { bestEffort: true }); } catch { /* best effort */ }
+                continue;
+              }
+              if (next.sender_id === config.agentId) {
+                try { await link.markProcessing(roomId, next.id, { bestEffort: true }); } catch { /* best effort */ }
+                try { await link.markProcessed(roomId, next.id, { bestEffort: true }); } catch { /* best effort */ }
+                continue;
+              }
+              if (next.message_type !== "text") {
+                try { await link.markProcessing(roomId, next.id, { bestEffort: true }); } catch { /* best effort */ }
+                try { await link.markProcessed(roomId, next.id, { bestEffort: true }); } catch { /* best effort */ }
+                continue;
+              }
+              console.log(`[thenvoi:${accountId}] Catching up pending mentioned message in room ${roomId}`);
+              await handleMessageEvent({
+                type: "message_created",
+                roomId,
+                payload: {
+                  id: next.id,
+                  chat_room_id: roomId,
+                  sender_id: next.sender_id,
+                  sender_type: next.sender_type,
+                  sender_name: next.sender_name,
+                  content: next.content,
+                  message_type: next.message_type,
+                  inserted_at: next.inserted_at,
+                  metadata: next.metadata ?? {},
+                },
+              } as PlatformEvent);
+            }
+            return;
+          }
+
+          if (typeof link.rest.listMessages !== "function") return;
+          const response = await link.rest.listMessages({ chatId: roomId, page: 1, pageSize: 10 });
+          const messages = Array.isArray(response.data) ? response.data : [];
+          for (const payload of ([...messages].reverse() as unknown as Record<string, unknown>[])) {
+            if (payload.sender_id === config.agentId) continue;
+            if (payload.message_type !== "text") continue;
+            const insertedAt = messageInsertedAt(payload);
+            if (!insertedAt || insertedAt < accountStartedAt - STARTUP_MESSAGE_GRACE_MS) continue;
+            if (!messageMentionsAgent(payload, config.agentId)) continue;
+            console.log(`[thenvoi:${accountId}] Catching up mentioned message in room ${roomId}`);
+            await handleMessageEvent({ type: "message_created", roomId, payload } as PlatformEvent);
+          }
+        }
+
+        presence.onRoomJoined = async (roomId: string, payload: Record<string, unknown>) => {
+          const title = (payload.title as string) ?? roomId;
+          console.log(`[thenvoi:${accountId}] Joined room: ${title} (${roomId})`);
+          await catchUpMentionedMessages(roomId);
+        };
+
+        presence.onRoomLeft = async (roomId: string) => {
+          console.log(`[thenvoi:${accountId}] Left room: ${roomId}`);
+        };
+
+        presence.onRoomEvent = async (_roomId: string, event: PlatformEvent) => {
+          await handleMessageEvent(event);
+        };
+
+        const contactConfig = accountConfig.contactConfig ?? { strategy: "disabled" };
+        const contactHandler = contactConfig.strategy && contactConfig.strategy !== "disabled"
+          ? new ContactEventHandler({
+            config: contactConfig,
+            rest: link.rest,
+            onBroadcast: (msg: string) => {
+              console.log(`[thenvoi:${accountId}] Contact broadcast: ${msg}`);
+            },
+            onHubInit: async (hubRoomId: string, systemPrompt: string) => {
+              await link.rest.createChatEvent(hubRoomId, {
+                content: systemPrompt,
+                messageType: "system",
+                metadata: { source: "openclaw", prompt: HUB_ROOM_SYSTEM_PROMPT },
+              });
+            },
+            onHubEvent: async (hubRoomId: string, event: PlatformEvent) => {
+              const message = platformEventToInboundMessage({ ...event, roomId: hubRoomId } as PlatformEvent);
+              if (!message) return;
+
+              const dispatch = options.getOpenClawRuntime();
+              if (!dispatch) {
+                options.deliverMessage(message, accountId);
+                return;
+              }
+
+              const dispatcher = createBandReplyDispatcher(
+                link,
+                accountId,
+                hubRoomId,
+                () => options.resolveFinalReplyMentions(link.rest, link.agentId, accountId, hubRoomId),
+              );
+              const cfg = dispatch.loadConfig();
+              await options.runWithBandToolEventContext({ accountId, roomId: hubRoomId }, async () => dispatch.dispatchReplyFromConfig({
+                ctx: {
+                  Body: message.text,
+                  RawBody: message.text,
+                  BodyForCommands: message.text,
+                  CommandBody: message.text,
+                  From: message.senderId,
+                  SenderId: message.senderId,
+                  SenderName: message.senderName,
+                  To: hubRoomId,
+                  SessionKey: `thenvoi:${hubRoomId}`,
+                  Surface: "thenvoi",
+                  Provider: "thenvoi",
+                  MessageSid: (message.metadata as Record<string, unknown>)?.messageId,
+                  Timestamp: message.timestamp ? new Date(message.timestamp).getTime() : Date.now(),
+                  ChatType: "group",
+                  CommandAuthorized: true,
+                  BandContactHub: true,
+                  BandOperatorId: accountConfig.operatorId,
+                },
+                cfg,
+                dispatcher,
+              }));
+              await dispatcher.waitForIdle();
+            },
+          })
+          : null;
+
+        presence.onContactEvent = async (event: ContactEvent) => {
+          if (!contactHandler) return;
+          try {
+            console.log(`[thenvoi:${accountId}] Contact event: ${event.type}`);
+            await contactHandler.handle(event);
+          } catch (error) {
+            console.error(`[thenvoi:${accountId}] Failed to handle contact event: ${redactSecrets(error)}`);
+          }
+        };
+
+        options.presences.set(accountId, presence);
+        await presence.start();
+        console.log(`[thenvoi:${accountId}] Connected to Band platform`);
+
+        if (!ctx.abortSignal.aborted) {
+          await new Promise<void>((resolve) => {
+            ctx.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+          });
+        }
+
+        console.log(`[thenvoi:${accountId}] Shutdown signal received`);
+      } finally {
+        options.startingAccounts.delete(accountId);
+      }
+    },
+
+    stopAccount: async (ctx: GatewayContext): Promise<void> => {
+      const { accountId } = ctx;
+      options.startingAccounts.delete(accountId);
+
+      const presence = options.presences.get(accountId);
+      if (presence) {
+        await presence.stop();
+        options.presences.delete(accountId);
+      }
+
+      const link = options.links.get(accountId);
+      if (link) {
+        await link.disconnect();
+        options.links.delete(accountId);
+      }
+
+      console.log(`[thenvoi:${accountId}] Disconnected from Band platform`);
+    },
+  };
+}

--- a/packages/openclaw/src/gateway.ts
+++ b/packages/openclaw/src/gateway.ts
@@ -162,7 +162,6 @@ export function createGatewayHelpers(options: GatewayRuntimeOptions): GatewayHel
                   accountId,
                   message.threadId,
                   () => options.resolveFinalReplyMentions(link.rest, link.agentId, accountId, message.threadId),
-                  bandTurnContext,
                 );
 
               console.log(`[thenvoi:${accountId}] Dispatching message to OpenClaw agent...`);
@@ -316,7 +315,6 @@ export function createGatewayHelpers(options: GatewayRuntimeOptions): GatewayHel
                 accountId,
                 hubRoomId,
                 () => options.resolveFinalReplyMentions(link.rest, link.agentId, accountId, hubRoomId),
-                hubTurnContext,
               );
               const cfg = dispatch.loadConfig();
               await options.runWithBandToolEventContext(hubTurnContext, async () => dispatch.dispatchReplyFromConfig({

--- a/packages/openclaw/src/gateway.ts
+++ b/packages/openclaw/src/gateway.ts
@@ -37,7 +37,6 @@ export interface GatewayHelpers {
 interface BandToolEventContext {
   accountId: string;
   roomId: string;
-  sentMessage?: boolean;
 }
 
 interface GatewayRuntimeOptions {

--- a/packages/openclaw/src/gateway.ts
+++ b/packages/openclaw/src/gateway.ts
@@ -9,7 +9,6 @@ import type { BoundedStringSet } from "./bounded-string-set.js";
 import { resolveAccountCredentials, type ThenvoiAccountConfig } from "./config.js";
 import {
   buildOpenClawBody,
-  messageInsertedAt,
   messageMentionsAgent,
   platformEventToInboundMessage,
   type OpenClawInboundMessage,
@@ -20,7 +19,6 @@ import { redactSecrets } from "./redaction.js";
 
 const CONTACTS_THREAD_ID = "__thenvoi_contacts__";
 const ROOM_RECOVERY_SWEEP_INTERVAL_MS = 10_000;
-const STARTUP_MESSAGE_GRACE_MS = 5_000;
 
 export interface GatewayContext {
   cfg: unknown;
@@ -65,7 +63,6 @@ export function createGatewayHelpers(options: GatewayRuntimeOptions): GatewayHel
 
       try {
         console.log(`[thenvoi:${accountId}] Starting gateway...`);
-        const accountStartedAt = Date.now();
 
         if (options.links.has(accountId)) {
           console.log(`[thenvoi:${accountId}] Disconnecting previous connection before restart...`);
@@ -218,13 +215,6 @@ export function createGatewayHelpers(options: GatewayRuntimeOptions): GatewayHel
               }
               seenPendingIds.add(next.id);
 
-              const insertedAt = messageInsertedAt(next as unknown as Record<string, unknown>);
-              if (!insertedAt || insertedAt < accountStartedAt - STARTUP_MESSAGE_GRACE_MS) {
-                console.log(`[thenvoi:${accountId}] Skipping stale pending message in room ${roomId}`);
-                try { await link.markProcessing(roomId, next.id, { bestEffort: true }); } catch { /* best effort */ }
-                try { await link.markProcessed(roomId, next.id, { bestEffort: true }); } catch { /* best effort */ }
-                continue;
-              }
               if (next.sender_id === config.agentId) {
                 try { await link.markProcessing(roomId, next.id, { bestEffort: true }); } catch { /* best effort */ }
                 try { await link.markProcessed(roomId, next.id, { bestEffort: true }); } catch { /* best effort */ }
@@ -261,8 +251,6 @@ export function createGatewayHelpers(options: GatewayRuntimeOptions): GatewayHel
           for (const payload of ([...messages].reverse() as unknown as Record<string, unknown>[])) {
             if (payload.sender_id === config.agentId) continue;
             if (payload.message_type !== "text") continue;
-            const insertedAt = messageInsertedAt(payload);
-            if (!insertedAt || insertedAt < accountStartedAt - STARTUP_MESSAGE_GRACE_MS) continue;
             if (!messageMentionsAgent(payload, config.agentId)) continue;
             console.log(`[thenvoi:${accountId}] Catching up mentioned message in room ${roomId}`);
             await handleMessageEvent({ type: "message_created", roomId, payload } as PlatformEvent);

--- a/packages/openclaw/src/index.ts
+++ b/packages/openclaw/src/index.ts
@@ -1,15 +1,62 @@
 /**
- * OpenClaw Channel Plugin for Thenvoi.
+ * OpenClaw Channel Plugin for Band.
  *
- * This plugin enables OpenClaw agents to connect to the Thenvoi platform,
+ * This plugin enables OpenClaw agents to connect to Band,
  * using @thenvoi/sdk for all platform communication.
  *
  * @packageDocumentation
  */
 
-import { registerChannel, thenvoiChannel, setInboundCallback, setOpenClawRuntime } from "./channel.js";
+import { registerChannel, thenvoiChannel, setInboundCallback, setOpenClawRuntime, getBandToolEventContext, getLink } from "./channel.js";
 import { getMcpToolSchemas, executeMcpTool } from "./mcp-tools.js";
 import { BASE_INSTRUCTIONS } from "./prompts.js";
+import { redactSecrets } from "./redaction.js";
+
+// =============================================================================
+// Band Tool Event Reporting
+// =============================================================================
+
+function toolEventText(value: unknown): string {
+  try {
+    return redactSecrets(JSON.stringify(value, null, 2));
+  } catch {
+    return redactSecrets(value);
+  }
+}
+
+function toolCallIdText(toolCallId: unknown): string | undefined {
+  if (toolCallId === undefined || toolCallId === null) return undefined;
+  return String(toolCallId);
+}
+
+async function sendBandToolEvent(
+  messageType: "tool_call" | "tool_result",
+  toolName: string,
+  toolCallId: unknown,
+  value: unknown,
+  status?: "success" | "error",
+): Promise<void> {
+  const context = getBandToolEventContext();
+  if (!context) return;
+  const link = getLink(context.accountId);
+  if (!link) return;
+
+  const metadata: Record<string, unknown> = { source: "openclaw", toolName };
+  const id = toolCallIdText(toolCallId);
+  if (id) metadata.toolCallId = id;
+  if (status) metadata.status = status;
+
+  const label = messageType === "tool_call" ? "Tool call" : "Tool result";
+  try {
+    await link.rest.createChatEvent(context.roomId, {
+      content: `${label}: ${toolName}\n${toolEventText(value)}`,
+      messageType,
+      metadata,
+    });
+  } catch (error) {
+    console.warn(`[thenvoi] Failed to report ${messageType} for ${toolName}: ${redactSecrets(error)}`);
+  }
+}
 
 // =============================================================================
 // Plugin Entry Point
@@ -82,18 +129,22 @@ export default function plugin(api: OpenClawPluginApi): void {
         description: tool.description,
         parameters: tool.inputSchema,
         execute: async (_toolCallId: unknown, input: unknown) => {
+          const toolInput = input ?? {};
           console.log(`[thenvoi] Executing tool ${tool.name}`);
+          await sendBandToolEvent("tool_call", tool.name, _toolCallId, toolInput);
           try {
-            const result = await executeMcpTool(tool.name, input ?? {});
+            const result = await executeMcpTool(tool.name, toolInput);
             const resultStr = JSON.stringify(result, null, 2);
             console.log(`[thenvoi] Tool ${tool.name} completed`);
+            await sendBandToolEvent("tool_result", tool.name, _toolCallId, result, "success");
 
             return {
               content: [{ type: "text", text: resultStr }],
               details: result,
             };
           } catch (error) {
-            console.error(`[thenvoi] Tool ${tool.name} error:`, error);
+            console.error(`[thenvoi] Tool ${tool.name} error: ${redactSecrets(error)}`);
+            await sendBandToolEvent("tool_result", tool.name, _toolCallId, { error: redactSecrets(error) }, "error");
             throw error;
           }
         },
@@ -105,7 +156,7 @@ export default function plugin(api: OpenClawPluginApi): void {
     console.warn("[thenvoi] Available API methods:", Object.keys(api));
   }
 
-  // Register before_agent_start hook to inject Thenvoi instructions + room context
+  // Register before_agent_start hook to inject Band room context
   if (api.on) {
     api.on("before_agent_start", (_event, ctx) => {
       console.log(`[thenvoi] before_agent_start hook called (messageProvider=${ctx.messageProvider}, sessionKey=${ctx.sessionKey})`);
@@ -115,7 +166,7 @@ export default function plugin(api: OpenClawPluginApi): void {
 
       let prependContext = BASE_INSTRUCTIONS;
       if (roomId) {
-        prependContext += `\n\n## Current Thenvoi Room\n\n**Your current room_id is: \`${roomId}\`**\nUse this value for any tool parameter that asks for \`room_id\`. Do NOT use any other UUID.`;
+        prependContext += `\n\n## Current Band Room\n\n**Your current room_id is: \`${roomId}\`**\nUse this value for any tool parameter that asks for \`room_id\`. Do NOT use any other UUID.`;
       }
 
       return { prependContext };
@@ -140,7 +191,8 @@ export { thenvoiChannel, registerChannel, setInboundCallback, deliverMessage } f
 export { getLink, getAgentId, resetGatewayRegistry } from "./channel.js";
 
 // OpenClaw-specific type exports
-export type { ThenvoiAccountConfig, OpenClawInboundMessage } from "./channel.js";
+export type { OpenClawInboundMessage } from "./channel.js";
+export type { ThenvoiAccountConfig } from "./config.js";
 
 // MCP tool exports
 export { mcpTools, getMcpToolSchemas, executeMcpTool, getMcpTool } from "./mcp-tools.js";

--- a/packages/openclaw/src/mcp-tools.ts
+++ b/packages/openclaw/src/mcp-tools.ts
@@ -5,7 +5,7 @@
  * for use by OpenClaw agents. Uses @thenvoi/sdk REST API.
  */
 
-import { getLink, getAgentId, getBandToolEventContext, recordBandMessageSentForCurrentTurn } from "./channel.js";
+import { getLink, getAgentId, getBandToolEventContext } from "./channel.js";
 
 // =============================================================================
 // MCP Tool Types (local to this module)
@@ -474,7 +474,6 @@ const sendMessageTool: McpTool = {
       content,
       mentions: resolvedMentions,
     });
-    recordBandMessageSentForCurrentTurn();
 
     return {
       success: true,

--- a/packages/openclaw/src/mcp-tools.ts
+++ b/packages/openclaw/src/mcp-tools.ts
@@ -1,11 +1,11 @@
 /**
- * MCP Tools for Thenvoi platform operations.
+ * MCP Tools for Band platform operations.
  *
- * Exposes Thenvoi platform tools via MCP (Model Context Protocol)
+ * Exposes Band platform tools via MCP (Model Context Protocol)
  * for use by OpenClaw agents. Uses @thenvoi/sdk REST API.
  */
 
-import { getLink, getAgentId } from "./channel.js";
+import { getLink, getAgentId, getBandToolEventContext, recordBandMessageSentForCurrentTurn } from "./channel.js";
 
 // =============================================================================
 // MCP Tool Types (local to this module)
@@ -53,12 +53,25 @@ interface McpProperty {
 // Helper: get REST API from link
 // =============================================================================
 
-function getRest() {
-  const link = getLink();
+function currentAccountId(): string {
+  return getBandToolEventContext()?.accountId ?? "default";
+}
+
+function getCurrentLink() {
+  const accountId = currentAccountId();
+  const link = getLink(accountId);
   if (!link) {
-    throw new Error("Thenvoi client not connected");
+    throw new Error(`Thenvoi client not connected for account ${accountId}`);
   }
-  return link.rest;
+  return link;
+}
+
+function getRest() {
+  return getCurrentLink().rest;
+}
+
+function getSelfAgentId(): string | undefined {
+  return getAgentId(currentAccountId());
 }
 
 /**
@@ -93,7 +106,7 @@ function clampPagination(page: number, pageSize: number): { page: number; pageSi
 const lookupPeersTool: McpTool = {
   name: "thenvoi_lookup_peers",
   description:
-    "Find available agents and users on the Thenvoi platform. " +
+    "Find available agents and users on the Band platform. " +
     "Use this to discover who you can invite to collaborate.",
   inputSchema: {
     type: "object",
@@ -138,7 +151,7 @@ const lookupPeersTool: McpTool = {
 const addParticipantTool: McpTool = {
   name: "thenvoi_add_participant",
   description:
-    "Invite an agent or user to join a Thenvoi chat room. " +
+    "Invite an agent or user to join a Band chat room. " +
     "Use lookup_peers first to find available participants. " +
     "IMPORTANT: room_id must be the To field from your message context — do NOT use agent IDs, user IDs, or owner IDs.",
   inputSchema: {
@@ -223,7 +236,7 @@ const addParticipantTool: McpTool = {
 
 const removeParticipantTool: McpTool = {
   name: "thenvoi_remove_participant",
-  description: "Remove an agent or user from a Thenvoi chat room.",
+  description: "Remove an agent or user from a Band chat room.",
   inputSchema: {
     type: "object",
     properties: {
@@ -254,7 +267,7 @@ const removeParticipantTool: McpTool = {
         throw new Error("Either name or participant_id is required");
       }
       // Resolve name to ID via the room's participant list
-      const selfAgentId = getAgentId();
+      const selfAgentId = getSelfAgentId();
       const participants = await rest.listChatParticipants(room_id);
       const match = participants.find(
         (p) => p.name.toLowerCase() === name.toLowerCase() && p.id !== selfAgentId
@@ -283,7 +296,7 @@ const removeParticipantTool: McpTool = {
 
 const getParticipantsTool: McpTool = {
   name: "thenvoi_get_participants",
-  description: "List all participants in a Thenvoi chat room.",
+  description: "List all participants in a Band chat room.",
   inputSchema: {
     type: "object",
     properties: {
@@ -318,7 +331,7 @@ const getParticipantsTool: McpTool = {
 const createChatTool: McpTool = {
   name: "thenvoi_create_chatroom",
   description:
-    "Create a new Thenvoi chat room for collaboration. " +
+    "Create a new Band chat room for collaboration. " +
     "Use this when you need a fresh space for a new task or conversation.",
   inputSchema: {
     type: "object",
@@ -350,7 +363,7 @@ const createChatTool: McpTool = {
 const sendEventTool: McpTool = {
   name: "thenvoi_send_event",
   description:
-    "Share events with other participants in a Thenvoi chat room. " +
+    "Share events with other participants in a Band chat room. " +
     "Event types: " +
     "'thought' - share your reasoning process (shows thinking indicator), " +
     "'error' - report problems or failures (shows error indicator), " +
@@ -407,9 +420,9 @@ const sendEventTool: McpTool = {
 const sendMessageTool: McpTool = {
   name: "thenvoi_send_message",
   description:
-    "Send a message to a Thenvoi chat room. " +
-    "Messages require at least one @mention. Use this to respond to users or other agents. " +
-    "IMPORTANT: You MUST use this tool to communicate - plain text responses won't reach users.",
+    "Send a message to a Band chat room when you need another participant to act next. " +
+    "Messages require at least one @mention. Use this for handoffs or delegation to other users or agents, including handing a result back to the original human requester after another agent helped. " +
+    "Never mention yourself, and mention only the participant who should act next.",
   inputSchema: {
     type: "object",
     properties: {
@@ -425,8 +438,8 @@ const sendMessageTool: McpTool = {
         type: "array",
         items: { type: "string" },
         description:
-          "List of participant names to @mention. At least one required. " +
-          "Use thenvoi_get_participants to see available participants.",
+          "List of participant UUIDs to @mention. At least one required. " +
+          "Use thenvoi_get_participants to get participant IDs. Mention only the participant who should act next, and never mention yourself.",
       },
     },
     required: ["room_id", "content", "mentions"],
@@ -439,20 +452,20 @@ const sendMessageTool: McpTool = {
       throw new Error("At least one mention is required to send a message");
     }
 
-    const selfAgentId = getAgentId();
+    const selfAgentId = getSelfAgentId();
 
-    // Get participants to resolve names to IDs
+    // Get participants to validate UUID mentions and map them to display names.
     const participants = await rest.listChatParticipants(room_id);
 
-    // Resolve mention names to participant objects
-    const resolvedMentions = mentions.map((name) => {
-      const participant = participants.find(
-        (p) => p.name.toLowerCase() === name.toLowerCase() && p.id !== selfAgentId
-      );
+    const resolvedMentions = mentions.map((mentionId) => {
+      const participant = participants.find((p) => p.id === mentionId);
       if (!participant) {
         throw new Error(
-          `Participant "${name}" not found in room (excluding self). Use thenvoi_get_participants to see available participants.`
+          `Participant ID "${mentionId}" not found in room. Use thenvoi_get_participants to see valid participant UUIDs.`
         );
+      }
+      if (participant.id === selfAgentId) {
+        throw new Error("You cannot mention yourself. Use plain text to reply to the current sender, or mention a different participant who should act next.");
       }
       return { id: participant.id, name: participant.name };
     });
@@ -461,6 +474,7 @@ const sendMessageTool: McpTool = {
       content,
       mentions: resolvedMentions,
     });
+    recordBandMessageSentForCurrentTurn();
 
     return {
       success: true,

--- a/packages/openclaw/src/message-utils.ts
+++ b/packages/openclaw/src/message-utils.ts
@@ -1,0 +1,70 @@
+import { SYNTHETIC_CONTACT_EVENTS_SENDER_ID } from "@thenvoi/sdk/runtime";
+import type { PlatformEvent } from "@thenvoi/sdk";
+
+export interface OpenClawInboundMessage {
+  channelId: "thenvoi";
+  threadId: string;
+  senderId: string;
+  senderType: string;
+  senderName: string;
+  text: string;
+  timestamp: string;
+  metadata?: Record<string, unknown>;
+}
+
+export function buildOpenClawBody(message: OpenClawInboundMessage): string {
+  if (message.senderType?.toLowerCase() !== "agent") return message.text;
+
+  return [
+    `[Band worker agent reply from ${message.senderName} (${message.senderId})]`,
+    "This message is from another agent in the room, not from the human requester. If you delegated work to this agent and a critique, improvement request, validation question, challenge, counterargument, or follow-up would improve the result, reply to this same worker with thenvoi_send_message instead of finaling back to the room owner. For debate, review, or compare/contrast tasks, the first worker answer is not enough; challenge it or add your own counterpoint before declaring consensus.",
+    "",
+    message.text,
+  ].join("\n");
+}
+
+export function platformEventToInboundMessage(event: PlatformEvent): OpenClawInboundMessage | null {
+  if (event.type !== "message_created") return null;
+  const payload = event.payload;
+  const roomId = event.roomId ?? payload.chat_room_id;
+  if (!roomId) return null;
+
+  const isTextMessage = payload.message_type === "text";
+  const isSyntheticContactEvent =
+    payload.message_type === "contact_event" && payload.sender_id === SYNTHETIC_CONTACT_EVENTS_SENDER_ID;
+  if (!isTextMessage && !isSyntheticContactEvent) {
+    console.log(`[thenvoi] Skipping non-text message (type=${payload.message_type}, room=${roomId})`);
+    return null;
+  }
+
+  return {
+    channelId: "thenvoi",
+    threadId: roomId,
+    senderId: payload.sender_id,
+    senderType: payload.sender_type,
+    senderName: payload.sender_name ?? "Unknown",
+    text: payload.content,
+    timestamp: payload.inserted_at,
+    metadata: {
+      messageId: payload.id,
+      messageType: payload.message_type,
+      mentions: payload.metadata?.mentions,
+      contactEvent: isSyntheticContactEvent,
+    },
+  };
+}
+
+export function messageMentionsAgent(payload: Record<string, unknown>, agentId: string): boolean {
+  const content = typeof payload.content === "string" ? payload.content : "";
+  if (content.includes(agentId)) return true;
+
+  const mentions = (payload.metadata as { mentions?: Array<{ id?: unknown; agent_id?: unknown; participant_id?: unknown }> } | undefined)?.mentions;
+  return Array.isArray(mentions) && mentions.some((mention) =>
+    mention.id === agentId || mention.agent_id === agentId || mention.participant_id === agentId,
+  );
+}
+
+export function messageInsertedAt(payload: Record<string, unknown>): number | undefined {
+  const insertedAt = typeof payload.inserted_at === "string" ? Date.parse(payload.inserted_at) : NaN;
+  return Number.isFinite(insertedAt) ? insertedAt : undefined;
+}

--- a/packages/openclaw/src/openclaw-runtime.ts
+++ b/packages/openclaw/src/openclaw-runtime.ts
@@ -1,0 +1,52 @@
+export interface OpenClawRuntimeDispatchArgs {
+  ctx: Record<string, unknown>;
+  cfg: unknown;
+  dispatcher: Record<string, unknown>;
+}
+
+export interface OpenClawRuntimeDispatch {
+  loadConfig: () => unknown;
+  dispatchReplyFromConfig: (args: OpenClawRuntimeDispatchArgs) => Promise<void>;
+}
+
+export interface OpenClawRuntimeDispatchResolution {
+  dispatch: OpenClawRuntimeDispatch | null;
+  reason?: string;
+}
+
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return value != null && typeof value === "object";
+}
+
+export function resolveOpenClawRuntimeDispatch(runtime: unknown): OpenClawRuntimeDispatchResolution {
+  if (!isRecord(runtime)) {
+    return { dispatch: null, reason: "runtime is not an object" };
+  }
+
+  const config = runtime.config;
+  if (!isRecord(config) || typeof config.loadConfig !== "function") {
+    return { dispatch: null, reason: "runtime.config.loadConfig is not available" };
+  }
+
+  const channel = runtime.channel;
+  if (!isRecord(channel)) {
+    return { dispatch: null, reason: "runtime.channel is not available" };
+  }
+
+  const reply = channel.reply;
+  if (!isRecord(reply) || typeof reply.dispatchReplyFromConfig !== "function") {
+    return { dispatch: null, reason: "runtime.channel.reply.dispatchReplyFromConfig is not available" };
+  }
+
+  const loadConfig = (config.loadConfig as () => unknown).bind(config);
+  const dispatchReplyFromConfig = (reply.dispatchReplyFromConfig as (args: OpenClawRuntimeDispatchArgs) => Promise<void>).bind(reply);
+
+  return {
+    dispatch: {
+      loadConfig,
+      dispatchReplyFromConfig,
+    },
+  };
+}

--- a/packages/openclaw/src/prompts.ts
+++ b/packages/openclaw/src/prompts.ts
@@ -4,9 +4,9 @@
  *
  * Ported from thenvoi-sdk-python/src/thenvoi/runtime/prompts.py
  */
-export const CORE_INSTRUCTIONS = `## Thenvoi Channel Instructions
+export const CORE_INSTRUCTIONS = `## Band Channel Instructions
 
-**These instructions explain how to interact with the Thenvoi platform.**
+**These instructions explain how to interact with the Band platform.**
 
 ### CRITICAL: How to Call Tools
 
@@ -17,18 +17,18 @@ The model's tool_use capability must be used - text that looks like a function c
 
 You operate in two contexts:
 
-1. **Webchat/CLI context** (no Thenvoi room):
+1. **Webchat/CLI context** (no Band room):
    - Messages come from the OpenClaw chat interface
    - You have NO room_id - do NOT use tools that require room_id
    - Contact management tools (thenvoi_add_contact, thenvoi_list_contacts, etc.) WORK here
    - Respond with plain text for normal conversation
 
-2. **Thenvoi room context** (messages from Thenvoi):
-   - Messages come from the Thenvoi platform
+2. **Band room context** (messages from Band):
+   - Messages come from the Band platform
    - **Your current room_id is the \`To\` field from the message context** (a UUID like \`920082ae-eed7-4b4a-941e-c0ef33a432c1\`). Use this value whenever a tool asks for \`room_id\`.
-   - **Just reply with plain text** - your response is automatically routed to the correct room
-   - You do NOT need to call thenvoi_send_message for normal responses
-   - Only use thenvoi_send_message if you need to send to a DIFFERENT room than the one you received the message from
+   - Use plain text final answers when you are answering the original requester; the Band channel routes final answers back to the room owner/requester.
+   - Use thenvoi_send_message only when another participant should act next.
+   - If you are delegating, call thenvoi_send_message with the next worker's participant UUID in \`mentions\`.
    - **IMPORTANT:** Do NOT confuse the room_id with other UUIDs (agent IDs, user IDs, owner IDs). The room_id is ONLY the \`To\` field value.
 
 ### Tools That Work WITHOUT room_id (use from webchat)
@@ -42,28 +42,52 @@ These contact/peer tools work from ANY context:
 - \`thenvoi_remove_contact\` - Remove a contact
 - \`thenvoi_create_chatroom\` - Create a new room
 
-### Tools That REQUIRE room_id (advanced usage)
+### Tools That REQUIRE room_id (Band room usage)
 
-These tools require a room_id parameter. For most responses, just use plain text instead:
-- \`thenvoi_send_message\` - Send a message to a SPECIFIC room (usually not needed - plain text auto-routes)
+These tools require a room_id parameter:
+- \`thenvoi_send_message\` - Send a message to the current Band room when another participant should act next.
 - \`thenvoi_send_event\` - Share thinking/progress (optional)
-- \`thenvoi_add_participant\` - Add someone to a room (use with thenvoi_create_chatroom)
+- \`thenvoi_add_participant\` - Add someone to a room
 - \`thenvoi_remove_participant\` - Remove someone from a room
-- \`thenvoi_get_participants\` - List room participants
+- \`thenvoi_get_participants\` - List room participants and their UUIDs
 
-**For normal responses, just reply with plain text - it will be automatically routed to the correct room.**
+**Do not use OpenClaw session tools such as sessions_spawn, sessions_list, sessions_history, or ACP runtime tools to bring another Band agent into the room.** Band collaboration is room-based: use thenvoi_lookup_peers, thenvoi_add_participant, then thenvoi_send_message.
 
-**When to use thenvoi_send_message instead of plain text:**
-- When you need to @mention a SPECIFIC participant (e.g., "say hi to agent2" → use thenvoi_send_message with mentions=["agent2"])
-- Plain text replies auto-mention the last sender, NOT other participants. If the user asks you to address someone specific, you MUST use thenvoi_send_message with their name in the mentions list.
+**In a Band room, use plain text final answers for the original requester. Use thenvoi_send_message only for handoffs, delegation, or follow-up questions where another participant should act next.**
 
-## Delegating to Other Agents (Thenvoi context only)
+**How to use thenvoi_send_message correctly:**
+- Do not use thenvoi_send_message just to answer the original requester; write the final answer normally and the channel will route it back to the room owner/requester.
+- Use thenvoi_send_message only when someone else in the room should act next.
+- Only @mention another agent when you are explicitly delegating work, asking that agent to do something, or responding to that agent with critique/follow-up.
+- When a worker agent replies to you, do NOT automatically summarize to the human. First decide whether the worker's answer fully satisfies the original request.
+- If the current message is from a worker agent during delegated work, do not final back to the room owner unless the task is complete, no useful critique or follow-up remains, and the original requester needs the result now.
+- If you have feedback for the worker, better facts, a requested refinement, a missing detail, or a required follow-up question, use thenvoi_send_message and mention only that worker's UUID.
+- After you use thenvoi_send_message to continue work with another agent, there is usually nothing to say to the human yet. If OpenClaw requires a final response for that turn, make it completely empty.
+- If the worker's answer is complete, you agree with it, or the agents have reached consensus and no further agent action is needed, write a plain text final answer for the original requester with the agreed result; the channel will mention the room owner/requester for you.
+- Never use plain text final answers to talk to a worker agent. Plain text finals go to the room owner/requester.
+- Never use thenvoi_send_message to mention yourself.
+- Mention only the participant who should act next.
+- When you need a specialist, first use thenvoi_lookup_peers, then add them if needed, then use thenvoi_get_participants and mention their UUID with thenvoi_send_message.
+- When a tool asks for mentions, use participant UUIDs from thenvoi_get_participants, not display names.
 
-When in a Thenvoi room and you cannot help directly (weather, news, etc.):
-1. Use thenvoi_lookup_peers to find specialized agents
-2. Use thenvoi_add_participant with \`room_id\` = the \`To\` field from your message context (NOT any other UUID)
-3. Reply with plain text asking them (will be auto-routed to the room)
-4. Relay their response back to the original requester with plain text
+## Delegating to Other Agents (Band room context only)
+
+Default to agent-to-agent communication until the delegated work is complete, blocked, or needs a human decision. A worker reply is not automatically the end of the task; it is part of the collaboration loop. When the current message is from a worker agent, your default next action is to respond to that same worker with thenvoi_send_message if another turn could improve the result, resolve ambiguity, validate output, or produce a clearer recommendation. For demo-style delegated work where the human asked you to debate, review, compare, argue, choose between options, or improve another agent's output, do not final after the worker's first answer; send at least one concrete challenge, counterargument, critique, improvement request, or validation question back to that worker with thenvoi_send_message. After sending a message to another agent, do not also summarize that message to the human; use an empty final for that turn unless the human must act. When the worker returns a final consensus draft or you agree no further worker turn is useful, bring the human back in with the agreed result. Do not merely copy the worker's text; state your own judgment, whether you agree or disagree, and the reason in one or two direct sentences before giving the result. Bring the human back in only when there is nothing useful left to ask the worker, the worker is blocked, or the human must choose a direction.
+
+When in a Band room and you cannot help directly (weather, news, etc.):
+1. Remember which human originally asked for help.
+2. Use thenvoi_lookup_peers only when you need another agent to act.
+3. Use thenvoi_add_participant with \`room_id\` = the \`To\` field from your message context (NOT any other UUID).
+4. Use thenvoi_get_participants to fetch the current room participant UUIDs.
+5. Use thenvoi_send_message to ask the specialist in that same room, with ONLY the specialist's UUID in \`mentions\`.
+6. When the specialist replies, do NOT reflexively summarize to the original requester.
+7. Decide who should act next:
+   - If the specialist still needs to do more work, mention the specialist again.
+   - If you have a critique, a better direction, or a requested follow-up, mention the specialist again.
+   - If the task is ready to hand back, write a plain text final answer for the original requester.
+8. Never mention yourself.
+9. If you are not sure the task is actually done, ask the specialist a short validation follow-up question before you hand the result back to the human.
+10. You must always close the loop with the original requester once the task is done or blocked by writing a normal final answer.
 
 ## Example: Webchat - User wants to add a contact
 
@@ -85,23 +109,34 @@ This is webchat with no room_id. Just respond with plain text:
 
 Do NOT try to use thenvoi_send_message - you have no room_id.
 
-## Example: Thenvoi room - Responding to a message
+## Example: Band room - Responding to a message
 
-Message from Thenvoi: [John Doe]: What's 2+2?
+Message from Band: [John Doe]: What's 2+2?
 
-Just reply with plain text - it will be routed to the correct room automatically:
-"4"
+1. Answer with plain text: \`4\`.
+2. The Band channel will route that final answer back to the original room requester.
 
-You do NOT need to call thenvoi_send_message for normal responses.
+## Example: Band room - Delegating to another agent
 
-## Example: Thenvoi room - Delegating to another agent
+Message from Band: [John Doe]: What's the weather in Tokyo?
 
-Message from Thenvoi: [John Doe]: What's the weather in Tokyo?
+1. Call thenvoi_lookup_peers to find a weather agent.
+2. Call thenvoi_add_participant to add Weather Agent to the current room.
+3. Call thenvoi_get_participants to fetch the current room participant UUIDs.
+4. Call thenvoi_send_message in the current room with Weather Agent's UUID in \`mentions\` and include the weather question.
+5. Do NOT @mention John Doe while asking Weather Agent; this step is only for the specialist.
+6. If Weather Agent replies with the finished answer, write a plain text final answer for John Doe; the channel will route it back to the room owner/requester.
+7. If Weather Agent replies with incomplete work, weak details, or an answer that needs refinement, ask Weather Agent a short follow-up question with thenvoi_send_message and keep the mention on Weather Agent.
+8. Never put your own UUID or your own name in \`mentions\`.
 
-1. Call thenvoi_lookup_peers to find a weather agent
-2. Call thenvoi_add_participant to add Weather Agent to the current room
-3. Reply with plain text asking the Weather Agent (the response is automatically routed)
-4. When Weather Agent responds, relay back to John Doe with plain text
+## Verifying another agent's work
+
+If another agent says they changed files, built something, or completed a task:
+- Do NOT claim you personally inspected files that live in that other agent's environment.
+- Do NOT pretend you can see another agent's filesystem or worktree unless they explicitly sent you the relevant contents.
+- If you need confidence before replying to the human, ask the worker a short validation question like what files changed, where the output lives, or what still needs manual review.
+- If you have feedback for the worker, send that feedback to the worker with thenvoi_send_message instead of putting it in a plain final reply.
+- Once you have enough confirmation and no more worker action is needed, hand the result back to the original requester with a plain text final answer.
 `;
 
 /**
@@ -173,7 +208,7 @@ Execute these tools (via tool API, not as text):
 
 Then respond with plain text: "I've sent a connection request to @weather-bot."
 
-### Example: Adding a contact from Thenvoi room
+### Example: Adding a contact from Band room
 
 [Thenvoi - General] [John Doe]: Can you connect me with the Weather Agent?
 (room_id available from message metadata)

--- a/packages/openclaw/src/redaction.ts
+++ b/packages/openclaw/src/redaction.ts
@@ -1,0 +1,29 @@
+const PREFIXED_REDACTION_PATTERNS: RegExp[] = [
+  /\b(Bearer\s+)[A-Za-z0-9._~+/=-]{8,}/gi,
+  /\b(gateway[-_ ]?token["'\s:=]+)[A-Za-z0-9._~+/=-]{8,}/gi,
+  /\b(api[-_ ]?key["'\s:=]+)[A-Za-z0-9._~+/=-]{8,}/gi,
+  /\b(thenvoi[-_ ]?api[-_ ]?key["'\s:=]+)[A-Za-z0-9._~+/=-]{8,}/gi,
+  /\b(authorization["'\s:=]+)[A-Za-z0-9._~+/=-]{8,}/gi,
+  /\b(x-api-key["'\s:=]+)[A-Za-z0-9._~+/=-]{8,}/gi,
+  /([?&](?:api_?key|token|gateway_?token)=)[^\s&]+/gi,
+];
+
+const TOKEN_REDACTION_PATTERNS: RegExp[] = [
+  /\btv_[A-Za-z0-9_-]{8,}\b/g,
+  /\bthnv_(?:a_|u_)?[A-Za-z0-9_-]{8,}\b/g,
+  /\bband_(?:a_|u_)[A-Za-z0-9_-]{8,}\b/g,
+  /\bsk-[A-Za-z0-9_-]{8,}\b/g,
+  /\bnvapi-[A-Za-z0-9_-]{8,}\b/g,
+  /\bhf_[A-Za-z0-9_-]{8,}\b/g,
+];
+
+export function redactSecrets(value: unknown): string {
+  let text = value instanceof Error ? value.message : String(value);
+  for (const pattern of PREFIXED_REDACTION_PATTERNS) {
+    text = text.replace(pattern, (_match: string, prefix: string) => `${prefix}[REDACTED]`);
+  }
+  for (const pattern of TOKEN_REDACTION_PATTERNS) {
+    text = text.replace(pattern, "[REDACTED]");
+  }
+  return text;
+}

--- a/packages/openclaw/src/reply-dispatcher.ts
+++ b/packages/openclaw/src/reply-dispatcher.ts
@@ -1,5 +1,4 @@
 import type { ThenvoiLink } from "@thenvoi/sdk";
-import type { BandToolEventContext } from "./channel.js";
 
 type Mention = { id: string; name?: string };
 
@@ -38,27 +37,13 @@ function hasExplicitUserFacingFinalText(text: string): boolean {
   return /<message to user>[\s\S]*?<\/message>/i.test(text);
 }
 
-function joinFinalReplyFragments(fragments: string[]): string {
-  return fragments.reduce((joined, fragment) => {
-    if (!joined || /^['’]/.test(fragment)) return `${joined}${fragment}`;
-    return `${joined} ${fragment}`;
-  }, "");
-}
-
 function selectFinalReplyText(texts: string[]): string | undefined {
-  const normalized = texts.map((text) => text.trim()).filter(Boolean);
-  if (normalized.length === 0) return undefined;
-
-  for (let index = normalized.length - 1; index >= 0; index -= 1) {
-    const text = normalized[index];
+  for (let index = texts.length - 1; index >= 0; index -= 1) {
+    const text = texts[index]?.trim();
     if (text && hasExplicitUserFacingFinalText(text)) return text;
   }
 
-  if (normalized.length === 1) {
-    return normalized[0];
-  }
-
-  return joinFinalReplyFragments(normalized);
+  return undefined;
 }
 
 async function sendFinalReplyToBand(
@@ -76,7 +61,6 @@ export function createBandReplyDispatcher(
   accountId: string,
   roomId: string,
   resolveFinalMentions: () => Promise<Mention[]>,
-  turnContext?: BandToolEventContext,
 ): ReplyDispatcher {
   const pendingReplies: Promise<void>[] = [];
   const deliveryErrors: Error[] = [];
@@ -127,10 +111,7 @@ export function createBandReplyDispatcher(
     },
     waitForIdle: async (): Promise<void> => {
       await Promise.resolve();
-      const candidateFinalTexts = turnContext?.sentMessage
-        ? finalReplyTexts.filter(hasExplicitUserFacingFinalText)
-        : finalReplyTexts;
-      const finalReplyText = finalReplySent ? undefined : selectFinalReplyText(candidateFinalTexts);
+      const finalReplyText = finalReplySent ? undefined : selectFinalReplyText(finalReplyTexts);
       if (finalReplyText) {
         finalReplySent = true;
         const mentions = await resolveFinalMentions();
@@ -140,9 +121,9 @@ export function createBandReplyDispatcher(
           extractUserFacingFinalText(finalReplyText),
           mentions,
         ));
-      } else if (!finalReplySent && turnContext?.sentMessage && finalReplyTexts.length > 0) {
+      } else if (!finalReplySent && finalReplyTexts.length > 0) {
         finalReplySent = true;
-        console.log(`[thenvoi] Dropped non-explicit final reply after thenvoi_send_message (room=${roomId})`);
+        console.log(`[thenvoi] Dropped non-explicit final reply (room=${roomId})`);
       }
       await Promise.allSettled(pendingReplies);
       if (deliveryErrors.length > 0) {

--- a/packages/openclaw/src/reply-dispatcher.ts
+++ b/packages/openclaw/src/reply-dispatcher.ts
@@ -28,19 +28,15 @@ function replyPayloadText(payload: unknown): string | undefined {
   return typeof payload === "string" ? payload : (payload as { text?: string })?.text;
 }
 
-function extractUserFacingFinalText(text: string): string {
-  const messageToUserMatch = text.match(/<message to user>([\s\S]*?)<\/message>/i);
-  return (messageToUserMatch?.[1] ?? text).trim();
-}
-
-function hasExplicitUserFacingFinalText(text: string): boolean {
-  return /<message to user>[\s\S]*?<\/message>/i.test(text);
+function extractUserFacingFinalText(text: string): string | undefined {
+  return text.match(/<message to user>([\s\S]*?)<\/message>/i)?.[1]?.trim();
 }
 
 function selectFinalReplyText(texts: string[]): string | undefined {
   for (let index = texts.length - 1; index >= 0; index -= 1) {
-    const text = texts[index]?.trim();
-    if (text && hasExplicitUserFacingFinalText(text)) return text;
+    const candidate = texts[index];
+    const text = candidate ? extractUserFacingFinalText(candidate) : undefined;
+    if (text) return text;
   }
 
   return undefined;
@@ -118,7 +114,7 @@ export function createBandReplyDispatcher(
         enqueueDelivery("final", sendFinalReplyToBand(
           link.rest,
           roomId,
-          extractUserFacingFinalText(finalReplyText),
+          finalReplyText,
           mentions,
         ));
       } else if (!finalReplySent && finalReplyTexts.length > 0) {

--- a/packages/openclaw/src/reply-dispatcher.ts
+++ b/packages/openclaw/src/reply-dispatcher.ts
@@ -38,11 +38,6 @@ function hasExplicitUserFacingFinalText(text: string): boolean {
   return /<message to user>[\s\S]*?<\/message>/i.test(text);
 }
 
-function isLikelyPartialFinalReply(text: string): boolean {
-  const trimmed = text.trim();
-  return trimmed.toLowerCase() === "i" || /^['’][a-z]/i.test(trimmed);
-}
-
 function joinFinalReplyFragments(fragments: string[]): string {
   return fragments.reduce((joined, fragment) => {
     if (!joined || /^['’]/.test(fragment)) return `${joined}${fragment}`;
@@ -60,15 +55,10 @@ function selectFinalReplyText(texts: string[]): string | undefined {
   }
 
   if (normalized.length === 1) {
-    const [text] = normalized;
-    return text && isLikelyPartialFinalReply(text) ? undefined : text;
+    return normalized[0];
   }
 
-  if (normalized.some(isLikelyPartialFinalReply)) {
-    return joinFinalReplyFragments(normalized);
-  }
-
-  return normalized[normalized.length - 1];
+  return joinFinalReplyFragments(normalized);
 }
 
 async function sendFinalReplyToBand(
@@ -136,6 +126,7 @@ export function createBandReplyDispatcher(
       return true;
     },
     waitForIdle: async (): Promise<void> => {
+      await Promise.resolve();
       const candidateFinalTexts = turnContext?.sentMessage
         ? finalReplyTexts.filter(hasExplicitUserFacingFinalText)
         : finalReplyTexts;

--- a/packages/openclaw/src/reply-dispatcher.ts
+++ b/packages/openclaw/src/reply-dispatcher.ts
@@ -40,7 +40,14 @@ function hasExplicitUserFacingFinalText(text: string): boolean {
 
 function isLikelyPartialFinalReply(text: string): boolean {
   const trimmed = text.trim();
-  return trimmed.length <= 2 || /^['’][a-z]/i.test(trimmed);
+  return trimmed.toLowerCase() === "i" || /^['’][a-z]/i.test(trimmed);
+}
+
+function joinFinalReplyFragments(fragments: string[]): string {
+  return fragments.reduce((joined, fragment) => {
+    if (!joined || /^['’]/.test(fragment)) return `${joined}${fragment}`;
+    return `${joined} ${fragment}`;
+  }, "");
 }
 
 function selectFinalReplyText(texts: string[]): string | undefined {
@@ -49,10 +56,19 @@ function selectFinalReplyText(texts: string[]): string | undefined {
 
   for (let index = normalized.length - 1; index >= 0; index -= 1) {
     const text = normalized[index];
-    if (text && !isLikelyPartialFinalReply(text)) return text;
+    if (text && hasExplicitUserFacingFinalText(text)) return text;
   }
 
-  return normalized.length > 1 ? normalized.join("") : undefined;
+  if (normalized.length === 1) {
+    const [text] = normalized;
+    return text && isLikelyPartialFinalReply(text) ? undefined : text;
+  }
+
+  if (normalized.some(isLikelyPartialFinalReply)) {
+    return joinFinalReplyFragments(normalized);
+  }
+
+  return normalized[normalized.length - 1];
 }
 
 async function sendFinalReplyToBand(

--- a/packages/openclaw/src/reply-dispatcher.ts
+++ b/packages/openclaw/src/reply-dispatcher.ts
@@ -1,0 +1,147 @@
+import type { ThenvoiLink } from "@thenvoi/sdk";
+import type { BandToolEventContext } from "./channel.js";
+
+type Mention = { id: string; name?: string };
+
+export interface ReplyDispatcher extends Record<string, unknown> {
+  sendToolResult: (payload: unknown) => boolean;
+  sendBlockReply: (payload: unknown) => boolean;
+  sendFinalReply: (payload: unknown) => boolean;
+  waitForIdle: () => Promise<void>;
+  getQueuedCounts: () => { tool: number; block: number; final: number };
+}
+
+export function createNoopReplyDispatcher(): ReplyDispatcher {
+  function sendReply(): boolean {
+    return true;
+  }
+
+  return {
+    sendToolResult: sendReply,
+    sendBlockReply: sendReply,
+    sendFinalReply: sendReply,
+    waitForIdle: async (): Promise<void> => {},
+    getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+  };
+}
+
+function replyPayloadText(payload: unknown): string | undefined {
+  return typeof payload === "string" ? payload : (payload as { text?: string })?.text;
+}
+
+function extractUserFacingFinalText(text: string): string {
+  const messageToUserMatch = text.match(/<message to user>([\s\S]*?)<\/message>/i);
+  return (messageToUserMatch?.[1] ?? text).trim();
+}
+
+function hasExplicitUserFacingFinalText(text: string): boolean {
+  return /<message to user>[\s\S]*?<\/message>/i.test(text);
+}
+
+function isLikelyPartialFinalReply(text: string): boolean {
+  const trimmed = text.trim();
+  return trimmed.length <= 2 || /^['’][a-z]/i.test(trimmed);
+}
+
+function selectFinalReplyText(texts: string[]): string | undefined {
+  const normalized = texts.map((text) => text.trim()).filter(Boolean);
+  if (normalized.length === 0) return undefined;
+
+  for (let index = normalized.length - 1; index >= 0; index -= 1) {
+    const text = normalized[index];
+    if (text && !isLikelyPartialFinalReply(text)) return text;
+  }
+
+  return normalized.length > 1 ? normalized.join("") : undefined;
+}
+
+async function sendFinalReplyToBand(
+  rest: ThenvoiLink["rest"],
+  roomId: string,
+  text: string,
+  mentions: Mention[],
+): Promise<void> {
+  await rest.createChatMessage(roomId, { content: text, mentions });
+  console.log(`[thenvoi] Final reply sent (room=${roomId}, textLength=${text.length})`);
+}
+
+export function createBandReplyDispatcher(
+  link: ThenvoiLink,
+  accountId: string,
+  roomId: string,
+  resolveFinalMentions: () => Promise<Mention[]>,
+  turnContext?: BandToolEventContext,
+): ReplyDispatcher {
+  const pendingReplies: Promise<void>[] = [];
+  const deliveryErrors: Error[] = [];
+  const queuedCounts = { tool: 0, block: 0, final: 0 };
+  const finalReplyTexts: string[] = [];
+  let finalReplySent = false;
+
+  function enqueueDelivery(kind: "final" | "tool", delivery: Promise<void>): void {
+    pendingReplies.push(
+      delivery.catch((err: unknown) => {
+        const error = err instanceof Error ? err : new Error(String(err));
+        deliveryErrors.push(error);
+        console.error(`[thenvoi:${accountId}] ${kind} delivery failed (room=${roomId}, error=${error.name || "Error"})`);
+      }),
+    );
+  }
+
+  function enqueueToolResult(payload: unknown): void {
+    queuedCounts.tool += 1;
+    const text = replyPayloadText(payload);
+    if (!text) return;
+    enqueueDelivery("tool", link.rest.createChatEvent(roomId, {
+      content: text,
+      messageType: "tool_result",
+      metadata: { source: "openclaw" },
+    }).then(() => undefined));
+  }
+
+  function queueFinalReply(payload: unknown): void {
+    queuedCounts.final += 1;
+    if (finalReplySent) return;
+    const text = replyPayloadText(payload);
+    if (text) finalReplyTexts.push(text);
+  }
+
+  return {
+    sendToolResult: (payload: unknown): boolean => {
+      enqueueToolResult(payload);
+      return true;
+    },
+    sendBlockReply: (): boolean => {
+      queuedCounts.block += 1;
+      return true;
+    },
+    sendFinalReply: (payload: unknown): boolean => {
+      queueFinalReply(payload);
+      return true;
+    },
+    waitForIdle: async (): Promise<void> => {
+      const candidateFinalTexts = turnContext?.sentMessage
+        ? finalReplyTexts.filter(hasExplicitUserFacingFinalText)
+        : finalReplyTexts;
+      const finalReplyText = finalReplySent ? undefined : selectFinalReplyText(candidateFinalTexts);
+      if (finalReplyText) {
+        finalReplySent = true;
+        const mentions = await resolveFinalMentions();
+        enqueueDelivery("final", sendFinalReplyToBand(
+          link.rest,
+          roomId,
+          extractUserFacingFinalText(finalReplyText),
+          mentions,
+        ));
+      } else if (!finalReplySent && turnContext?.sentMessage && finalReplyTexts.length > 0) {
+        finalReplySent = true;
+        console.log(`[thenvoi] Dropped non-explicit final reply after thenvoi_send_message (room=${roomId})`);
+      }
+      await Promise.allSettled(pendingReplies);
+      if (deliveryErrors.length > 0) {
+        console.error(`[thenvoi:${accountId}] ${deliveryErrors.length}/${pendingReplies.length} replies failed to deliver (room=${roomId})`);
+      }
+    },
+    getQueuedCounts: () => ({ ...queuedCounts }),
+  };
+}

--- a/packages/openclaw/tests/e2e/setup.ts
+++ b/packages/openclaw/tests/e2e/setup.ts
@@ -25,8 +25,8 @@ export function getE2EConfig(): E2EConfig {
   const agentId = process.env.THENVOI_AGENT_ID;
   const userId = process.env.THENVOI_API_KEY_USER;
   const wsUrl =
-    process.env.THENVOI_WS_URL ?? "wss://app.thenvoi.com/api/v1/socket";
-  const restUrl = process.env.THENVOI_REST_URL ?? "https://app.thenvoi.com";
+    process.env.THENVOI_WS_URL ?? "wss://app.band.ai/api/v1/socket";
+  const restUrl = process.env.THENVOI_REST_URL ?? "https://app.band.ai";
 
   if (!apiKey) {
     throw new Error(

--- a/packages/openclaw/tests/unit/channel-gateway.test.ts
+++ b/packages/openclaw/tests/unit/channel-gateway.test.ts
@@ -66,7 +66,6 @@ import {
   setOpenClawRuntime,
   getLink,
   getAgentId,
-  recordBandMessageSentForCurrentTurn,
   resetGatewayRegistry,
 } from "../../src/channel.js";
 import { mockAccountConfig } from "../fixtures/configs.js";
@@ -198,9 +197,8 @@ describe("Channel Gateway Lifecycle", () => {
       expect(capturedContactHandlerOptions?.onHubInit).toEqual(expect.any(Function));
     });
 
-    it("should drop non-explicit hub final replies after sending a Band message", async () => {
+    it("should drop non-explicit hub final replies", async () => {
       const dispatchFn = vi.fn().mockImplementation(async ({ dispatcher }) => {
-        recordBandMessageSentForCurrentTurn();
         dispatcher.sendFinalReply({ text: "I accepted the contact request." });
         await dispatcher.waitForIdle();
       });
@@ -657,9 +655,8 @@ describe("Channel Gateway Lifecycle", () => {
       );
     });
 
-    it("should drop non-explicit final replies after sending a Band message to another participant", async () => {
+    it("should drop non-explicit final replies", async () => {
       const dispatchFn = vi.fn().mockImplementation(async ({ dispatcher }) => {
-        recordBandMessageSentForCurrentTurn();
         dispatcher.sendFinalReply({ text: "I asked Codex to revise that list." });
         await dispatcher.waitForIdle();
       });

--- a/packages/openclaw/tests/unit/channel-gateway.test.ts
+++ b/packages/openclaw/tests/unit/channel-gateway.test.ts
@@ -30,6 +30,7 @@ vi.mock("@thenvoi/sdk", () => ({
       listAllChats: vi.fn().mockResolvedValue([]),
       markProcessing: vi.fn().mockResolvedValue(undefined),
       markProcessed: vi.fn().mockResolvedValue(undefined),
+      markFailed: vi.fn().mockResolvedValue(undefined),
     };
     return mockLinkInstance;
   }),
@@ -195,6 +196,50 @@ describe("Channel Gateway Lifecycle", () => {
       });
       expect(capturedContactHandlerOptions?.onHubEvent).toEqual(expect.any(Function));
       expect(capturedContactHandlerOptions?.onHubInit).toEqual(expect.any(Function));
+    });
+
+    it("should drop non-explicit hub final replies after sending a Band message", async () => {
+      const dispatchFn = vi.fn().mockImplementation(async ({ dispatcher }) => {
+        recordBandMessageSentForCurrentTurn();
+        dispatcher.sendFinalReply({ text: "I accepted the contact request." });
+        await dispatcher.waitForIdle();
+      });
+      setOpenClawRuntime({
+        channel: {
+          reply: {
+            dispatchReplyFromConfig: dispatchFn,
+          },
+        },
+        config: {
+          loadConfig: () => ({}),
+        },
+      });
+      const ctx = createGatewayContext("default", {
+        ...mockAccountConfig,
+        contactConfig: { strategy: "hub_room", hubTaskId: "task-123" },
+      }, { aborted: true });
+
+      await thenvoiChannel.gateway!.startAccount(ctx);
+      const onHubEvent = capturedContactHandlerOptions?.onHubEvent as (
+        hubRoomId: string,
+        event: Record<string, unknown>,
+      ) => Promise<void>;
+      await onHubEvent("hub-room", {
+        type: "message_created",
+        payload: {
+          id: "contact-msg-1",
+          chat_room_id: "hub-room",
+          sender_id: "user-789",
+          sender_type: "User",
+          sender_name: "John Doe",
+          content: "[Contact Request] Alice wants to connect.",
+          message_type: "text",
+          inserted_at: "2025-01-15T10:00:00Z",
+          metadata: {},
+        },
+      });
+
+      expect(mockLinkInstance.rest.createChatMessage).not.toHaveBeenCalled();
     });
 
     it("should skip when startAccount is already in progress for same account", async () => {
@@ -692,6 +737,54 @@ describe("Channel Gateway Lifecycle", () => {
       );
       expect(mockLinkInstance.markProcessing).toHaveBeenCalledWith("room-123", "msg-pending-001", { bestEffort: true });
       expect(mockLinkInstance.markProcessed).toHaveBeenCalledWith("room-123", "msg-pending-001", { bestEffort: true });
+    });
+
+    it("should mark message as failed instead of processed when OpenClaw dispatch fails", async () => {
+      setOpenClawRuntime({
+        channel: {
+          reply: {
+            dispatchReplyFromConfig: vi.fn().mockRejectedValue(new Error("dispatch failed")),
+          },
+        },
+        config: {
+          loadConfig: () => ({}),
+        },
+      });
+      const ctx = createGatewayContext("default", mockAccountConfig, { aborted: true });
+      await thenvoiChannel.gateway!.startAccount(ctx);
+
+      const onRoomEvent = capturedPresenceInstance.onRoomEvent as (
+        roomId: string,
+        event: Record<string, unknown>,
+      ) => Promise<void>;
+
+      await onRoomEvent("room-123", {
+        type: "message_created",
+        roomId: "room-123",
+        payload: {
+          id: "msg-fail",
+          chat_room_id: "room-123",
+          sender_id: "user-789",
+          sender_type: "User",
+          sender_name: "John Doe",
+          content: "Hello!",
+          message_type: "text",
+          inserted_at: "2025-01-15T10:00:00Z",
+          metadata: {},
+        },
+      });
+
+      expect(mockLinkInstance.markProcessed).not.toHaveBeenCalledWith(
+        "room-123",
+        "msg-fail",
+        { bestEffort: true },
+      );
+      expect(mockLinkInstance.markFailed).toHaveBeenCalledWith(
+        "room-123",
+        "msg-fail",
+        expect.stringContaining("dispatch failed"),
+        { bestEffort: true },
+      );
     });
 
     it("should mark message as processed after handling", async () => {

--- a/packages/openclaw/tests/unit/channel-gateway.test.ts
+++ b/packages/openclaw/tests/unit/channel-gateway.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // Capture RoomPresence instances so we can invoke event handlers in tests
 let capturedPresenceInstance: Record<string, unknown>;
 let mockLinkInstance: Record<string, unknown>;
+let capturedContactHandlerOptions: Record<string, unknown> | undefined;
 
 vi.mock("@thenvoi/sdk", () => ({
   ThenvoiLink: vi.fn().mockImplementation((opts: Record<string, unknown>) => {
@@ -15,13 +16,19 @@ vi.mock("@thenvoi/sdk", () => ({
       rest: {
         getAgentMe: vi.fn().mockResolvedValue({ id: opts.agentId }),
         listChatParticipants: vi.fn().mockResolvedValue([
-          { id: "user-789", name: "John Doe", type: "User" },
+          { id: "user-789", name: "John Doe", type: "Owner" },
           { id: opts.agentId, name: "Test Agent", type: "Agent" },
         ]),
         createChatMessage: vi.fn().mockResolvedValue({ ok: true, id: "msg-001" }),
+        createChatEvent: vi.fn().mockResolvedValue({ ok: true, id: "event-001" }),
+        getNextMessage: vi.fn().mockResolvedValue(null),
       },
       connect: vi.fn().mockResolvedValue(undefined),
       disconnect: vi.fn().mockResolvedValue(undefined),
+      subscribeRoom: vi.fn().mockResolvedValue(undefined),
+      unsubscribeRoom: vi.fn().mockResolvedValue(undefined),
+      listAllChats: vi.fn().mockResolvedValue([]),
+      markProcessing: vi.fn().mockResolvedValue(undefined),
       markProcessed: vi.fn().mockResolvedValue(undefined),
     };
     return mockLinkInstance;
@@ -31,6 +38,7 @@ vi.mock("@thenvoi/sdk", () => ({
 vi.mock("@thenvoi/sdk/runtime", () => ({
   RoomPresence: vi.fn().mockImplementation(() => {
     capturedPresenceInstance = {
+      rooms: new Set<string>(),
       onRoomJoined: null,
       onRoomLeft: null,
       onRoomEvent: null,
@@ -40,9 +48,12 @@ vi.mock("@thenvoi/sdk/runtime", () => ({
     };
     return capturedPresenceInstance;
   }),
-  ContactEventHandler: vi.fn().mockImplementation(() => ({
-    handle: vi.fn().mockResolvedValue(undefined),
-  })),
+  ContactEventHandler: vi.fn().mockImplementation((options: Record<string, unknown>) => {
+    capturedContactHandlerOptions = options;
+    return {
+      handle: vi.fn().mockResolvedValue(undefined),
+    };
+  }),
 }));
 
 vi.mock("@thenvoi/sdk/rest", () => ({}));
@@ -54,6 +65,7 @@ import {
   setOpenClawRuntime,
   getLink,
   getAgentId,
+  recordBandMessageSentForCurrentTurn,
   resetGatewayRegistry,
 } from "../../src/channel.js";
 import { mockAccountConfig } from "../fixtures/configs.js";
@@ -82,6 +94,7 @@ function createGatewayContext(
 describe("Channel Gateway Lifecycle", () => {
   beforeEach(() => {
     resetGatewayRegistry();
+    capturedContactHandlerOptions = undefined;
   });
 
   describe("deliverMessage", () => {
@@ -158,6 +171,32 @@ describe("Channel Gateway Lifecycle", () => {
       expect(capturedPresenceInstance.start).toHaveBeenCalled();
     });
 
+    it("should leave contact events disabled unless account config opts in", async () => {
+      const ctx = createGatewayContext("default", mockAccountConfig, { aborted: true });
+
+      await thenvoiChannel.gateway!.startAccount(ctx);
+
+      expect(capturedContactHandlerOptions).toBeUndefined();
+    });
+
+    it("should configure contact hub handling when hub room config is provided", async () => {
+      const ctx = createGatewayContext("default", {
+        ...mockAccountConfig,
+        operatorId: "operator-123",
+        contactConfig: { strategy: "hub_room", hubTaskId: "task-123", broadcastChanges: true },
+      }, { aborted: true });
+
+      await thenvoiChannel.gateway!.startAccount(ctx);
+
+      expect(capturedContactHandlerOptions?.config).toEqual({
+        strategy: "hub_room",
+        hubTaskId: "task-123",
+        broadcastChanges: true,
+      });
+      expect(capturedContactHandlerOptions?.onHubEvent).toEqual(expect.any(Function));
+      expect(capturedContactHandlerOptions?.onHubInit).toEqual(expect.any(Function));
+    });
+
     it("should skip when startAccount is already in progress for same account", async () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -188,7 +227,7 @@ describe("Channel Gateway Lifecycle", () => {
 
     it("should clean up race guard on error", async () => {
       const badConfig = { ...mockAccountConfig, apiKey: undefined, agentId: undefined };
-      // Remove env vars so resolveConfig throws
+      // Remove env vars so credential resolution throws
       delete process.env.THENVOI_API_KEY;
       delete process.env.THENVOI_AGENT_ID;
 
@@ -458,6 +497,201 @@ describe("Channel Gateway Lifecycle", () => {
           }),
         }),
       );
+    });
+
+    it("should mark worker replies in all OpenClaw body fields", async () => {
+      const dispatchFn = vi.fn().mockResolvedValue(undefined);
+      setOpenClawRuntime({
+        channel: {
+          reply: {
+            dispatchReplyFromConfig: dispatchFn,
+          },
+        },
+        config: {
+          loadConfig: () => ({}),
+        },
+      });
+
+      const ctx = createGatewayContext("default", mockAccountConfig, { aborted: true });
+      await thenvoiChannel.gateway!.startAccount(ctx);
+
+      const onRoomEvent = capturedPresenceInstance.onRoomEvent as (
+        roomId: string,
+        event: Record<string, unknown>,
+      ) => Promise<void>;
+
+      await onRoomEvent("room-123", {
+        type: "message_created",
+        roomId: "room-123",
+        payload: {
+          id: "msg-001",
+          chat_room_id: "room-123",
+          sender_id: "agent-456",
+          sender_type: "Agent",
+          sender_name: "Codex",
+          content: "I think dogs win.",
+          message_type: "text",
+          inserted_at: "2025-01-15T10:00:00Z",
+          metadata: {},
+        },
+      });
+
+      expect(dispatchFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ctx: expect.objectContaining({
+            Body: expect.stringContaining("Band worker agent reply from Codex"),
+            RawBody: expect.stringContaining("Band worker agent reply from Codex"),
+            BodyForCommands: expect.stringContaining("Band worker agent reply from Codex"),
+            CommandBody: expect.stringContaining("Band worker agent reply from Codex"),
+            SenderType: "Agent",
+          }),
+        }),
+      );
+    });
+
+    it("should send tool results as Band events and route one stable final reply to the room owner", async () => {
+      const dispatchFn = vi.fn().mockImplementation(async ({ dispatcher }) => {
+        dispatcher.sendToolResult({ text: "tool output" });
+        dispatcher.sendBlockReply({ text: "partial block" });
+        dispatcher.sendFinalReply({ text: "I" });
+        dispatcher.waitForIdle();
+        dispatcher.sendFinalReply({ text: "'ll help you get started with that." });
+        dispatcher.sendFinalReply({ text: "<message to user>Done. I pulled Codex into the room and asked them to help.</message>" });
+        await dispatcher.waitForIdle();
+        dispatcher.sendFinalReply({ text: "I" });
+        dispatcher.sendFinalReply({ text: "'ll help you pull in Codex and build out a project about NVIDIA!" });
+        await dispatcher.waitForIdle();
+      });
+      setOpenClawRuntime({
+        channel: {
+          reply: {
+            dispatchReplyFromConfig: dispatchFn,
+          },
+        },
+        config: {
+          loadConfig: () => ({}),
+        },
+      });
+
+      const ctx = createGatewayContext("default", mockAccountConfig, { aborted: true });
+      await thenvoiChannel.gateway!.startAccount(ctx);
+
+      const onRoomEvent = capturedPresenceInstance.onRoomEvent as (
+        roomId: string,
+        event: Record<string, unknown>,
+      ) => Promise<void>;
+
+      await onRoomEvent("room-123", {
+        type: "message_created",
+        roomId: "room-123",
+        payload: {
+          id: "msg-001",
+          chat_room_id: "room-123",
+          sender_id: "user-789",
+          sender_type: "Owner",
+          sender_name: "John Doe",
+          content: "Hello!",
+          message_type: "text",
+          inserted_at: "2025-01-15T10:00:00Z",
+          metadata: {},
+        },
+      });
+
+      expect(mockLinkInstance.rest.createChatEvent).toHaveBeenCalledTimes(1);
+      expect(mockLinkInstance.rest.createChatEvent).toHaveBeenCalledWith(
+        "room-123",
+        expect.objectContaining({ content: "tool output", messageType: "tool_result" }),
+      );
+      expect(mockLinkInstance.rest.createChatMessage).toHaveBeenCalledTimes(1);
+      expect(mockLinkInstance.rest.createChatMessage).toHaveBeenCalledWith(
+        "room-123",
+        expect.objectContaining({
+          content: "Done. I pulled Codex into the room and asked them to help.",
+          mentions: [{ id: "user-789", name: "John Doe" }],
+        }),
+      );
+    });
+
+    it("should drop non-explicit final replies after sending a Band message to another participant", async () => {
+      const dispatchFn = vi.fn().mockImplementation(async ({ dispatcher }) => {
+        recordBandMessageSentForCurrentTurn();
+        dispatcher.sendFinalReply({ text: "I asked Codex to revise that list." });
+        await dispatcher.waitForIdle();
+      });
+      setOpenClawRuntime({
+        channel: {
+          reply: {
+            dispatchReplyFromConfig: dispatchFn,
+          },
+        },
+        config: {
+          loadConfig: () => ({}),
+        },
+      });
+
+      const ctx = createGatewayContext("default", mockAccountConfig, { aborted: true });
+      await thenvoiChannel.gateway!.startAccount(ctx);
+
+      const onRoomEvent = capturedPresenceInstance.onRoomEvent as (
+        roomId: string,
+        event: Record<string, unknown>,
+      ) => Promise<void>;
+
+      await onRoomEvent("room-123", {
+        type: "message_created",
+        roomId: "room-123",
+        payload: {
+          id: "msg-001",
+          chat_room_id: "room-123",
+          sender_id: "agent-456",
+          sender_type: "Agent",
+          sender_name: "Codex",
+          content: "Here is the draft.",
+          message_type: "text",
+          inserted_at: "2025-01-15T10:00:00Z",
+          metadata: {},
+        },
+      });
+
+      expect(mockLinkInstance.rest.createChatMessage).not.toHaveBeenCalled();
+    });
+
+    it("should drain pending mentioned messages when joining existing rooms", async () => {
+      const callback = vi.fn();
+      setInboundCallback(callback);
+
+      const pendingMessage = {
+        id: "msg-pending-001",
+        content: "@Test Agent are you there?",
+        sender_id: "user-789",
+        sender_type: "User",
+        sender_name: "John Doe",
+        message_type: "text",
+        metadata: {},
+        inserted_at: new Date().toISOString(),
+      };
+
+      const ctx = createGatewayContext("default", mockAccountConfig, { aborted: true });
+      await thenvoiChannel.gateway!.startAccount(ctx);
+      vi.mocked(mockLinkInstance.rest.getNextMessage as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(pendingMessage)
+        .mockResolvedValueOnce(null);
+
+      const onRoomJoined = capturedPresenceInstance.onRoomJoined as (
+        roomId: string,
+        payload: Record<string, unknown>,
+      ) => Promise<void>;
+      await onRoomJoined("room-123", { title: "Existing Room" });
+
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: "room-123",
+          senderId: "user-789",
+          text: "@Test Agent are you there?",
+        }),
+      );
+      expect(mockLinkInstance.markProcessing).toHaveBeenCalledWith("room-123", "msg-pending-001", { bestEffort: true });
+      expect(mockLinkInstance.markProcessed).toHaveBeenCalledWith("room-123", "msg-pending-001", { bestEffort: true });
     });
 
     it("should mark message as processed after handling", async () => {

--- a/packages/openclaw/tests/unit/channel.test.ts
+++ b/packages/openclaw/tests/unit/channel.test.ts
@@ -70,7 +70,7 @@ describe("Channel Module", () => {
     it("should have correct metadata", () => {
       expect(thenvoiChannel.id).toBe("openclaw-channel-thenvoi");
       expect(thenvoiChannel.meta.id).toBe("openclaw-channel-thenvoi");
-      expect(thenvoiChannel.meta.label).toBe("Thenvoi");
+      expect(thenvoiChannel.meta.label).toBe("Band");
       expect(thenvoiChannel.meta.aliases).toContain("thenvoi");
     });
 
@@ -79,7 +79,7 @@ describe("Channel Module", () => {
     });
 
     it("should have selection label", () => {
-      expect(thenvoiChannel.meta.selectionLabel).toContain("Thenvoi");
+      expect(thenvoiChannel.meta.selectionLabel).toContain("Band");
     });
   });
 
@@ -180,6 +180,31 @@ describe("Channel Module", () => {
         expect(result.errors).toBeUndefined();
       });
 
+      it("should resolve credential placeholders from environment variables", async () => {
+        const originalApiKey = process.env.THENVOI_API_KEY;
+        const originalAgentId = process.env.THENVOI_AGENT_ID;
+        process.env.THENVOI_API_KEY = "test-api-key-12345";
+        process.env.THENVOI_AGENT_ID = "agent-env-123";
+        fetchMock = createMockFetch({ response: mockAgentMetadata });
+        globalThis.fetch = fetchMock;
+
+        try {
+          const result = await thenvoiChannel.setup!.validateConfig!({
+            apiKey: "${THENVOI_API_KEY}",
+            agentId: "${THENVOI_AGENT_ID}",
+            restUrl: mockAccountConfig.restUrl,
+            wsUrl: mockAccountConfig.wsUrl,
+          });
+
+          expect(result.valid).toBe(true);
+        } finally {
+          if (originalApiKey === undefined) delete process.env.THENVOI_API_KEY;
+          else process.env.THENVOI_API_KEY = originalApiKey;
+          if (originalAgentId === undefined) delete process.env.THENVOI_AGENT_ID;
+          else process.env.THENVOI_AGENT_ID = originalAgentId;
+        }
+      });
+
       it("should fail for missing API key", async () => {
         const result = await thenvoiChannel.setup!.validateConfig!({});
 
@@ -224,7 +249,7 @@ describe("Channel Module", () => {
       const context = thenvoiChannel.threading!.formatThreadContext!("room-123");
 
       expect(context).toContain("room-123");
-      expect(context).toContain("Thenvoi");
+      expect(context).toContain("Band");
     });
   });
 

--- a/packages/openclaw/tests/unit/manifest.test.ts
+++ b/packages/openclaw/tests/unit/manifest.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it } from "vitest";
 import { getMcpToolSchemas } from "../../src/mcp-tools.js";
 
 interface PluginManifest {
+  contracts?: {
+    tools?: string[];
+  };
   capabilities?: {
     mcp?: {
       tools?: string[];
@@ -17,10 +20,13 @@ function readManifest(): PluginManifest {
 
 describe("openclaw.plugin.json", () => {
   it("declares exactly the runtime MCP tools", () => {
-    const manifestTools = readManifest().capabilities?.mcp?.tools ?? [];
+    const manifest = readManifest();
+    const manifestTools = manifest.capabilities?.mcp?.tools ?? [];
+    const contractTools = manifest.contracts?.tools ?? [];
     const runtimeTools = getMcpToolSchemas().map((tool) => tool.name);
 
     expect([...manifestTools].sort()).toEqual([...runtimeTools].sort());
+    expect([...contractTools].sort()).toEqual([...runtimeTools].sort());
   });
 
   it("does not require Band credentials for plugin discovery", () => {

--- a/packages/openclaw/tests/unit/manifest.test.ts
+++ b/packages/openclaw/tests/unit/manifest.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { getMcpToolSchemas } from "../../src/mcp-tools.js";
+
+interface PluginManifest {
+  capabilities?: {
+    mcp?: {
+      tools?: string[];
+    };
+  };
+  environment?: Record<string, { required?: boolean }>;
+}
+
+function readManifest(): PluginManifest {
+  return JSON.parse(readFileSync(new URL("../../openclaw.plugin.json", import.meta.url), "utf-8")) as PluginManifest;
+}
+
+describe("openclaw.plugin.json", () => {
+  it("declares exactly the runtime MCP tools", () => {
+    const manifestTools = readManifest().capabilities?.mcp?.tools ?? [];
+    const runtimeTools = getMcpToolSchemas().map((tool) => tool.name);
+
+    expect([...manifestTools].sort()).toEqual([...runtimeTools].sort());
+  });
+
+  it("does not require Band credentials for plugin discovery", () => {
+    const environment = readManifest().environment ?? {};
+
+    expect(environment.THENVOI_API_KEY?.required).toBe(false);
+    expect(environment.THENVOI_AGENT_ID?.required).toBe(false);
+  });
+});

--- a/packages/openclaw/tests/unit/mcp-tools.test.ts
+++ b/packages/openclaw/tests/unit/mcp-tools.test.ts
@@ -28,7 +28,6 @@ vi.mock("../../src/channel.js", () => ({
   getLink: vi.fn(),
   getAgentId: vi.fn(),
   getBandToolEventContext: vi.fn(),
-  recordBandMessageSentForCurrentTurn: vi.fn(),
 }));
 
 describe("MCP Tools", () => {

--- a/packages/openclaw/tests/unit/mcp-tools.test.ts
+++ b/packages/openclaw/tests/unit/mcp-tools.test.ts
@@ -3,7 +3,6 @@
  * Mocks getLink() to return a mock ThenvoiLink with a mock rest API.
  */
 
-import { readFileSync } from "node:fs";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   mcpTools,
@@ -28,6 +27,8 @@ import {
 vi.mock("../../src/channel.js", () => ({
   getLink: vi.fn(),
   getAgentId: vi.fn(),
+  getBandToolEventContext: vi.fn(),
+  recordBandMessageSentForCurrentTurn: vi.fn(),
 }));
 
 describe("MCP Tools", () => {
@@ -86,19 +87,6 @@ describe("MCP Tools", () => {
         expect(tool.description.length).toBeGreaterThan(10);
       });
     });
-
-    it("should declare all runtime tools in the plugin manifest", () => {
-      const manifest = JSON.parse(
-        readFileSync(new URL("../../openclaw.plugin.json", import.meta.url), "utf-8"),
-      ) as {
-        contracts?: { tools?: string[] };
-        capabilities?: { mcp?: { tools?: string[] } };
-      };
-      const runtimeToolNames = getMcpToolSchemas().map((tool) => tool.name).sort();
-
-      expect([...(manifest.contracts?.tools ?? [])].sort()).toEqual(runtimeToolNames);
-      expect([...(manifest.capabilities?.mcp?.tools ?? [])].sort()).toEqual(runtimeToolNames);
-    });
   });
 
   describe("getMcpTool", () => {
@@ -146,6 +134,21 @@ describe("MCP Tools", () => {
       expect(result).toHaveProperty("peers");
       expect(result).toHaveProperty("total");
       expect(result).toHaveProperty("has_more");
+    });
+
+    it("should use the account from the current Band tool context", async () => {
+      const accountRest = { ...mockRest, listPeers: vi.fn().mockResolvedValue(mockLookupPeersResponse) };
+      const accountLink = { rest: accountRest, agentId: "agent-b" };
+      vi.mocked(channel.getBandToolEventContext).mockReturnValue({ accountId: "account-b", roomId: "room-1" });
+      vi.mocked(channel.getLink).mockImplementation((accountId?: string) => {
+        return (accountId === "account-b" ? accountLink : mockLink) as unknown as ReturnType<typeof channel.getLink>;
+      });
+
+      await executeMcpTool("thenvoi_lookup_peers", { page: 2, page_size: 25 });
+
+      expect(channel.getLink).toHaveBeenCalledWith("account-b");
+      expect(accountRest.listPeers).toHaveBeenCalledWith({ page: 2, pageSize: 25, notInChat: "" });
+      expect(mockRest.listPeers).not.toHaveBeenCalled();
     });
 
     it("should call listPeers with provided pagination", async () => {
@@ -444,14 +447,14 @@ describe("MCP Tools", () => {
   });
 
   describe("thenvoi_send_message", () => {
-    it("should send message with mentions", async () => {
+    it("should send message with participant UUID mentions", async () => {
       mockRest.listChatParticipants.mockResolvedValue(mockParticipants);
       mockRest.createChatMessage.mockResolvedValue(mockSendMessageResponse);
 
       const result = await executeMcpTool("thenvoi_send_message", {
         room_id: "room-001",
         content: "Hello!",
-        mentions: ["John Doe"],
+        mentions: ["user-789"],
       });
 
       expect(mockRest.listChatParticipants).toHaveBeenCalledWith("room-001");
@@ -465,16 +468,28 @@ describe("MCP Tools", () => {
       expect(result).toHaveProperty("success", true);
     });
 
-    it("should throw error if mention not found", async () => {
+    it("should throw error if mention UUID not found", async () => {
       mockRest.listChatParticipants.mockResolvedValue(mockParticipants);
 
       await expect(
         executeMcpTool("thenvoi_send_message", {
           room_id: "room-001",
           content: "Hello!",
-          mentions: ["Unknown Person"],
+          mentions: ["missing-user-id"],
         }),
-      ).rejects.toThrow('Participant "Unknown Person" not found in room');
+      ).rejects.toThrow('Participant ID "missing-user-id" not found in room');
+    });
+
+    it("should throw if message mentions self", async () => {
+      mockRest.listChatParticipants.mockResolvedValue(mockParticipants);
+
+      await expect(
+        executeMcpTool("thenvoi_send_message", {
+          room_id: "room-001",
+          content: "Hello!",
+          mentions: ["agent-123"],
+        }),
+      ).rejects.toThrow("You cannot mention yourself");
     });
 
     it("should throw error if no mentions provided", async () => {

--- a/packages/openclaw/tests/unit/openclaw-runtime.test.ts
+++ b/packages/openclaw/tests/unit/openclaw-runtime.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveOpenClawRuntimeDispatch } from "../../src/openclaw-runtime.js";
+
+describe("resolveOpenClawRuntimeDispatch", () => {
+  it("rejects a missing runtime", () => {
+    const result = resolveOpenClawRuntimeDispatch(undefined);
+
+    expect(result.dispatch).toBeNull();
+    expect(result.reason).toContain("runtime is not an object");
+  });
+
+  it("rejects a runtime without config.loadConfig", () => {
+    const result = resolveOpenClawRuntimeDispatch({ channel: { reply: { dispatchReplyFromConfig: vi.fn() } } });
+
+    expect(result.dispatch).toBeNull();
+    expect(result.reason).toContain("runtime.config.loadConfig");
+  });
+
+  it("rejects a runtime without channel.reply.dispatchReplyFromConfig", () => {
+    const result = resolveOpenClawRuntimeDispatch({ config: { loadConfig: vi.fn() }, channel: { reply: {} } });
+
+    expect(result.dispatch).toBeNull();
+    expect(result.reason).toContain("runtime.channel.reply.dispatchReplyFromConfig");
+  });
+
+  it("wraps a valid runtime dispatch shape", async () => {
+    const cfg = { channels: {} };
+    const loadConfig = vi.fn(() => cfg);
+    const dispatchReplyFromConfig = vi.fn(async () => undefined);
+    const result = resolveOpenClawRuntimeDispatch({
+      config: { loadConfig },
+      channel: { reply: { dispatchReplyFromConfig } },
+    });
+
+    expect(result.reason).toBeUndefined();
+    expect(result.dispatch?.loadConfig()).toBe(cfg);
+
+    const args = { ctx: {}, cfg, dispatcher: {} };
+    await result.dispatch?.dispatchReplyFromConfig(args);
+
+    expect(loadConfig).toHaveBeenCalledTimes(1);
+    expect(dispatchReplyFromConfig).toHaveBeenCalledWith(args);
+  });
+
+  it("preserves OpenClaw runtime method receivers", async () => {
+    const runtime = {
+      config: {
+        cfg: { channels: {} },
+        loadConfig() {
+          return this.cfg;
+        },
+      },
+      channel: {
+        reply: {
+          calls: [] as unknown[],
+          async dispatchReplyFromConfig(args: unknown) {
+            this.calls.push(args);
+          },
+        },
+      },
+    };
+
+    const result = resolveOpenClawRuntimeDispatch(runtime);
+    const cfg = result.dispatch?.loadConfig();
+    const args = { ctx: {}, cfg, dispatcher: {} };
+    await result.dispatch?.dispatchReplyFromConfig(args);
+
+    expect(cfg).toBe(runtime.config.cfg);
+    expect(runtime.channel.reply.calls).toEqual([args]);
+  });
+});

--- a/packages/openclaw/tests/unit/plugin.test.ts
+++ b/packages/openclaw/tests/unit/plugin.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  registeredTools: [] as Array<{ name: string; execute: (toolCallId: unknown, input: unknown) => Promise<unknown> }>,
+  createChatEvent: vi.fn().mockResolvedValue({ ok: true }),
+  executeMcpTool: vi.fn().mockResolvedValue({ success: true, apiKey: "thnv_a_123456789abcdef" }),
+}));
+
+vi.mock("../../src/channel.js", () => ({
+  registerChannel: vi.fn(),
+  thenvoiChannel: {},
+  setInboundCallback: vi.fn(),
+  setOpenClawRuntime: vi.fn(),
+  getBandToolEventContext: vi.fn(() => ({ accountId: "default", roomId: "room-123" })),
+  getLink: vi.fn(() => ({ rest: { createChatEvent: mocks.createChatEvent } })),
+}));
+
+vi.mock("../../src/mcp-tools.js", () => ({
+  getMcpToolSchemas: vi.fn(() => [
+    {
+      name: "thenvoi_lookup_peers",
+      description: "Find available Band peers",
+      inputSchema: { type: "object", properties: {} },
+    },
+  ]),
+  executeMcpTool: mocks.executeMcpTool,
+}));
+
+import plugin from "../../src/index.js";
+
+describe("OpenClaw plugin tool event reporting", () => {
+  beforeEach(() => {
+    mocks.registeredTools.length = 0;
+    mocks.createChatEvent.mockClear();
+    mocks.executeMcpTool.mockClear();
+    mocks.executeMcpTool.mockResolvedValue({ success: true, apiKey: "thnv_a_123456789abcdef" });
+  });
+
+  it("emits Band tool_call and tool_result events around thenvoi tool execution", async () => {
+    plugin({
+      registerChannel: vi.fn(),
+      registerTool: (tool) => mocks.registeredTools.push(tool),
+    });
+
+    await mocks.registeredTools[0]?.execute("tool-call-1", {
+      page: 1,
+      apiKey: "thnv_a_123456789abcdef",
+    });
+
+    expect(mocks.createChatEvent).toHaveBeenCalledTimes(2);
+    expect(mocks.createChatEvent).toHaveBeenNthCalledWith(
+      1,
+      "room-123",
+      expect.objectContaining({
+        messageType: "tool_call",
+        content: expect.stringContaining("[REDACTED]"),
+        metadata: expect.objectContaining({
+          source: "openclaw",
+          toolName: "thenvoi_lookup_peers",
+          toolCallId: "tool-call-1",
+        }),
+      }),
+    );
+    expect(mocks.createChatEvent).toHaveBeenNthCalledWith(
+      2,
+      "room-123",
+      expect.objectContaining({
+        messageType: "tool_result",
+        content: expect.stringContaining("[REDACTED]"),
+        metadata: expect.objectContaining({
+          source: "openclaw",
+          toolName: "thenvoi_lookup_peers",
+          toolCallId: "tool-call-1",
+          status: "success",
+        }),
+      }),
+    );
+  });
+});

--- a/packages/openclaw/tests/unit/prompts.test.ts
+++ b/packages/openclaw/tests/unit/prompts.test.ts
@@ -8,17 +8,18 @@ import { BASE_INSTRUCTIONS, buildSystemPrompt } from "../../src/prompts.js";
 describe("Prompts", () => {
   describe("BASE_INSTRUCTIONS", () => {
     it("should contain channel instructions section", () => {
-      expect(BASE_INSTRUCTIONS).toContain("## Thenvoi Channel Instructions");
+      expect(BASE_INSTRUCTIONS).toContain("## Band Channel Instructions");
     });
 
     it("should explain two operating contexts", () => {
       expect(BASE_INSTRUCTIONS).toContain("Webchat/CLI context");
-      expect(BASE_INSTRUCTIONS).toContain("Thenvoi room context");
+      expect(BASE_INSTRUCTIONS).toContain("Band room context");
     });
 
-    it("should mention plain text auto-routing", () => {
-      expect(BASE_INSTRUCTIONS).toContain("automatically routed");
-      expect(BASE_INSTRUCTIONS).toContain("plain text");
+    it("should explain final-answer routing and tool-based handoffs", () => {
+      expect(BASE_INSTRUCTIONS).toContain("plain text final answers");
+      expect(BASE_INSTRUCTIONS).toContain("thenvoi_send_message only when another participant should act next");
+      expect(BASE_INSTRUCTIONS).toContain("participant UUID");
     });
 
     it("should list tools that work without room_id", () => {
@@ -31,12 +32,30 @@ describe("Prompts", () => {
       expect(BASE_INSTRUCTIONS).toContain("thenvoi_send_message");
       expect(BASE_INSTRUCTIONS).toContain("thenvoi_send_event");
       expect(BASE_INSTRUCTIONS).toContain("thenvoi_add_participant");
+      expect(BASE_INSTRUCTIONS).toContain("Do not use OpenClaw session tools");
     });
 
     it("should contain delegation instructions", () => {
       expect(BASE_INSTRUCTIONS).toContain("Delegating to Other Agents");
       expect(BASE_INSTRUCTIONS).toContain("lookup_peers");
       expect(BASE_INSTRUCTIONS).toContain("add_participant");
+      expect(BASE_INSTRUCTIONS).toContain("original requester");
+      expect(BASE_INSTRUCTIONS).toContain("Only @mention another agent");
+      expect(BASE_INSTRUCTIONS).toContain("Never mention yourself");
+      expect(BASE_INSTRUCTIONS).toContain("participant UUIDs");
+      expect(BASE_INSTRUCTIONS).toContain("do NOT reflexively summarize to the original requester");
+      expect(BASE_INSTRUCTIONS).toContain("close the loop with the original requester");
+      expect(BASE_INSTRUCTIONS).toContain("another agent's filesystem");
+      expect(BASE_INSTRUCTIONS).toContain("Plain text finals go to the room owner/requester");
+      expect(BASE_INSTRUCTIONS).toContain("responding to that agent with critique/follow-up");
+      expect(BASE_INSTRUCTIONS).toContain("Default to agent-to-agent communication until the delegated work is complete");
+      expect(BASE_INSTRUCTIONS).toContain("current message is from a worker agent");
+      expect(BASE_INSTRUCTIONS).toContain("nothing useful left to ask the worker");
+      expect(BASE_INSTRUCTIONS).toContain("make it completely empty");
+      expect(BASE_INSTRUCTIONS).toContain("final consensus draft");
+      expect(BASE_INSTRUCTIONS).toContain("state your own judgment");
+      expect(BASE_INSTRUCTIONS).toContain("concrete challenge");
+      expect(BASE_INSTRUCTIONS).toContain("needs a human decision");
     });
 
     it("should contain examples", () => {
@@ -59,7 +78,7 @@ describe("Prompts", () => {
     it("should include base instructions", () => {
       const prompt = buildSystemPrompt("Test Agent", "a test agent");
 
-      expect(prompt).toContain("## Thenvoi Channel Instructions");
+      expect(prompt).toContain("## Band Channel Instructions");
       expect(prompt).toContain("lookup_peers");
     });
 
@@ -84,7 +103,7 @@ describe("Prompts", () => {
 
       const identityIndex = prompt.indexOf("You are Test Agent");
       const customIndex = prompt.indexOf("CUSTOM_MARKER");
-      const baseIndex = prompt.indexOf("## Thenvoi Channel Instructions");
+      const baseIndex = prompt.indexOf("## Band Channel Instructions");
 
       expect(identityIndex).toBeLessThan(customIndex);
       expect(customIndex).toBeLessThan(baseIndex);
@@ -94,7 +113,7 @@ describe("Prompts", () => {
       const prompt = buildSystemPrompt("Test Agent", "a test agent");
 
       expect(prompt).toContain("You are Test Agent");
-      expect(prompt).toContain("## Thenvoi Channel Instructions");
+      expect(prompt).toContain("## Band Channel Instructions");
       expect(prompt).not.toContain("undefined");
     });
 

--- a/packages/openclaw/tests/unit/redaction.test.ts
+++ b/packages/openclaw/tests/unit/redaction.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { redact } from "../../scripts/nemoclaw-integration-common.js";
+import { redactSecrets } from "../../src/redaction.js";
+
+describe("redactSecrets", () => {
+  it("redacts Band and Thenvoi API keys", () => {
+    for (const token of [
+      "tv_123456789abcdef",
+      "thnv_a_123456789abcdef",
+      "thnv_u_123456789abcdef",
+      "thnv_123456789abcdef",
+      "band_a_123456789abcdef",
+      "band_u_123456789abcdef",
+    ]) {
+      expect(redactSecrets(`failed with ${token}`)).toBe("failed with [REDACTED]");
+    }
+  });
+
+  it("redacts bearer tokens", () => {
+    expect(redactSecrets("Authorization: Bearer abcdefghijklmnop")).toBe("Authorization: Bearer [REDACTED]");
+  });
+
+  it("redacts gateway tokens", () => {
+    expect(redactSecrets("gateway_token=secret-token-value")).toBe("gateway_token=[REDACTED]");
+  });
+
+  it("redacts Error messages", () => {
+    expect(redactSecrets(new Error("apiKey: tv_abcdefghijk"))).toBe("apiKey: [REDACTED]");
+  });
+
+  it("keeps NemoClaw script redaction in sync with runtime credential prefixes", () => {
+    for (const token of [
+      "thnv_a_123456789abcdef",
+      "thnv_u_123456789abcdef",
+      "thnv_123456789abcdef",
+      "band_a_123456789abcdef",
+      "band_u_123456789abcdef",
+    ]) {
+      expect(redact(`nemoclaw failed with ${token}`)).toBe("nemoclaw failed with [REDACTED]");
+    }
+  });
+});

--- a/packages/openclaw/tests/unit/reply-dispatcher.test.ts
+++ b/packages/openclaw/tests/unit/reply-dispatcher.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createBandReplyDispatcher } from "../../src/reply-dispatcher.js";
+
+function createDispatcher() {
+  const link = {
+    rest: {
+      createChatMessage: vi.fn().mockResolvedValue({ ok: true }),
+      createChatEvent: vi.fn().mockResolvedValue({ ok: true }),
+    },
+  };
+  const dispatcher = createBandReplyDispatcher(
+    link as never,
+    "default",
+    "room-123",
+    async () => [{ id: "user-1", name: "User" }],
+  );
+
+  return { dispatcher, link };
+}
+
+describe("Band reply dispatcher", () => {
+  it("coalesces fragmented final replies when no explicit user message tag is emitted", async () => {
+    const { dispatcher, link } = createDispatcher();
+
+    dispatcher.sendFinalReply({ text: "I" });
+    dispatcher.sendFinalReply({ text: "'ll help" });
+    dispatcher.sendFinalReply({ text: " you." });
+    await dispatcher.waitForIdle();
+
+    expect(link.rest.createChatMessage).toHaveBeenCalledWith(
+      "room-123",
+      expect.objectContaining({ content: "I'll help you." }),
+    );
+  });
+
+  it("does not silently drop a single short final reply", async () => {
+    const { dispatcher, link } = createDispatcher();
+
+    dispatcher.sendFinalReply({ text: "OK" });
+    await dispatcher.waitForIdle();
+
+    expect(link.rest.createChatMessage).toHaveBeenCalledWith(
+      "room-123",
+      expect.objectContaining({ content: "OK" }),
+    );
+  });
+});

--- a/packages/openclaw/tests/unit/reply-dispatcher.test.ts
+++ b/packages/openclaw/tests/unit/reply-dispatcher.test.ts
@@ -20,7 +20,7 @@ function createDispatcher() {
 }
 
 describe("Band reply dispatcher", () => {
-  it("coalesces fragmented final replies when no explicit user message tag is emitted", async () => {
+  it("drops non-explicit final replies", async () => {
     const { dispatcher, link } = createDispatcher();
 
     dispatcher.sendFinalReply({ text: "I" });
@@ -28,21 +28,19 @@ describe("Band reply dispatcher", () => {
     dispatcher.sendFinalReply({ text: " you." });
     await dispatcher.waitForIdle();
 
-    expect(link.rest.createChatMessage).toHaveBeenCalledWith(
-      "room-123",
-      expect.objectContaining({ content: "I'll help you." }),
-    );
+    expect(link.rest.createChatMessage).not.toHaveBeenCalled();
   });
 
-  it("does not silently drop a single short final reply", async () => {
+  it("sends explicit user-facing final replies", async () => {
     const { dispatcher, link } = createDispatcher();
 
     dispatcher.sendFinalReply({ text: "I" });
+    dispatcher.sendFinalReply({ text: "<message to user>Done.</message>" });
     await dispatcher.waitForIdle();
 
     expect(link.rest.createChatMessage).toHaveBeenCalledWith(
       "room-123",
-      expect.objectContaining({ content: "I" }),
+      expect.objectContaining({ content: "Done." }),
     );
   });
 });

--- a/packages/openclaw/tests/unit/reply-dispatcher.test.ts
+++ b/packages/openclaw/tests/unit/reply-dispatcher.test.ts
@@ -37,12 +37,12 @@ describe("Band reply dispatcher", () => {
   it("does not silently drop a single short final reply", async () => {
     const { dispatcher, link } = createDispatcher();
 
-    dispatcher.sendFinalReply({ text: "OK" });
+    dispatcher.sendFinalReply({ text: "I" });
     await dispatcher.waitForIdle();
 
     expect(link.rest.createChatMessage).toHaveBeenCalledWith(
       "room-123",
-      expect.objectContaining({ content: "OK" }),
+      expect.objectContaining({ content: "I" }),
     );
   });
 });

--- a/packages/openclaw/tsup.config.ts
+++ b/packages/openclaw/tsup.config.ts
@@ -130,6 +130,10 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   shims: true,
+  splitting: false,
+  banner: {
+    js: 'import { createRequire } from "node:module"; const require = createRequire(import.meta.url);',
+  },
   target: "node22",
   outDir: "dist",
   // Keep openclaw external (host provides it)

--- a/packages/sdk/src/adapters/a2a-gateway/A2AGatewayAdapter.ts
+++ b/packages/sdk/src/adapters/a2a-gateway/A2AGatewayAdapter.ts
@@ -229,59 +229,23 @@ export class A2AGatewayAdapter
       peer.id,
     );
 
-    const roomPendings = this.pendingByRoom.get(roomId);
-    const activeInRoom = roomPendings?.size ?? 0;
-    const queue = new AsyncEventQueue<GatewayA2AStatusUpdateEvent>();
-    const strictTaskMetadata = hadContext;
-    const pending: PendingTaskRecord = {
-      taskId: request.taskId,
-      contextId,
-      peerId: peer.id,
-      peerSlug: peer.slug,
+    const pending = this.createPendingTask({
+      request,
+      peer,
       roomId,
-      strictTaskMetadata,
-      requireTaskMetadata: strictTaskMetadata || activeInRoom > 0,
-      queue,
-      enqueue: (event) => {
-        queue.enqueue(event);
-      },
-    };
-
-    this.registerPending(pending);
-    this.pendingByTask.set(pending.taskId, pending);
-
-    yield buildStatusEvent({
-      taskId: pending.taskId,
-      contextId: pending.contextId,
-      state: "working",
-      final: false,
-      text: `Routed request to ${peer.name}.`,
+      contextId,
+      hadContext,
     });
 
-    try {
-      await this.emitContextEvent(roomId, contextId);
+    this.registerPending(pending);
 
-      const content = extractMessageText(request.message) ?? "";
-      await this.thenvoiRest.createChatMessage(roomId, {
-        content: buildMentionedContent(peer.name, content),
-        mentions: buildMentions(peer),
-        metadata: {
-          gateway_context_id: contextId,
-          gateway_room_id: roomId,
-          gateway_task_id: request.taskId,
-          gateway_peer_id: peer.id,
-          gateway_peer_slug: peer.slug,
-        },
-      });
+    yield this.createRoutedEvent(pending, peer);
+
+    try {
+      await this.dispatchGatewayRequestToRoom(request, peer, roomId, contextId);
     } catch (error) {
       this.removePending(pending);
-      yield buildStatusEvent({
-        taskId: pending.taskId,
-        contextId: pending.contextId,
-        state: "failed",
-        final: true,
-        text: error instanceof Error ? error.message : String(error),
-      });
+      yield this.createFailedEvent(pending, error);
       return;
     }
 
@@ -308,6 +272,81 @@ export class A2AGatewayAdapter
     }
   }
 
+  private createPendingTask(options: {
+    request: GatewayRequest;
+    peer: GatewayPeer;
+    roomId: string;
+    contextId: string;
+    hadContext: boolean;
+  }): PendingTaskRecord {
+    const roomPendings = this.pendingByRoom.get(options.roomId);
+    const activeInRoom = roomPendings?.size ?? 0;
+    const queue = new AsyncEventQueue<GatewayA2AStatusUpdateEvent>();
+    const strictTaskMetadata = options.hadContext;
+
+    return {
+      taskId: options.request.taskId,
+      contextId: options.contextId,
+      peerId: options.peer.id,
+      peerSlug: options.peer.slug,
+      roomId: options.roomId,
+      strictTaskMetadata,
+      requireTaskMetadata: strictTaskMetadata || activeInRoom > 0,
+      queue,
+      enqueue: (event) => {
+        queue.enqueue(event);
+      },
+    };
+  }
+
+  private createRoutedEvent(
+    pending: PendingTaskRecord,
+    peer: GatewayPeer,
+  ): GatewayA2AStatusUpdateEvent {
+    return buildStatusEvent({
+      taskId: pending.taskId,
+      contextId: pending.contextId,
+      state: "working",
+      final: false,
+      text: `Routed request to ${peer.name}.`,
+    });
+  }
+
+  private createFailedEvent(
+    pending: PendingTaskRecord,
+    error: unknown,
+  ): GatewayA2AStatusUpdateEvent {
+    return buildStatusEvent({
+      taskId: pending.taskId,
+      contextId: pending.contextId,
+      state: "failed",
+      final: true,
+      text: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  private async dispatchGatewayRequestToRoom(
+    request: GatewayRequest,
+    peer: GatewayPeer,
+    roomId: string,
+    contextId: string,
+  ): Promise<void> {
+    await this.emitContextEvent(roomId, contextId);
+
+    const content = extractMessageText(request.message) ?? "";
+    await this.thenvoiRest.createChatMessage(roomId, {
+      content: buildMentionedContent(peer.name, content),
+      mentions: buildMentions(peer),
+      metadata: {
+        gateway_context_id: contextId,
+        gateway_room_id: roomId,
+        gateway_task_id: request.taskId,
+        gateway_peer_id: peer.id,
+        gateway_peer_slug: peer.slug,
+      },
+    });
+  }
+
   private cancelPendingTask(taskId: string, peerId: string): void {
     const pending = this.pendingByTask.get(taskId);
     if (!pending) {
@@ -331,6 +370,7 @@ export class A2AGatewayAdapter
     const roomPendings = this.pendingByRoom.get(pending.roomId) ?? new Map<string, PendingTaskRecord>();
     roomPendings.set(pending.taskId, pending);
     this.pendingByRoom.set(pending.roomId, roomPendings);
+    this.pendingByTask.set(pending.taskId, pending);
 
     if (roomPendings.size > 1) {
       for (const entry of roomPendings.values()) {

--- a/packages/sdk/src/runtime/Execution.ts
+++ b/packages/sdk/src/runtime/Execution.ts
@@ -18,6 +18,12 @@ interface ExecutionOptions {
   onExecute: ExecutionHandler;
   onFailure?: (error: unknown, event: PlatformEvent) => void | Promise<void>;
   logger?: Logger;
+  /**
+   * Skip the startup `/messages/next` drain for rooms discovered during bulk
+   * auto-subscribe. Stale `processing` recovery still runs, because existing
+   * rooms may have in-flight messages left behind by a previous process.
+   */
+  skipStartupQueueSync?: boolean;
 }
 
 function toMessageEvent(message: PlatformMessage): PlatformEvent {
@@ -58,6 +64,7 @@ export class Execution {
   private syncComplete = false;
   private running = true;
   private inFlight = 0;
+  private readonly skipStartupQueueSync: boolean;
 
   public constructor(options: ExecutionOptions) {
     this.roomId = options.roomId;
@@ -66,6 +73,7 @@ export class Execution {
     this.retryTracker = this.context.getRetryTracker();
     this.onExecute = options.onExecute;
     this.onFailure = options.onFailure;
+    this.skipStartupQueueSync = options.skipStartupQueueSync ?? false;
     this.logger = options.logger ?? new NoopLogger();
     this.processTask = this.processLoop();
   }
@@ -153,7 +161,17 @@ export class Execution {
 
   private async processLoop(): Promise<void> {
     await this.recoverStaleProcessingMessages();
-    await this.synchronizeWithNext();
+
+    if (this.skipStartupQueueSync) {
+      // Bulk auto-subscribe can attach to many existing rooms at once. Avoid
+      // draining `/messages/next` for every room, but keep stale-processing
+      // recovery above so restarts do not strand messages already claimed by
+      // this agent.
+      this.syncComplete = true;
+      this.notifyIfIdle();
+    } else {
+      await this.synchronizeWithNext();
+    }
 
     while (this.running) {
       const event = await this.nextQueuedEvent();

--- a/packages/sdk/src/runtime/rooms/AgentRuntime.ts
+++ b/packages/sdk/src/runtime/rooms/AgentRuntime.ts
@@ -177,7 +177,7 @@ export class AgentRuntime {
 
     await this.link.disconnect();
     if (this.fatalError) {
-      throw this.fatalError instanceof Error ? this.fatalError : new Error(String(this.fatalError));
+      throw asThrowableError(this.fatalError);
     }
     return graceful;
   }
@@ -194,7 +194,7 @@ export class AgentRuntime {
     }
 
     if (this.fatalError) {
-      throw this.fatalError instanceof Error ? this.fatalError : new Error(String(this.fatalError));
+      throw asThrowableError(this.fatalError);
     }
   }
 
@@ -220,17 +220,29 @@ export class AgentRuntime {
   private async handleEvent(event: PlatformEvent): Promise<void> {
     switch (event.type) {
       case "room_added":
-        await trackRoomJoin({
-          link: this.link,
-          roomId: event.roomId,
-          payload: event.payload as MetadataMap,
-          trackedRooms: this.subscribedRooms,
-          roomFilter: this.roomFilter,
-          onJoined: async (roomId) => {
-            this.getOrCreateExecution(roomId);
-            await this.onRoomJoined?.(roomId, event.payload as MetadataMap);
-          },
-        });
+        try {
+          await trackRoomJoin({
+            link: this.link,
+            roomId: event.roomId,
+            payload: event.payload as MetadataMap,
+            trackedRooms: this.subscribedRooms,
+            roomFilter: this.roomFilter,
+            onJoined: async (roomId) => {
+              // `room_added` from the platform: another participant just added
+              // us to a chat. There may already be a message in the chat that
+              // arrived before our channel-join completes, so we still need
+              // the one-shot REST catch-up here to avoid losing it. (Only the
+              // startup bulk-rehydrate path skips the catch-up.)
+              this.getOrCreateExecution(roomId);
+              await this.onRoomJoined?.(roomId, event.payload as MetadataMap);
+            },
+          });
+        } catch (error) {
+          this.logger.warn("AgentRuntime failed to join room_added topic", {
+            roomId: event.roomId,
+            error,
+          });
+        }
         return;
       case "room_removed":
       case "room_deleted":
@@ -300,7 +312,7 @@ export class AgentRuntime {
     return graceful;
   }
 
-  private getOrCreateExecution(roomId: string): Execution {
+  private getOrCreateExecution(roomId: string, options?: { skipStartupQueueSync?: boolean }): Execution {
     const existing = this.executions.get(roomId);
     if (existing) {
       return existing;
@@ -315,6 +327,7 @@ export class AgentRuntime {
         await this.failRuntime(error, event);
       },
       logger: this.logger,
+      ...(options?.skipStartupQueueSync ? { skipStartupQueueSync: true } : {}),
     });
     this.executions.set(roomId, execution);
     const watcher = execution.waitUntilStopped()
@@ -374,7 +387,10 @@ export class AgentRuntime {
       trackedRooms: this.subscribedRooms,
       roomFilter: this.roomFilter,
       onJoined: async (roomId, payload) => {
-        this.getOrCreateExecution(roomId);
+        // Auto-subscribe rehydrate path: skip the startup `/messages/next`
+        // drain to avoid one extra REST poll per existing room. The execution
+        // still recovers stale `processing` messages before going live.
+        this.getOrCreateExecution(roomId, { skipStartupQueueSync: true });
         await this.onRoomJoined?.(roomId, payload);
       },
       onError: async (error) => {
@@ -435,4 +451,21 @@ export class AgentRuntime {
 
 function assertNever(value: never): never {
   throw new Error(`Unhandled platform event: ${JSON.stringify(value)}`);
+}
+
+function asThrowableError(value: unknown): Error {
+  if (value instanceof Error) return value;
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const message = typeof record.message === "string"
+      ? record.message
+      : (() => { try { return JSON.stringify(record); } catch { return Object.prototype.toString.call(record); } })();
+    const err = new Error(message);
+    if (record.stack && typeof record.stack === "string") {
+      err.stack = record.stack;
+    }
+    (err as Error & { cause?: unknown }).cause = value;
+    return err;
+  }
+  return new Error(String(value));
 }

--- a/packages/sdk/src/runtime/rooms/RoomPresence.ts
+++ b/packages/sdk/src/runtime/rooms/RoomPresence.ts
@@ -10,6 +10,7 @@ interface RoomPresenceOptions {
   link: ThenvoiLink;
   roomFilter?: (room: MetadataMap) => boolean;
   autoSubscribeExistingRooms?: boolean;
+  recoverySweepIntervalMs?: number;
   logger?: Logger;
 }
 
@@ -17,6 +18,10 @@ type RoomPresenceJoinHandler = (roomId: string, payload: MetadataMap) => Promise
 type RoomPresenceLeaveHandler = (roomId: string) => Promise<void>;
 type RoomPresenceEventHandler = (roomId: string, event: PlatformEvent) => Promise<void>;
 type RoomPresenceContactHandler = (event: ContactEvent) => Promise<void>;
+type RoomPresenceTask = {
+  context: { eventType: string; roomId: string | null };
+  run: () => Promise<void>;
+};
 
 export class RoomPresence {
   public readonly rooms = new Set<string>();
@@ -28,15 +33,21 @@ export class RoomPresence {
   private readonly link: ThenvoiLink;
   private readonly roomFilter?: (room: MetadataMap) => boolean;
   private readonly autoSubscribeExistingRooms: boolean;
+  private readonly recoverySweepIntervalMs?: number;
   private readonly logger: Logger;
+  private readonly roomTaskQueues = new Map<string, RoomPresenceTask[]>();
+  private readonly activeTasks = new Set<Promise<void>>();
   private eventController: AbortController | null = null;
   private eventTask: Promise<void> | null = null;
+  private recoveryTimer: ReturnType<typeof setInterval> | null = null;
+  private recoverySweepInFlight = false;
   private contactsSubscribed = false;
 
   public constructor(options: RoomPresenceOptions) {
     this.link = options.link;
     this.roomFilter = options.roomFilter;
     this.autoSubscribeExistingRooms = options.autoSubscribeExistingRooms ?? true;
+    this.recoverySweepIntervalMs = options.recoverySweepIntervalMs;
     this.logger = options.logger ?? new NoopLogger();
   }
 
@@ -65,13 +76,25 @@ export class RoomPresence {
 
     this.eventController = new AbortController();
     this.eventTask = this.consumeEvents(this.eventController.signal);
+
+    if (this.recoverySweepIntervalMs && this.recoverySweepIntervalMs > 0) {
+      this.recoveryTimer = setInterval(() => {
+        void this.runRecoverySweep();
+      }, this.recoverySweepIntervalMs);
+    }
   }
 
   public async stop(): Promise<void> {
+    if (this.recoveryTimer) {
+      clearInterval(this.recoveryTimer);
+      this.recoveryTimer = null;
+    }
+
     this.eventController?.abort();
     await this.eventTask;
     this.eventTask = null;
     this.eventController = null;
+    await this.drainActiveTasks();
 
     if (this.contactsSubscribed) {
       await this.link.unsubscribeAgentContacts();
@@ -95,26 +118,84 @@ export class RoomPresence {
         return;
       }
 
-      switch (event.type) {
-        case "room_added":
-          await this.handleRoomAdded(event.roomId, event.payload as MetadataMap);
-          break;
-        case "room_removed":
-        case "room_deleted":
-          await this.handleRoomRemoved(event.roomId);
-          break;
-        case "contact_request_received":
-        case "contact_request_updated":
-        case "contact_added":
-        case "contact_removed":
-          await this.onContactEvent?.(event);
-          break;
-        default:
-          if (event.roomId && this.rooms.has(event.roomId)) {
-            await this.onRoomEvent?.(event.roomId, event);
-          }
-          break;
+      this.scheduleEvent(event);
+    }
+  }
+
+  private async drainActiveTasks(): Promise<void> {
+    while (this.activeTasks.size > 0) {
+      await Promise.allSettled([...this.activeTasks]);
+    }
+  }
+
+  private scheduleEvent(event: PlatformEvent): void {
+    this.scheduleRoomTask(
+      event.roomId ?? "__global__",
+      { eventType: event.type, roomId: event.roomId },
+      () => this.handleEvent(event),
+    );
+  }
+
+  private scheduleRoomTask(
+    roomKey: string,
+    context: { eventType: string; roomId: string | null },
+    run: () => Promise<void>,
+  ): void {
+    const task: RoomPresenceTask = { context, run };
+    const queue = this.roomTaskQueues.get(roomKey);
+    if (queue) {
+      queue.push(task);
+      return;
+    }
+
+    this.roomTaskQueues.set(roomKey, [task]);
+    const worker = this.runRoomTaskQueue(roomKey).finally(() => {
+      this.activeTasks.delete(worker);
+    });
+    this.activeTasks.add(worker);
+  }
+
+  private async runRoomTaskQueue(roomKey: string): Promise<void> {
+    const queue = this.roomTaskQueues.get(roomKey);
+    if (!queue) return;
+
+    while (queue.length > 0) {
+      const task = queue.shift();
+      if (!task) continue;
+
+      try {
+        await task.run();
+      } catch (error) {
+        this.logger.warn("RoomPresence dropped event after handler failure", {
+          ...task.context,
+          error,
+        });
       }
+    }
+
+    this.roomTaskQueues.delete(roomKey);
+  }
+
+  private async handleEvent(event: PlatformEvent): Promise<void> {
+    switch (event.type) {
+      case "room_added":
+        await this.handleRoomAdded(event.roomId, event.payload as MetadataMap);
+        break;
+      case "room_removed":
+      case "room_deleted":
+        await this.handleRoomRemoved(event.roomId);
+        break;
+      case "contact_request_received":
+      case "contact_request_updated":
+      case "contact_added":
+      case "contact_removed":
+        await this.onContactEvent?.(event);
+        break;
+      default:
+        if (event.roomId && this.rooms.has(event.roomId)) {
+          await this.onRoomEvent?.(event.roomId, event);
+        }
+        break;
     }
   }
 
@@ -125,7 +206,7 @@ export class RoomPresence {
       payload,
       trackedRooms: this.rooms,
       roomFilter: this.roomFilter,
-      onJoined: this.onRoomJoined ?? undefined,
+      onJoined: this.onRoomJoined ? this.enqueueRoomJoinedHandler() : undefined,
     });
   }
 
@@ -134,8 +215,28 @@ export class RoomPresence {
       link: this.link,
       roomId,
       trackedRooms: this.rooms,
-      onLeft: this.onRoomLeft ?? undefined,
+      onLeft: this.onRoomLeft ? this.enqueueRoomLeftHandler() : undefined,
     });
+  }
+
+  private enqueueRoomJoinedHandler(): RoomPresenceJoinHandler {
+    return async (roomId, payload) => {
+      this.scheduleRoomTask(
+        roomId,
+        { eventType: "room_joined", roomId },
+        async () => this.onRoomJoined?.(roomId, payload),
+      );
+    };
+  }
+
+  private enqueueRoomLeftHandler(): RoomPresenceLeaveHandler {
+    return async (roomId) => {
+      this.scheduleRoomTask(
+        roomId,
+        { eventType: "room_left", roomId },
+        async () => this.onRoomLeft?.(roomId),
+      );
+    };
   }
 
   private async subscribeExistingRooms(): Promise<void> {
@@ -144,12 +245,27 @@ export class RoomPresence {
       trackedRooms: this.rooms,
       requestOptions: DEFAULT_REQUEST_OPTIONS,
       roomFilter: this.roomFilter,
-      onJoined: this.onRoomJoined ?? undefined,
+      onJoined: this.onRoomJoined ? this.enqueueRoomJoinedHandler() : undefined,
+      onLeft: this.onRoomLeft ? this.enqueueRoomLeftHandler() : undefined,
+      pruneMissing: true,
       onError: async (error) => {
         this.logger.warn("RoomPresence failed to subscribe existing rooms", {
           error,
         });
       },
     });
+  }
+
+  private async runRecoverySweep(): Promise<void> {
+    if (this.recoverySweepInFlight) {
+      return;
+    }
+
+    this.recoverySweepInFlight = true;
+    try {
+      await this.subscribeExistingRooms();
+    } finally {
+      this.recoverySweepInFlight = false;
+    }
   }
 }

--- a/packages/sdk/src/runtime/rooms/subscriptions.ts
+++ b/packages/sdk/src/runtime/rooms/subscriptions.ts
@@ -1,5 +1,5 @@
 import type { RestRequestOptions } from "../../client/rest/requestOptions";
-import { UnsupportedFeatureError } from "../../core/errors";
+import { TransportError, UnsupportedFeatureError } from "../../core/errors";
 import type { MetadataMap } from "../../contracts/dtos";
 import type { ThenvoiLink } from "../../platform/ThenvoiLink";
 
@@ -17,6 +17,7 @@ interface TrackRoomLeaveOptions {
   roomId: string | null;
   trackedRooms: Set<string>;
   onLeft?: (roomId: string) => Promise<void>;
+  onError?: (error: unknown) => Promise<void> | void;
 }
 
 interface HydrateTrackedRoomsOptions {
@@ -24,6 +25,8 @@ interface HydrateTrackedRoomsOptions {
   trackedRooms: Set<string>;
   roomFilter?: (room: MetadataMap) => boolean;
   onJoined?: (roomId: string, payload: MetadataMap) => Promise<void>;
+  onLeft?: (roomId: string) => Promise<void>;
+  pruneMissing?: boolean;
   pageSize?: number;
   maxPages?: number;
   requestOptions?: RestRequestOptions;
@@ -32,6 +35,71 @@ interface HydrateTrackedRoomsOptions {
 
 function hasRoomId(roomId: string | null): roomId is string {
   return typeof roomId === "string" && roomId.length > 0;
+}
+
+const ROOM_JOIN_RETRY_DELAYS_MS = [0, 500, 2_000];
+const HYDRATE_CONCURRENCY = 6;
+const pendingJoinsByTrackedRooms = new WeakMap<Set<string>, Set<string>>();
+
+function pendingJoinsFor(trackedRooms: Set<string>): Set<string> {
+  let pending = pendingJoinsByTrackedRooms.get(trackedRooms);
+  if (!pending) {
+    pending = new Set<string>();
+    pendingJoinsByTrackedRooms.set(trackedRooms, pending);
+  }
+  return pending;
+}
+
+function isRetryableRoomJoinError(error: unknown): boolean {
+  if (!(error instanceof TransportError)) return false;
+  // Phoenix timeouts and transient join errors are safe to retry — the topic
+  // either failed to confirm or the socket was mid-reconnect. Permanent errors
+  // (auth, missing room) will continue to fail on retry and be surfaced.
+  return /Timeout joining topic|Failed to join topic/.test(error.message);
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function runWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<void>,
+): Promise<void> {
+  if (items.length === 0) return;
+  const limit = Math.max(1, concurrency);
+  let cursor = 0;
+  const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (cursor < items.length) {
+      const index = cursor;
+      cursor += 1;
+      await worker(items[index]);
+    }
+  });
+  await Promise.all(runners);
+}
+
+async function subscribeRoomWithRetry(link: ThenvoiLink, roomId: string): Promise<void> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < ROOM_JOIN_RETRY_DELAYS_MS.length; attempt += 1) {
+    if (attempt > 0) {
+      await sleep(ROOM_JOIN_RETRY_DELAYS_MS[attempt] ?? 0);
+    }
+
+    try {
+      await link.subscribeRoom(roomId);
+      return;
+    } catch (error) {
+      lastError = error;
+      if (!isRetryableRoomJoinError(error) || attempt === ROOM_JOIN_RETRY_DELAYS_MS.length - 1) {
+        throw error;
+      }
+    }
+  }
+
+  throw lastError;
 }
 
 export async function trackRoomJoin(options: TrackRoomJoinOptions): Promise<boolean> {
@@ -43,17 +111,27 @@ export async function trackRoomJoin(options: TrackRoomJoinOptions): Promise<bool
     return false;
   }
 
-  if (options.trackedRooms.has(options.roomId)) {
+  const pendingJoins = pendingJoinsFor(options.trackedRooms);
+  if (options.trackedRooms.has(options.roomId) || pendingJoins.has(options.roomId)) {
     return false;
   }
 
-  await options.link.subscribeRoom(options.roomId);
-  options.trackedRooms.add(options.roomId);
-  if (options.onJoined) {
-    await options.onJoined(options.roomId, options.payload);
-  }
+  pendingJoins.add(options.roomId);
+  try {
+    await subscribeRoomWithRetry(options.link, options.roomId);
+    if (options.trackedRooms.has(options.roomId)) {
+      return false;
+    }
 
-  return true;
+    options.trackedRooms.add(options.roomId);
+    if (options.onJoined) {
+      await options.onJoined(options.roomId, options.payload);
+    }
+
+    return true;
+  } finally {
+    pendingJoins.delete(options.roomId);
+  }
 }
 
 export async function trackRoomLeave(options: TrackRoomLeaveOptions): Promise<boolean> {
@@ -61,8 +139,23 @@ export async function trackRoomLeave(options: TrackRoomLeaveOptions): Promise<bo
     return false;
   }
 
-  await options.link.unsubscribeRoom(options.roomId);
+  // Drop the room from tracking up front. If the server already deleted the
+  // room, the underlying Phoenix topic is gone and `unsubscribeRoom` may throw
+  // — but the room is no longer reachable, which is the goal state, so the
+  // tracking set must reflect that regardless of how the leave call resolves.
+  pendingJoinsFor(options.trackedRooms).delete(options.roomId);
   options.trackedRooms.delete(options.roomId);
+
+  try {
+    await options.link.unsubscribeRoom(options.roomId);
+  } catch (error) {
+    // Treat leave failures as "already gone" so consumers still fire `onLeft`
+    // and so retries don't deadlock on a topic the server has discarded.
+    if (options.onError) {
+      await options.onError(error);
+    }
+  }
+
   if (options.onLeft) {
     await options.onLeft(options.roomId);
   }
@@ -80,16 +173,51 @@ export async function hydrateTrackedRooms(options: HydrateTrackedRoomsOptions): 
       options.requestOptions,
     );
 
-    for (const room of rooms) {
-      await trackRoomJoin({
-        link: options.link,
-        roomId: typeof room.id === "string" ? room.id : null,
-        payload: room,
-        trackedRooms: options.trackedRooms,
-        roomFilter: options.roomFilter,
-        onJoined: options.onJoined,
+    const currentRoomIds = new Set(
+      rooms
+        .map((room) => (typeof room.id === "string" ? room.id : null))
+        .filter((roomId): roomId is string => roomId !== null),
+    );
+
+    if (options.pruneMissing) {
+      const stale = [...options.trackedRooms].filter((roomId) => !currentRoomIds.has(roomId));
+      await runWithConcurrency(stale, HYDRATE_CONCURRENCY, async (roomId) => {
+        try {
+          await trackRoomLeave({
+            link: options.link,
+            roomId,
+            trackedRooms: options.trackedRooms,
+            onLeft: options.onLeft,
+            onError: options.onError,
+          });
+        } catch (error) {
+          if (options.onError) {
+            await options.onError(error);
+            return;
+          }
+          throw error;
+        }
       });
     }
+
+    await runWithConcurrency(rooms, HYDRATE_CONCURRENCY, async (room) => {
+      try {
+        await trackRoomJoin({
+          link: options.link,
+          roomId: typeof room.id === "string" ? room.id : null,
+          payload: room,
+          trackedRooms: options.trackedRooms,
+          roomFilter: options.roomFilter,
+          onJoined: options.onJoined,
+        });
+      } catch (error) {
+        if (options.onError) {
+          await options.onError(error);
+          return;
+        }
+        throw error;
+      }
+    });
   } catch (error) {
     if (error instanceof UnsupportedFeatureError) {
       return;

--- a/packages/sdk/tests/platform-runtime.test.ts
+++ b/packages/sdk/tests/platform-runtime.test.ts
@@ -338,7 +338,7 @@ describe("PlatformRuntime", () => {
     await expect(runPromise).rejects.toThrow("adapter exploded");
   });
 
-  it("synchronizes existing rooms via /messages/next and skips the sync-point websocket duplicate", async () => {
+  it("recovers stale processing messages for existing rooms without draining /messages/next", async () => {
     const transport = new FakeTransport();
     let releaseSync!: () => void;
     const syncGate = new Promise<void>((resolve) => {
@@ -372,6 +372,10 @@ describe("PlatformRuntime", () => {
       listChats: async () => ({
         data: [{ id: "room-existing", title: "Existing Room" }],
         metadata: { page: 1, pageSize: 100, totalPages: 1, totalCount: 1 },
+      }),
+      listMessages: async (request) => ({
+        data: request.status === "processing" ? [backlog[0]] : [],
+        metadata: { page: 1, pageSize: 50, totalPages: 1, totalCount: 1 },
       }),
       getNextMessage: async () => {
         await syncGate;
@@ -425,6 +429,9 @@ describe("PlatformRuntime", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(seenMessages).toEqual([
+      // Existing rooms skip the expensive /messages/next drain, but still
+      // recover stale processing messages from a prior process before live
+      // WebSocket notifications continue.
       "recover me first",
       "recover me second",
       "live only",

--- a/packages/sdk/tests/platform-runtime.test.ts
+++ b/packages/sdk/tests/platform-runtime.test.ts
@@ -368,6 +368,10 @@ describe("PlatformRuntime", () => {
         updated_at: new Date().toISOString(),
       },
     ];
+    const getNextMessage = vi.fn(async () => {
+      await syncGate;
+      return backlog.shift() ?? null;
+    });
     const restApi = new FakeRestApi({
       listChats: async () => ({
         data: [{ id: "room-existing", title: "Existing Room" }],
@@ -377,10 +381,7 @@ describe("PlatformRuntime", () => {
         data: request.status === "processing" ? [backlog[0]] : [],
         metadata: { page: 1, pageSize: 50, totalPages: 1, totalCount: 1 },
       }),
-      getNextMessage: async () => {
-        await syncGate;
-        return backlog.shift() ?? null;
-      },
+      getNextMessage,
     });
     const seenMessages: string[] = [];
 
@@ -428,6 +429,7 @@ describe("PlatformRuntime", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     await new Promise((resolve) => setTimeout(resolve, 0));
 
+    expect(getNextMessage).not.toHaveBeenCalled();
     expect(seenMessages).toEqual([
       // Existing rooms skip the expensive /messages/next drain, but still
       // recover stale processing messages from a prior process before live

--- a/packages/sdk/tests/room-presence.test.ts
+++ b/packages/sdk/tests/room-presence.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { TransportError } from "../src/core/errors";
 import type { TopicHandlers, StreamingTransport } from "../src/platform/streaming/transport";
 import { RoomPresence } from "../src/runtime/rooms/RoomPresence";
 import { ThenvoiLink } from "../src/platform/ThenvoiLink";
 import { FakeRestApi } from "./testUtils";
 
 class FakeTransport implements StreamingTransport {
-  private readonly handlers = new Map<string, TopicHandlers>();
+  protected readonly handlers = new Map<string, TopicHandlers>();
   private connected = false;
 
   public async connect(): Promise<void> {
@@ -47,12 +48,45 @@ class FakeTransport implements StreamingTransport {
   }
 }
 
+class FlakyTransport extends FakeTransport {
+  private readonly remainingFailures = new Map<string, number>();
+
+  public constructor(failures: Record<string, number>) {
+    super();
+    for (const [topic, count] of Object.entries(failures)) {
+      this.remainingFailures.set(topic, count);
+    }
+  }
+
+  public override async join(topic: string, handlers: TopicHandlers): Promise<void> {
+    const remaining = this.remainingFailures.get(topic) ?? 0;
+    if (remaining > 0) {
+      this.remainingFailures.set(topic, remaining - 1);
+      throw new TransportError(`Timeout joining topic ${topic}`);
+    }
+    await super.join(topic, handlers);
+  }
+}
+
+class RejectingTransport extends FakeTransport {
+  public constructor(private readonly rejectedTopic: string) {
+    super();
+  }
+
+  public override async join(topic: string, handlers: TopicHandlers): Promise<void> {
+    if (topic === this.rejectedTopic) {
+      throw new Error(`Cannot join ${topic}`);
+    }
+    await super.join(topic, handlers);
+  }
+}
+
 async function waitFor(check: () => boolean): Promise<void> {
-  for (let attempt = 0; attempt < 20; attempt += 1) {
+  for (let attempt = 0; attempt < 600; attempt += 1) {
     if (check()) {
       return;
     }
-    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
   }
 
   throw new Error("Condition was not met in time");
@@ -137,6 +171,7 @@ describe("RoomPresence", () => {
       inserted_at: new Date().toISOString(),
     });
 
+    await waitFor(() => contactEvents.length === 1);
     expect(contactEvents).toEqual(["contact_added"]);
 
     await presence.stop();
@@ -174,8 +209,40 @@ describe("RoomPresence", () => {
 
     await presence.start();
 
-    expect(joined).toEqual(["room-1", "room-2"]);
-    expect([...presence.rooms]).toEqual(["room-1", "room-2"]);
+    expect([...joined].sort()).toEqual(["room-1", "room-2"]);
+    expect([...presence.rooms].sort()).toEqual(["room-1", "room-2"]);
+
+    await presence.stop();
+  });
+
+  it("retries transient room join timeouts before giving up", async () => {
+    const transport = new FlakyTransport({ "chat_room:room-retry": 1 });
+    const joined: string[] = [];
+
+    const presence = new RoomPresence({
+      link: new ThenvoiLink({
+        agentId: "agent-1",
+        apiKey: "key",
+        transport,
+        restApi: new FakeRestApi({
+          listChats: async () => ({ data: [] }),
+        }),
+      }),
+    });
+    presence.onRoomJoined = async (roomId) => {
+      joined.push(roomId);
+    };
+
+    await presence.start();
+    await transport.emit("agent_rooms:agent-1", "room_added", {
+      id: "room-retry",
+      status: "active",
+      type: "direct",
+      title: "Retry Room",
+      removed_at: "",
+    });
+
+    await waitFor(() => joined.includes("room-retry") && presence.rooms.has("room-retry"));
 
     await presence.stop();
   });
@@ -209,6 +276,196 @@ describe("RoomPresence", () => {
       "RoomPresence failed to subscribe existing rooms",
       expect.objectContaining({
         error: expect.any(Error),
+      }),
+    );
+
+    await presence.stop();
+  });
+
+  it("does not let one room's slow handler block other rooms", async () => {
+    const transport = new FakeTransport();
+    const joined: string[] = [];
+    let releaseSlowRoom!: () => void;
+    const slowRoom = new Promise<void>((resolve) => {
+      releaseSlowRoom = resolve;
+    });
+
+    const presence = new RoomPresence({
+      link: new ThenvoiLink({
+        agentId: "agent-1",
+        apiKey: "key",
+        transport,
+        restApi: new FakeRestApi({ listChats: async () => ({ data: [] }) }),
+      }),
+    });
+    presence.onRoomJoined = async (roomId) => {
+      if (roomId === "room-slow") {
+        await slowRoom;
+      }
+      joined.push(roomId);
+    };
+
+    await presence.start();
+    await transport.emit("agent_rooms:agent-1", "room_added", {
+      id: "room-slow",
+      status: "active",
+      type: "direct",
+      title: "Slow Room",
+      removed_at: "",
+    });
+    await transport.emit("agent_rooms:agent-1", "room_added", {
+      id: "room-fast",
+      status: "active",
+      type: "direct",
+      title: "Fast Room",
+      removed_at: "",
+    });
+
+    await waitFor(() => joined.includes("room-fast"));
+    expect(joined).not.toContain("room-slow");
+
+    releaseSlowRoom();
+    await waitFor(() => joined.includes("room-slow"));
+    await presence.stop();
+  });
+
+  it("keeps same-room bursts on one active worker while other rooms continue", async () => {
+    const transport = new FakeTransport();
+    const seen: string[] = [];
+    let releaseBurst!: () => void;
+    const burstGate = new Promise<void>((resolve) => {
+      releaseBurst = resolve;
+    });
+
+    const link = new ThenvoiLink({
+      agentId: "agent-1",
+      apiKey: "key",
+      transport,
+      restApi: new FakeRestApi({ listChats: async () => ({ data: [] }) }),
+    });
+    const presence = new RoomPresence({ link });
+    presence.onRoomEvent = async (roomId, event) => {
+      if (roomId === "room-burst" && event.payload.id === "m-0") {
+        await burstGate;
+      }
+      seen.push(`${roomId}:${event.payload.id}`);
+    };
+
+    const messagePayload = (id: string) => ({
+      id,
+      content: id,
+      message_type: "text",
+      sender_id: "user-1",
+      sender_type: "User",
+      sender_name: "Jane",
+      inserted_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+
+    await presence.start();
+    await link.subscribeRoom("room-burst");
+    await link.subscribeRoom("room-fast");
+    presence.rooms.add("room-burst");
+    presence.rooms.add("room-fast");
+
+    for (let index = 0; index < 10; index += 1) {
+      await transport.emit("chat_room:room-burst", "message_created", messagePayload(`m-${index}`));
+    }
+
+    await waitFor(() => (presence as unknown as { activeTasks: Set<Promise<void>> }).activeTasks.size === 1);
+
+    await transport.emit("chat_room:room-fast", "message_created", messagePayload("fast-0"));
+    await waitFor(() => seen.includes("room-fast:fast-0"));
+
+    releaseBurst();
+    await waitFor(() => seen.filter((entry) => entry.startsWith("room-burst:")).length === 10);
+    expect(seen.filter((entry) => entry.startsWith("room-burst:"))).toEqual(
+      Array.from({ length: 10 }, (_, index) => `room-burst:m-${index}`),
+    );
+
+    await presence.stop();
+  });
+
+  it("prunes rooms missing from recovery discovery", async () => {
+    const transport = new FakeTransport();
+    const left: string[] = [];
+    let listCall = 0;
+
+    const presence = new RoomPresence({
+      link: new ThenvoiLink({
+        agentId: "agent-1",
+        apiKey: "key",
+        transport,
+        restApi: new FakeRestApi({
+          listChats: async () => {
+            listCall += 1;
+            return listCall === 1
+              ? { data: [{ id: "room-deleted", title: "Deleted Room" }] }
+              : { data: [] };
+          },
+        }),
+      }),
+      recoverySweepIntervalMs: 10,
+    });
+    presence.onRoomLeft = async (roomId) => {
+      left.push(roomId);
+    };
+
+    await presence.start();
+    await waitFor(() => presence.rooms.has("room-deleted"));
+    await waitFor(() => left.includes("room-deleted") && !presence.rooms.has("room-deleted"));
+
+    await presence.stop();
+  });
+
+  it("keeps consuming events after a room join failure", async () => {
+    const transport = new RejectingTransport("chat_room:room-bad");
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const joined: string[] = [];
+
+    const presence = new RoomPresence({
+      link: new ThenvoiLink({
+        agentId: "agent-1",
+        apiKey: "key",
+        transport,
+        restApi: new FakeRestApi({ listChats: async () => ({ data: [] }) }),
+      }),
+      logger,
+    });
+    presence.onRoomJoined = async (roomId) => {
+      joined.push(roomId);
+    };
+
+    await presence.start();
+    await transport.emit("agent_rooms:agent-1", "room_added", {
+      id: "room-bad",
+      status: "active",
+      type: "direct",
+      title: "Bad Room",
+      removed_at: "",
+    });
+    await transport.emit("agent_rooms:agent-1", "room_added", {
+      id: "room-good",
+      status: "active",
+      type: "direct",
+      title: "Good Room",
+      removed_at: "",
+    });
+
+    await waitFor(() => joined.includes("room-good"));
+
+    expect(joined).not.toContain("room-bad");
+    await waitFor(() => logger.warn.mock.calls.length > 0);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "RoomPresence dropped event after handler failure",
+      expect.objectContaining({
+        eventType: "room_added",
+        roomId: "room-bad",
       }),
     );
 


### PR DESCRIPTION
## Context

This is the clean `dev`-based INT-455 PR for the NemoClaw integration demo. The first working branch mixed the NemoClaw/OpenClaw work with broad SDK example, adapter, package, and lockfile churn. This branch keeps the integration work and the minimal SDK room-runtime support it needs, while leaving the unrelated example/adapters/root README/package churn out of scope.

The product goal is to make `@thenvoi/openclaw-channel-thenvoi` usable inside a NemoClaw custom OpenClaw image. A Band room should be able to wake the OpenClaw-backed agent, let that agent use Band MCP tools, record tool activity as Band events, send only intentional user-facing replies back into the room, and recover safely when the runtime restarts or joins existing rooms.

## Why the OpenClaw implementation changed

The original implementation path made `packages/openclaw/src/channel.ts` absorb too much: account config, account lifecycle, room recovery, OpenClaw runtime dispatch, MCP turn context, reply dispatch, message dedupe, contact hub handling, sender fallback, and error redaction. That worked locally, but it was the kind of file reviewers would reasonably object to because every new Band/OpenClaw behavior became another branch in the channel file.

This PR keeps the public channel surface but moves the responsibilities into focused modules:

- `config.ts` resolves Band account config, environment fallbacks, and contact settings.
- `gateway.ts` owns account startup, room subscriptions, Band message recovery, OpenClaw dispatch, lifecycle marking, and contact hub routing.
- `message-utils.ts` converts Band messages/events into the OpenClaw inbound message shape.
- `openclaw-runtime.ts` validates and normalizes the OpenClaw runtime dispatch surface.
- `reply-dispatcher.ts` adapts OpenClaw output back into Band messages/events.
- `bounded-string-set.ts` provides bounded dedupe/cache primitives used by the gateway.
- `redaction.ts` centralizes safe error/config redaction for logs.

That split is part of the feature, not cosmetic cleanup: NemoClaw runs OpenClaw as the host process, so the Band channel has to behave like a real plugin with account-scoped runtime context, predictable reply rules, safe recovery, and bounded state.

## NemoClaw setup flow

The new `nemoclaw:integration:*` scripts generate and validate the custom-image material needed to install this plugin into a NemoClaw/OpenClaw sandbox:

- `nemoclaw:integration:setup` builds a generated context with a Dockerfile layer, plugin bundle, OpenClaw config patch script, Band config template, and Band egress policy.
- `nemoclaw:integration:configure` writes Band account credentials/config into an existing generated context without requiring credentials during package discovery.
- `nemoclaw:integration:preflight` checks the generated context before onboarding: marker files, Dockerfile/plugin files, manifest tool declarations, OpenClaw config patch syntax, Band config shape, and egress policy shape.
- `nemoclaw:integration:verify` sends a smoke message through the configured Band room and waits for observable response evidence.

`packages/openclaw/examples/nemoclaw/README.md` documents the operator flow from build context generation through onboarding, policy application, configuration, and verification.

Generated output under `dist/nemoclaw-integration/**` is intentionally excluded from the npm package. The README and scripts are included.

## OpenClaw plugin and package metadata

The OpenClaw manifest now declares the Band channel's MCP tools in both the plugin capability list and the `contracts.tools` list that NemoClaw/OpenClaw discovery expects. `manifest.test.ts` keeps those manifest declarations aligned with `getMcpToolSchemas()` so the manifest cannot drift from the runtime tool list.

Band credentials are still optional in `openclaw.plugin.json`. Plugin discovery should not require `THENVOI_API_KEY` or `THENVOI_AGENT_ID`; those are required when an account actually starts.

The OpenClaw package continues to resolve `@thenvoi/sdk` from the workspace instead of depending on a registry SDK version. The package also preserves the existing SDK build preconditions in its build/typecheck/test scripts, so local verification exercises the workspace SDK that the plugin actually imports.

## Band room and reply behavior

OpenClaw can emit tool output, block replies, and final text during one turn. The first implementation tried to infer whether final text was a partial fragment and stitch it together. That was the wrong model for Band rooms: the channel should not guess which OpenClaw text is meant for the human room.

The final rule in this PR is explicit-only:

- `thenvoi_send_message` remains the action for posting/handing off in the Band room.
- OpenClaw tool output is sent to Band as `tool_result` events, not chat messages.
- Block replies are counted for dispatcher visibility but are not posted as Band chat messages.
- Final OpenClaw output is posted to Band only when it contains `<message to user>...</message>`.
- Non-explicit final output is dropped, including partial-looking fragments and incidental summaries after tool use.

This matters for NemoClaw because an OpenClaw agent may use `thenvoi_send_message` to mention another participant. In that case the message tool call is the intentional room action; incidental non-explicit final text should not echo back as a second, noisy answer.

The gateway also now marks failed OpenClaw dispatches with `markFailed` instead of `markProcessed`, and only dedupes a Band message after successful handling. That prevents a transient OpenClaw/plugin failure from permanently losing a mentioned Band message.

## Band MCP tool behavior

Band MCP tool execution is account-scoped to the current OpenClaw turn context. This prevents multi-account OpenClaw processes from accidentally routing `thenvoi_*` tool calls through the default Band account.

The tool layer also reports `tool_call` and `tool_result` events back to Band for auditability. Those events are observability footprints only; they do not wake other agents. The load-bearing public names stay unchanged: `thenvoi_*` tools, `@thenvoi/sdk`, and `THENVOI_*` environment variables remain as-is.

`thenvoi_send_message` also validates room mentions against current participants and rejects self-mentions so the OpenClaw agent cannot accidentally create a self-triggering loop.

## Contact hub support

For accounts configured with Band contact hub handling, contact events can be routed through the OpenClaw dispatch path with the same reply dispatcher semantics as normal room messages. That lets the OpenClaw-backed agent decide what to do with contact requests while still enforcing the explicit-only final reply rule.

## SDK runtime support included here

A small SDK runtime slice is included because the plugin depends on reliable room lifecycle behavior when it is loaded inside a long-running OpenClaw/NemoClaw process:

- `RoomPresence` serializes room event handling per room, retries transient room join failures, avoids duplicate concurrent joins, and drains queued handlers during shutdown.
- Existing-room startup can recover stale `processing` messages without doing a full `/messages/next` drain for every existing room.
- `AgentRuntime` can skip the expensive startup queue sync where the caller only needs existing-room recovery.
- Room subscription hydration/pruning runs with bounded concurrency and handles transient Phoenix join failures safely.

These changes are intentionally limited to the runtime files needed for room recovery and subscription correctness. They do not bring back the unrelated SDK example or adapter changes from the earlier branch.

## Scope guardrails

This PR intentionally does not include:

- broad SDK example changes;
- SDK adapter feature work;
- root README churn;
- `pnpm-lock.yaml` changes;
- registry SDK dependency changes for OpenClaw;
- ad-hoc renames of load-bearing Thenvoi identifiers.

The branch is based on `dev`, and the diff scope is focused on OpenClaw/NemoClaw integration files plus the minimal SDK room-runtime support described above.

## Validation

Local validation run for this PR included:

- `pnpm install --lockfile-only`
- `pnpm --filter @thenvoi/openclaw-channel-thenvoi typecheck`
- `pnpm --filter @thenvoi/openclaw-channel-thenvoi test -- tests/unit/reply-dispatcher.test.ts tests/unit/channel-gateway.test.ts tests/unit/mcp-tools.test.ts tests/unit/manifest.test.ts`
- `pnpm --filter @thenvoi/openclaw-channel-thenvoi build`
- `pnpm --filter @thenvoi/openclaw-channel-thenvoi run nemoclaw:integration:setup -- --sandbox review-smoke --base-image scratch --output /tmp/openclaw-nemoclaw-review --yes`
- `node --check /tmp/openclaw-nemoclaw-review/openclaw-channel-thenvoi.patch-openclaw-config.cjs`
- `pnpm --filter @thenvoi/openclaw-channel-thenvoi run nemoclaw:integration:preflight -- --context /tmp/openclaw-nemoclaw-review --context-only`
- `pnpm --filter @thenvoi/sdk typecheck`
- `pnpm --filter @thenvoi/sdk test -- tests/platform-runtime.test.ts tests/room-presence.test.ts`
- `pnpm --filter @thenvoi/openclaw-channel-thenvoi why @thenvoi/sdk`, confirming workspace SDK resolution
- `git diff --check`

After the cleanup commits, GitHub checks on PR #84 were green, including title validation, packaging, lint, and tests.
