### PR TITLE
ci: publish only the @band-ai packages (#113)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,12 +70,6 @@ jobs:
         if: steps.release.outputs['packages/sdk--release_created'] == 'true'
         run: cp README.md packages/sdk/README.md
 
-      - name: Publish SDK to npm (@thenvoi)
-        if: steps.release.outputs['packages/sdk--release_created'] == 'true'
-        run: |
-          cd packages/sdk
-          npm publish --provenance --access public
-
       - name: Publish SDK to npm (@band-ai)
         if: steps.release.outputs['packages/sdk--release_created'] == 'true'
         run: |
@@ -83,18 +77,12 @@ jobs:
           sed -i 's/"@thenvoi\/sdk"/"@band-ai\/sdk"/' package.json
           npm publish --provenance --access public
 
-      - name: Publish OpenClaw to npm (@thenvoi)
-        if: steps.release.outputs['packages/openclaw--release_created'] == 'true'
-        run: |
-          cd packages/openclaw
-          npm publish --provenance --access public
-
       - name: Publish OpenClaw to npm (@band-ai)
         if: steps.release.outputs['packages/openclaw--release_created'] == 'true'
         run: |
           cd packages/openclaw
-          sed -i 's/"@thenvoi\/openclaw-channel-thenvoi"/"@band-ai\/openclaw-channel-thenvoi"/' package.json
-          sed -i 's/"@thenvoi\/sdk"/"@band-ai\/sdk"/' package.json
+          # name is already @band-ai/openclaw-channel-band and the SDK is bundled
+          # (types inlined), so the package is self-contained — nothing to rewrite.
           npm publish --provenance --access public
 
       - name: Publish release summary
@@ -104,10 +92,8 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Packages released:" >> $GITHUB_STEP_SUMMARY
           if [ "${{ steps.release.outputs['packages/sdk--release_created'] }}" == "true" ]; then
-            echo "- **@thenvoi/sdk** v${{ steps.release.outputs['packages/sdk--version'] }}" >> $GITHUB_STEP_SUMMARY
             echo "- **@band-ai/sdk** v${{ steps.release.outputs['packages/sdk--version'] }}" >> $GITHUB_STEP_SUMMARY
           fi
           if [ "${{ steps.release.outputs['packages/openclaw--release_created'] }}" == "true" ]; then
-            echo "- **@thenvoi/openclaw-channel-thenvoi** v${{ steps.release.outputs['packages/openclaw--version'] }}" >> $GITHUB_STEP_SUMMARY
-            echo "- **@band-ai/openclaw-channel-thenvoi** v${{ steps.release.outputs['packages/openclaw--version'] }}" >> $GITHUB_STEP_SUMMARY
+            echo "- **@band-ai/openclaw-channel-band** v${{ steps.release.outputs['packages/openclaw--version'] }}" >> $GITHUB_STEP_SUMMARY
           fi

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -35,10 +35,8 @@
     "stage:link": "node scripts/stage-link.mjs",
     "link:local": "pnpm build && node scripts/stage-link.mjs"
   },
-  "dependencies": {
-    "@thenvoi/sdk": "workspace:*"
-  },
   "devDependencies": {
+    "@thenvoi/sdk": "workspace:*",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.0.0",

--- a/packages/openclaw/tsup.config.ts
+++ b/packages/openclaw/tsup.config.ts
@@ -126,7 +126,11 @@ const openclawPkg = JSON.parse(readFileSync("package.json", "utf-8")) as { versi
 export default defineConfig({
   entry: ["src/index.ts", "src/setup-entry.ts"],
   format: ["esm"],
-  dts: true,
+  // Inline the bundled SDK's types into our .d.ts so the published package is
+  // fully self-contained (no `@thenvoi/sdk` type import leaking into dist/*.d.ts,
+  // hence no SDK dependency needed). openclaw stays an external type import — it's
+  // a peer the host provides.
+  dts: { resolve: ["@thenvoi/sdk", "@thenvoi/rest-client", "zod", "zod-to-json-schema"] },
   sourcemap: true,
   clean: true,
   shims: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,11 +36,10 @@ importers:
   .: {}
 
   packages/openclaw:
-    dependencies:
+    devDependencies:
       '@thenvoi/sdk':
         specifier: workspace:*
         version: link:../sdk
-    devDependencies:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.15

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,13 +3,13 @@
   "release-type": "node",
   "packages": {
     "packages/sdk": {
-      "package-name": "@thenvoi/sdk",
+      "package-name": "@band-ai/sdk",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true
     },
     "packages/openclaw": {
-      "package-name": "@thenvoi/openclaw-channel-thenvoi",
+      "package-name": "@band-ai/openclaw-channel-band",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,


### PR DESCRIPTION
* ci(release): publish only the @band-ai packages

Drop the @thenvoi npm publishes; publish only @band-ai/sdk and @band-ai/openclaw-channel-band.

- release.yml: remove the two @thenvoi publish steps. The SDK step renames @thenvoi/sdk -> @band-ai/sdk (source keeps the @thenvoi workspace name); the OpenClaw step keeps its name (@band-ai/openclaw-channel-band already) and just repoints its SDK dependency to @band-ai/sdk. Removed the dead openclaw-channel-thenvoi rename sed. Updated the release summary.
- release-please-config.json: set package-name to @band-ai/sdk and @band-ai/openclaw-channel-band so changelog/release labels match what ships.

Note: the openclaw release tag prefix changes (openclaw-channel-thenvoi-v* ->
openclaw-channel-band-v*) since the component name follows package-name.



* build(openclaw): bundle SDK types so the package is fully self-contained

The runtime already bundles @thenvoi/sdk (tsup noExternal), but the generated .d.ts still imported its types, forcing a vestigial @thenvoi/sdk dependency (shipped as an uninstallable "workspace:*" spec). Make the types self-contained too and drop the runtime dependency:

- tsup: dts.resolve the bundled packages (@thenvoi/sdk, @thenvoi/rest-client, zod, zod-to-json-schema) so dist/index.d.ts no longer imports @thenvoi/sdk. openclaw stays an external type import (host-provided peer).
- package.json: move @thenvoi/sdk to devDependencies (needed only to build/bundle); the published package now has zero runtime dependencies.
- release.yml: drop the now-unneeded SDK-dependency rewrite in the OpenClaw publish step.

Verified: dist/index.js and dist/index.d.ts have no @thenvoi/sdk import; npm
publish --dry-run yields @band-ai/openclaw-channel-band with dependencies: {}.



---------