### PR TITLE
fix(openclaw): log dropped reply when account is not connected

### DIFF
--- a/packages/openclaw/src/transport.ts
+++ b/packages/openclaw/src/transport.ts
@@ -166,7 +166,13 @@ export function createReplyDeliver(
     const text = typeof payload === "string" ? payload : payload?.text;
     if (!text) return;
     const account = getAccount(accountId);
-    if (!account) return;
+    if (!account) {
+      // The account can disappear between dispatch and delivery (e.g. a teardown
+      // race on restart). Log it — this function's contract is that delivery
+      // failures are observable, never silently dropped.
+      log(`[band:${accountId}] skipping reply (room=${roomId}): account not connected`);
+      return;
+    }
     try {
       await outboundSendText(
         {

--- a/packages/openclaw/tests/unit/transport.test.ts
+++ b/packages/openclaw/tests/unit/transport.test.ts
@@ -395,4 +395,12 @@ describe("createReplyDeliver (the deliver -> outbound.sendText seam)", () => {
     await expect(deliver({ text: "hi" })).resolves.toBeUndefined();
     expect(log).toHaveBeenCalledWith(expect.stringMatching(/reply delivery failed/));
   });
+
+  it("logs (does not silently drop) when the account is not connected", async () => {
+    // No setAccount — the account is absent (e.g. a teardown race).
+    const log = vi.fn();
+    const deliver = createReplyDeliver("default", "room-1", log);
+    await expect(deliver({ text: "hi" })).resolves.toBeUndefined();
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/account not connected/i));
+  });
 });


### PR DESCRIPTION
## What

`createReplyDeliver` silently `return`ed when the account was missing (e.g. a teardown race between dispatch and delivery), which contradicts the function's documented contract that delivery failures are *observable, never silently dropped*. This adds a log line on that path.

(Surfaced by the earlier code review as finding #5.)

## Why now — validation release

This is a genuine small `fix(openclaw)`, so it doubles as a **deliberate validation release**: merging it (→ `dev` → `main`) makes release-please cut a new `@thenvoi/openclaw-channel-thenvoi` / `@band-ai/openclaw-channel-thenvoi` version, which exercises the newly-configured **OIDC trusted publishing** end-to-end for the first time.

If the OIDC publish succeeds, the pipeline is proven (and npm catches up). If anything in the trusted-publisher setup is misconfigured, we find out now rather than at the next real release.

## After merge
1. Merge `dev → main`.
2. release-please opens a release PR — merge it.
3. The release run should publish both openclaw scopes via OIDC. Watch that run to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)