### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,11 @@ jobs:
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 
+      # OIDC trusted publishing requires npm >= 11.5.1; Node 22 ships npm 10.x.
+      - name: Upgrade npm for OIDC trusted publishing
+        if: steps.release.outputs['packages/sdk--release_created'] == 'true' || steps.release.outputs['packages/openclaw--release_created'] == 'true'
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         if: steps.release.outputs['packages/sdk--release_created'] == 'true' || steps.release.outputs['packages/openclaw--release_created'] == 'true'
         run: pnpm install --frozen-lockfile
@@ -70,8 +75,6 @@ jobs:
         run: |
           cd packages/sdk
           npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish SDK to npm (@band-ai)
         if: steps.release.outputs['packages/sdk--release_created'] == 'true'
@@ -79,16 +82,12 @@ jobs:
           cd packages/sdk
           sed -i 's/"@thenvoi\/sdk"/"@band-ai\/sdk"/' package.json
           npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.BAND_AI_NPM_TOKEN }}
 
       - name: Publish OpenClaw to npm (@thenvoi)
         if: steps.release.outputs['packages/openclaw--release_created'] == 'true'
         run: |
           cd packages/openclaw
           npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish OpenClaw to npm (@band-ai)
         if: steps.release.outputs['packages/openclaw--release_created'] == 'true'
@@ -97,8 +96,6 @@ jobs:
           sed -i 's/"@thenvoi\/openclaw-channel-thenvoi"/"@band-ai\/openclaw-channel-thenvoi"/' package.json
           sed -i 's/"@thenvoi\/sdk"/"@band-ai\/sdk"/' package.json
           npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.BAND_AI_NPM_TOKEN }}
 
       - name: Publish release summary
         if: steps.release.outputs['packages/sdk--release_created'] == 'true' || steps.release.outputs['packages/openclaw--release_created'] == 'true'


### PR DESCRIPTION
## Why

The release on \`main\` failed at **Publish SDK to npm (@thenvoi)** with:
\`\`\`
npm error 404 Not Found - PUT https://registry.npmjs.org/@thenvoi%2fsdk
\`\`\`
For an existing scoped package, a 404 on PUT is npm's way of saying **the credential isn't authorized** (it returns 404, not 403, to avoid leaking package existence). The \`NODE_AUTH_TOKEN\` secrets (\`NPM_TOKEN\` / \`BAND_AI_NPM_TOKEN\`) are no longer valid/authorized.

## What

Trusted Publishers (OIDC) are now configured on npm for all four published packages (\`@thenvoi/sdk\`, \`@band-ai/sdk\`, \`@thenvoi/openclaw-channel-thenvoi\`, \`@band-ai/openclaw-channel-thenvoi\`), so this switches the workflow to OIDC:

- **Remove \`NODE_AUTH_TOKEN\` from all four publish steps** — npm authenticates via GitHub OIDC. The job already has \`id-token: write\` and \`environment: release\`, which match the Trusted Publisher config.
- **Add an npm upgrade step** — OIDC trusted publishing requires **npm ≥ 11.5.1**, but Node 22 ships npm 10.x.

\`--provenance\` is retained (works with OIDC).

## After merge
This must reach \`main\` (via the next \`dev → main\`) before a release re-run uses it. Once there, re-run the failed release to publish 0.1.7. The \`NPM_TOKEN\` / \`BAND_AI_NPM_TOKEN\` GitHub secrets can be deleted afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)