### PR TITLE
feat: Int 876 agentruntime backlog drain (#125)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -436,6 +436,7 @@ Each example is a standalone TypeScript script runnable with `tsx`. Folders incl
 - Never bundle peer dependencies — they must remain `external` in `tsup.config.ts`.
 - Async/await everywhere; do not return raw promises from non-async functions in library code.
 - Keep node compatibility at `>=22` (`engines.node` in both root and SDK package.json).
+- Never put issue-tracker references in code — no Linear issue IDs (e.g. `INT-123`), Linear URLs, or ticket numbers in comments, docstrings, or strings. Explain the *why* in plain terms instead. (Branch names, commit messages, and PR descriptions may reference issues.)
 
 ## Pre-Commit Checklist
 

--- a/packages/openclaw/src/config.ts
+++ b/packages/openclaw/src/config.ts
@@ -26,7 +26,11 @@ export interface BandAccountConfig {
   restUrl?: string;
   /** Directory for persisted state (e.g. the F1 hub id). */
   stateDir?: string;
+  /** Bounds `runtime.stop()` on teardown/restart (default 30s, matching the SDK's graceful-shutdown convention). */
+  stopTimeoutMs?: number;
 }
+
+export const DEFAULT_STOP_TIMEOUT_MS = 30_000;
 
 type AccountsMap = Record<string, BandAccountConfig>;
 

--- a/packages/openclaw/src/state.ts
+++ b/packages/openclaw/src/state.ts
@@ -18,8 +18,10 @@ export interface AccountState {
   selfAgentId: string;
   /** The agent owner's id; commands are authorized only for the owner (F2). */
   ownerUuid?: string | null;
-  /** The RoomPresence instance (opaque here), so teardown can stop it. */
-  presence?: unknown;
+  /** The AgentRuntime instance (opaque here), so teardown can stop it. */
+  runtime?: unknown;
+  /** Bounds `runtime.stop()` on teardown/restart. */
+  stopTimeoutMs?: number;
   /** roomId -> room type (populated from onRoomJoined; drives L2 ChatType). */
   roomTypes: Map<string, string>;
   /** roomId -> last sender (LRU; auto-mention fallback). */

--- a/packages/openclaw/src/transport.ts
+++ b/packages/openclaw/src/transport.ts
@@ -1,12 +1,11 @@
 /**
- * Band transport layer.
+ * Band transport layer: owns the WebSocket connection lifecycle (ThenvoiLink +
+ * AgentRuntime) and turns inbound Band platform events into OpenClaw inbound
+ * contexts dispatched to core. `AgentRuntime` (one `Execution` per room) drains
+ * the REST backlog on (re)connect, so messages sent while disconnected aren't
+ * silently dropped.
  *
- * This file owns the WebSocket connection lifecycle (ThenvoiLink + RoomPresence)
- * and turns inbound Band platform events into OpenClaw inbound contexts that are
- * dispatched to core. The pure event->context mapping is split out as a testable
- * function; the live lifecycle (startAccount/stopAccount) is wired separately.
- *
- * Key INT-836 invariants encoded here (see REWRITE_PLAN D5/L2/F2):
+ * Invariants:
  *  - the `[Band Room: <id>]` marker is a SUFFIX on the model-visible Body only;
  *    command fields stay RAW so stripMentions + command-parse aren't corrupted
  *  - ChatType is derived from the (cached) room type, default 'group'
@@ -16,7 +15,7 @@
 
 import type { PlatformEvent, ContactEvent } from "@thenvoi/sdk";
 import { ThenvoiLink } from "@thenvoi/sdk";
-import { RoomPresence, ContactEventHandler } from "@thenvoi/sdk/runtime";
+import { AgentRuntime, ContactEventHandler } from "@thenvoi/sdk/runtime";
 import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { dispatchInboundMessageWithBufferedDispatcher } from "openclaw/plugin-sdk/reply-runtime";
 import { runPassiveAccountLifecycle } from "openclaw/plugin-sdk/channel-lifecycle";
@@ -24,7 +23,7 @@ import type {
   ChannelGatewayAdapter,
   ChannelGatewayContext,
 } from "openclaw/plugin-sdk/channel-runtime";
-import { resolveConnectionConfig, type BandAccountConfig } from "./config.js";
+import { resolveConnectionConfig, DEFAULT_STOP_TIMEOUT_MS, type BandAccountConfig } from "./config.js";
 import {
   setAccount,
   deleteAccount,
@@ -78,14 +77,10 @@ export function platformEventToInboundContext(
   const payload = event.payload;
   const roomId = event.roomId ?? payload.chat_room_id;
   if (!roomId) return null;
-
-  // Skip the agent's own messages and anything that isn't a plain text message.
   if (payload.sender_id === opts.selfAgentId) return null;
   if (payload.message_type !== "text") return null;
 
   const content = payload.content;
-  // Model-facing body: rewrite Band's `@[[uuid]]` tokens to `@handle`, then append
-  // a participant roster and the room marker. Command/parse fields below stay RAW.
   const participants = opts.participants ?? [];
   const displayContent = replaceUuidMentions(content, participants);
   const roster = buildParticipantsBlock(participants, opts.selfAgentId);
@@ -94,13 +89,12 @@ export function platformEventToInboundContext(
     .join("\n\n");
 
   const ctx: MsgContext = {
-    // Model-facing bodies carry the room marker as a trailing SUFFIX so it can't
-    // collide with leading-@agent strip or leading-/command parse.
+    // Room marker is a trailing SUFFIX so it can't collide with leading-@agent
+    // strip or leading-/command parse.
     Body: withMarker,
     BodyForAgent: withMarker,
-    // Command/parse fields stay RAW (no marker) — core's stripMentions + command
-    // parser operate on these. BodyForCommands is the preferred command field;
-    // CommandBody is set too. (RawBody is deprecated — intentionally omitted.)
+    // Command/parse fields stay RAW (no marker); RawBody is deprecated and
+    // intentionally omitted.
     BodyForCommands: content,
     CommandBody: content,
     From: payload.sender_id,
@@ -113,7 +107,7 @@ export function platformEventToInboundContext(
     MessageSid: payload.id,
     Timestamp: payload.inserted_at ? new Date(payload.inserted_at).getTime() : Date.now(),
     ChatType: roomTypeToChatType(opts.roomType),
-    // Owner-only commands; fail closed when the owner is unknown.
+    // Fail closed when the owner is unknown.
     CommandAuthorized: opts.ownerUuid != null && payload.sender_id === opts.ownerUuid,
   };
   return ctx;
@@ -136,15 +130,12 @@ interface LinkLike {
     [k: string]: unknown;
   };
   markProcessed?: (roomId: string, messageId: string, opts?: { bestEffort?: boolean }) => Promise<unknown>;
+  markProcessing?: (roomId: string, messageId: string, opts?: { bestEffort?: boolean }) => Promise<unknown>;
 }
 
-interface PresenceLike {
-  onRoomJoined?: (roomId: string, payload: Record<string, unknown>) => unknown;
-  onRoomLeft?: (roomId: string) => unknown;
-  onRoomEvent?: (roomId: string, event: PlatformEvent) => unknown;
-  onContactEvent?: (event: ContactEvent) => unknown;
+interface RuntimeLike {
   start: () => Promise<unknown>;
-  stop: () => Promise<unknown>;
+  stop: (timeoutMs?: number) => Promise<unknown>;
 }
 
 interface DispatchParams {
@@ -157,11 +148,44 @@ interface DispatchParams {
 /** Injectable dependencies (defaults use the real SDK + openclaw runtime). */
 export interface BandGatewayDeps {
   createLink?: (conn: { agentId: string; apiKey: string; wsUrl: string; restUrl: string }) => LinkLike;
-  createPresence?: (link: LinkLike) => PresenceLike;
+  createRuntime?: (
+    link: LinkLike,
+    opts: {
+      agentId: string;
+      onExecute: (context: unknown, event: PlatformEvent) => Promise<void>;
+      onRoomJoined?: (roomId: string, payload: Record<string, unknown>) => unknown;
+      onContactEvent?: (event: ContactEvent) => Promise<void>;
+      onError?: (error: unknown, event: PlatformEvent) => void;
+    },
+  ) => RuntimeLike;
   createContactHandler?: (link: LinkLike) => { handle: (event: ContactEvent) => Promise<unknown> };
   dispatch?: (params: DispatchParams) => Promise<void>;
   runLifecycle?: (params: { abortSignal: AbortSignal; start: () => Promise<void>; stop: () => Promise<void> }) => Promise<void>;
   log?: (msg: string) => void;
+}
+
+/** Build the options object passed to `new AgentRuntime(...)`, pulled out as a
+ * pure function so the `autoSubscribeExistingRooms` wiring can be tested
+ * without constructing a real runtime. */
+export function buildRuntimeOptions(
+  link: LinkLike,
+  opts: {
+    agentId: string;
+    onExecute: (context: unknown, event: PlatformEvent) => Promise<void>;
+    onRoomJoined?: (roomId: string, payload: Record<string, unknown>) => unknown;
+    onContactEvent?: (event: ContactEvent) => Promise<void>;
+    onError?: (error: unknown, event: PlatformEvent) => void;
+  },
+) {
+  return {
+    link: link as never,
+    agentId: opts.agentId,
+    onExecute: opts.onExecute as never,
+    onRoomJoined: opts.onRoomJoined,
+    onContactEvent: opts.onContactEvent,
+    onError: opts.onError,
+    agentConfig: { autoSubscribeExistingRooms: true },
+  };
 }
 
 // Module-scoped race guard: which accounts are mid-start.
@@ -172,12 +196,8 @@ export function resetGatewayStarting(): void {
   starting.clear();
 }
 
-/**
- * Build the reply `deliver` callback that routes a model reply payload to the
- * Band room via the outbound adapter. Exported so the deliver seam (the heart
- * of the inbound→reply round-trip) is unit-testable directly. A delivery
- * failure is logged (observable), never thrown.
- */
+/** Build the reply `deliver` callback that routes a model reply payload to the
+ * Band room. A delivery failure is logged, never thrown. */
 export function createReplyDeliver(
   accountId: string,
   roomId: string,
@@ -188,9 +208,7 @@ export function createReplyDeliver(
     if (!text) return;
     const account = getAccount(accountId);
     if (!account) {
-      // The account can disappear between dispatch and delivery (e.g. a teardown
-      // race on restart). Log it — this function's contract is that delivery
-      // failures are observable, never silently dropped.
+      // Can disappear between dispatch and delivery (e.g. a teardown race on restart).
       log(`[band:${accountId}] skipping reply (room=${roomId}): account not connected`);
       return;
     }
@@ -216,23 +234,20 @@ function defaultDispatch(deps: Required<Pick<BandGatewayDeps, "log">>): (p: Disp
       cfg: cfg as Parameters<typeof dispatchInboundMessageWithBufferedDispatcher>[0]["cfg"],
       dispatcherOptions: {
         deliver: createReplyDeliver(accountId, roomId, deps.log),
-        // Observability: surface delivery/reply errors rather than dropping silently.
         onError: (err: unknown) => deps.log(`[band:${accountId}] reply error (room=${roomId}): ${String(err)}`),
       } as Parameters<typeof dispatchInboundMessageWithBufferedDispatcher>[0]["dispatcherOptions"],
     });
   };
 }
 
-/**
- * Build the Band gateway adapter. Dependencies are injected (defaults use the
- * real SDK + openclaw runtime) so the lifecycle is unit-testable with fakes.
- */
+/** Build the Band gateway adapter. Dependencies are injected so the lifecycle
+ * is unit-testable with fakes. */
 export function createBandGateway(deps: BandGatewayDeps = {}): ChannelGatewayAdapter<BandAccountConfig> {
   const log = deps.log ?? ((msg: string) => console.log(msg));
   const createLink = deps.createLink ?? ((conn) => new ThenvoiLink(conn) as unknown as LinkLike);
-  const createPresence =
-    deps.createPresence ??
-    ((link) => new RoomPresence({ link: link as never, autoSubscribeExistingRooms: true }) as unknown as PresenceLike);
+  const createRuntime =
+    deps.createRuntime ??
+    ((link, opts) => new AgentRuntime(buildRuntimeOptions(link, opts) as never) as unknown as RuntimeLike);
   const createContactHandler =
     deps.createContactHandler ??
     ((link) =>
@@ -245,9 +260,9 @@ export function createBandGateway(deps: BandGatewayDeps = {}): ChannelGatewayAda
   async function teardown(accountId: string): Promise<void> {
     const account = getAccount(accountId);
     if (!account) return;
-    const presence = account.presence as PresenceLike | undefined;
+    const runtime = account.runtime as RuntimeLike | undefined;
     try {
-      if (presence) await presence.stop();
+      if (runtime) await runtime.stop(account.stopTimeoutMs ?? DEFAULT_STOP_TIMEOUT_MS);
     } finally {
       try {
         await account.link.disconnect();
@@ -282,27 +297,69 @@ export function createBandGateway(deps: BandGatewayDeps = {}): ChannelGatewayAda
       const selfAgentId = me.id ?? link.agentId;
       const ownerUuid = me.ownerUuid ?? null;
 
-      const presence = createPresence(link);
       const contactHandler = createContactHandler(link);
 
-      presence.onRoomJoined = (roomId, payload) => {
-        const type = typeof payload?.type === "string" ? payload.type : undefined;
-        if (type) cacheRoomType(accountId, roomId, type);
+      // A throw here would propagate through AgentRuntime's consumeLoop and
+      // abort the whole account's live loop, same as in onExecute below.
+      const onRoomJoined = (roomId: string, payload: Record<string, unknown>) => {
+        try {
+          const type = typeof payload?.type === "string" ? payload.type : undefined;
+          if (type) cacheRoomType(accountId, roomId, type);
+        } catch (err) {
+          log(`[band:${accountId}] onRoomJoined failed (room=${roomId}): ${String(err)}`);
+        }
       };
 
-      presence.onRoomEvent = async (_roomId, event) => {
-        if (event.type !== "message_created") return;
+      const onContactEvent = async (event: ContactEvent) => {
+        try {
+          await contactHandler.handle(event);
+        } catch (err) {
+          log(`[band:${accountId}] contact event failed: ${String(err)}`);
+        }
+      };
+
+      const onError = (error: unknown, event: PlatformEvent) => {
+        log(`[band:${accountId}] fatal runtime error (room=${event.roomId ?? "?"}): ${String(error)}`);
+      };
+
+      // Band's message status is sent -> processing -> processed; markProcessing
+      // must be called before markProcessed. Not bestEffort: we want a REST
+      // failure here to surface (via the catch below) rather than be silently
+      // swallowed by ThenvoiLink's no-op logger, since a message that never
+      // gets marked processed is redelivered from the backlog.
+      async function markRoomMessageHandled(roomId: string, messageId: string): Promise<void> {
+        if (link.markProcessing) {
+          try {
+            await link.markProcessing(roomId, messageId);
+          } catch (err) {
+            log(`[band:${accountId}] markProcessing failed (room=${roomId}, msg=${messageId}): ${String(err)}`);
+          }
+        }
+        if (link.markProcessed) {
+          try {
+            await link.markProcessed(roomId, messageId);
+          } catch (err) {
+            log(`[band:${accountId}] markProcessed failed (room=${roomId}, msg=${messageId}): ${String(err)}`);
+          }
+        }
+      }
+
+      /** Filter + build the inbound context for a platform event; null means skip. */
+      async function prepareInboundMessage(event: PlatformEvent): Promise<{
+        ctx: MsgContext;
+        roomId: string;
+        messageId: string | undefined;
+      } | null> {
+        if (event.type !== "message_created") return null;
         const roomId = event.roomId ?? event.payload.chat_room_id;
-        if (!roomId) return;
+        if (!roomId) return null;
 
         const roomType = getRoomType(accountId, roomId);
         if (roomType === undefined) {
           log(`[band:${accountId}] room ${roomId} has no cached type; defaulting ChatType to 'group'`);
         }
 
-        // Fetch participants so the inbound body can rewrite `@[[uuid]]` tokens to
-        // handles and carry a roster. Best-effort: an empty roster on failure
-        // degrades to the prior behaviour (raw content), never blocks dispatch.
+        // Best-effort: an empty roster on failure degrades to raw content.
         let participants: MentionParticipant[] = [];
         try {
           const list = (await link.rest.listChatParticipants?.(roomId)) ?? [];
@@ -311,13 +368,13 @@ export function createBandGateway(deps: BandGatewayDeps = {}): ChannelGatewayAda
           log(`[band:${accountId}] could not list participants (room=${roomId}): ${String(err)}`);
         }
 
-        const msgCtx = platformEventToInboundContext(event, {
+        const ctx = platformEventToInboundContext(event, {
           selfAgentId,
           ownerUuid,
           roomType,
           participants,
         });
-        if (!msgCtx) return; // self-authored / non-text skip
+        if (!ctx) return null; // self-authored / non-text skip
 
         if (event.payload.sender_id && event.payload.sender_name) {
           trackLastSender(accountId, roomId, {
@@ -326,34 +383,45 @@ export function createBandGateway(deps: BandGatewayDeps = {}): ChannelGatewayAda
           });
         }
 
+        return { ctx, roomId, messageId: event.payload.id };
+      }
+
+      async function dispatchInbound(roomId: string, msgCtx: MsgContext): Promise<void> {
         try {
           await dispatch({ ctx: msgCtx, cfg: ctx.cfg, roomId, accountId });
         } catch (err) {
           log(`[band:${accountId}] dispatch failed (room=${roomId}): ${String(err)}`);
         }
+      }
 
-        // Mark processed (best effort — never throw out of the handler).
-        const messageId = event.payload.id;
-        if (messageId && link.markProcessed) {
-          try {
-            await link.markProcessed(roomId, messageId, { bestEffort: true });
-          } catch {
-            /* best effort */
-          }
-        }
-      };
-
-      presence.onContactEvent = async (event) => {
+      // Must never throw: Execution.executeEvent rethrows, which aborts the
+      // whole account's live-event consume loop.
+      async function onExecute(_context: unknown, event: PlatformEvent): Promise<void> {
         try {
-          await contactHandler.handle(event);
+          const inbound = await prepareInboundMessage(event);
+          if (!inbound) return;
+
+          await dispatchInbound(inbound.roomId, inbound.ctx);
+
+          if (inbound.messageId) {
+            await markRoomMessageHandled(inbound.roomId, inbound.messageId);
+          }
         } catch (err) {
-          log(`[band:${accountId}] contact event failed: ${String(err)}`);
+          log(`[band:${accountId}] onExecute failed (room=${event.roomId ?? "?"}): ${String(err)}`);
         }
-      };
+      }
 
-      setAccount(accountId, { link: link as never, selfAgentId, ownerUuid, presence: presence as never });
+      const runtime = createRuntime(link, { agentId: selfAgentId, onExecute, onRoomJoined, onContactEvent, onError });
 
-      await presence.start();
+      setAccount(accountId, {
+        link: link as never,
+        selfAgentId,
+        ownerUuid,
+        runtime: runtime as never,
+        stopTimeoutMs: ctx.account.stopTimeoutMs,
+      });
+
+      await runtime.start();
       log(`[band:${accountId}] connected to Band`);
 
       // Hold the account open for its lifetime; tear down on abort.

--- a/packages/openclaw/tests/unit/mentions.test.ts
+++ b/packages/openclaw/tests/unit/mentions.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for the pure mention-resolution module.
  *
- * Contract (INT-836 / architect consensus C2):
+ * Contract (architect consensus C2):
  *  - explicit @Name in text wins over any fallback
  *  - multiple @Names -> multiple mentions
  *  - case-insensitive

--- a/packages/openclaw/tests/unit/outbound.test.ts
+++ b/packages/openclaw/tests/unit/outbound.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for the Band outbound send logic.
  *
- * Contract (D2/D3 + INT-836 C2):
+ * Contract (D2/D3):
  *  - sendText resolves mentions via mentions.ts, then createChatMessage, returns { messageId }
  *  - mandatory-mention invariant: THROW when mentions resolve to empty
  *  - explicit @Name in the reply text resolves end-to-end through the adapter

--- a/packages/openclaw/tests/unit/prompts.test.ts
+++ b/packages/openclaw/tests/unit/prompts.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for the Band prompts module.
  *
- * Contract (D5 / INT-836 C1):
+ * Contract (D5 C1):
  *  - BASE_INSTRUCTIONS is STATIC (no prompt-time room_id injection)
  *  - fully rebranded thenvoi -> band (no "thenvoi" / "Thenvoi" anywhere)
  *  - room_id is sourced from the `[Band Room: <uuid>]` marker, NOT "the To field"

--- a/packages/openclaw/tests/unit/transport.test.ts
+++ b/packages/openclaw/tests/unit/transport.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for the pure inbound-context builder (transport layer).
  *
- * Contract (D5 C1 + INT-836 L2/F2):
+ * Contract (D5 C1 L2/F2):
  *  - message_created text -> inbound ctx; self-authored + non-text -> null
  *  - display Body carries the `[Band Room: <id>]` SUFFIX; command fields
  *    (RawBody/CommandBody/BodyForCommands) stay RAW (so stripMentions +
@@ -177,12 +177,18 @@ describe("platformEventToInboundContext", () => {
 // Gateway lifecycle (HARD GATE: re-covers the deleted channel-gateway.test)
 // =============================================================================
 
-import { createBandGateway, resetGatewayStarting, createReplyDeliver } from "../../src/transport.js";
+import {
+  createBandGateway,
+  resetGatewayStarting,
+  createReplyDeliver,
+  buildRuntimeOptions,
+} from "../../src/transport.js";
 import {
   resetAccounts,
   getAccount,
   setAccount,
   cacheRoomType,
+  getRoomType,
   trackLastSender,
 } from "../../src/state.js";
 
@@ -191,17 +197,27 @@ function makeLink(overrides: Record<string, unknown> = {}) {
     agentId: "agent-self",
     connect: vi.fn().mockResolvedValue(undefined),
     disconnect: vi.fn().mockResolvedValue(undefined),
+    markProcessing: vi.fn().mockResolvedValue(undefined),
     markProcessed: vi.fn().mockResolvedValue(undefined),
     rest: { getAgentMe: vi.fn().mockResolvedValue({ id: "agent-self", ownerUuid: "owner-1" }) },
     ...overrides,
   };
 }
 
-function makePresence() {
+/** Captures the opts passed by `createRuntime(link, opts)` so tests can invoke
+ * `onExecute`/`onRoomJoined`/`onContactEvent`/`onError` directly, mirroring how
+ * the real `AgentRuntime` would call them. */
+function makeRuntime() {
   return {
-    onRoomJoined: undefined as unknown,
-    onRoomEvent: undefined as unknown,
-    onContactEvent: undefined as unknown,
+    opts: undefined as
+      | {
+          agentId: string;
+          onExecute: (context: unknown, event: unknown) => Promise<void>;
+          onRoomJoined?: (roomId: string, payload: Record<string, unknown>) => unknown;
+          onContactEvent?: (event: unknown) => Promise<void>;
+          onError?: (error: unknown, event: unknown) => void;
+        }
+      | undefined,
     start: vi.fn().mockResolvedValue(undefined),
     stop: vi.fn().mockResolvedValue(undefined),
   };
@@ -226,15 +242,20 @@ function makeCtx(account: Record<string, unknown> = { apiKey: "k", agentId: "a" 
 
 function deps(extra: Record<string, unknown> = {}) {
   const link = makeLink();
-  const presence = makePresence();
+  const runtime = makeRuntime();
   const dispatch = vi.fn().mockResolvedValue(undefined);
+  const log = vi.fn();
   return {
     link,
-    presence,
+    runtime,
     dispatch,
+    log,
     base: {
       createLink: () => link,
-      createPresence: () => presence,
+      createRuntime: (_l: unknown, opts: typeof runtime.opts) => {
+        runtime.opts = opts;
+        return runtime;
+      },
       createContactHandler: () => ({ handle: vi.fn().mockResolvedValue(undefined) }),
       dispatch,
       // runLifecycle resolves only when aborted (mirrors runPassiveAccountLifecycle)
@@ -243,7 +264,7 @@ function deps(extra: Record<string, unknown> = {}) {
           if (abortSignal.aborted) return void stop().then(resolve);
           abortSignal.addEventListener("abort", () => void stop().then(resolve), { once: true });
         }),
-      log: () => {},
+      log,
       ...extra,
     },
   };
@@ -267,12 +288,14 @@ describe("gateway lifecycle", () => {
     expect(d.link.connect).toHaveBeenCalledOnce();
     expect(getAccount("default")?.selfAgentId).toBe("agent-self");
     expect(getAccount("default")?.ownerUuid).toBe("owner-1");
-    expect(d.presence.start).toHaveBeenCalledOnce();
+    expect(d.runtime.start).toHaveBeenCalledOnce();
 
     controller.abort();
     await started;
 
-    expect(d.presence.stop).toHaveBeenCalledOnce();
+    expect(d.runtime.stop).toHaveBeenCalledOnce();
+    // stop() must be called with a finite timeout, never undefined.
+    expect(d.runtime.stop.mock.calls[0][0]).toEqual(expect.any(Number));
     expect(d.link.disconnect).toHaveBeenCalledOnce();
     expect(getAccount("default")).toBeUndefined();
   });
@@ -294,13 +317,13 @@ describe("gateway lifecycle", () => {
   });
 
   it("disconnect-before-restart: an existing connection is torn down before a new start", async () => {
-    // pre-seed an existing account with a stoppable presence + link
+    // pre-seed an existing account with a stoppable runtime + link
     const oldStop = vi.fn().mockResolvedValue(undefined);
     const oldDisconnect = vi.fn().mockResolvedValue(undefined);
     setAccount("default", {
       link: { disconnect: oldDisconnect } as never,
       selfAgentId: "old",
-      presence: { stop: oldStop },
+      runtime: { stop: oldStop },
     });
 
     const d = deps();
@@ -317,7 +340,7 @@ describe("gateway lifecycle", () => {
     await p;
   });
 
-  it("dispatch-routing: a text message is mapped and routed to dispatch; markProcessed best-effort", async () => {
+  it("onExecute dispatch-routing: a text message is mapped and routed to dispatch; markProcessing then markProcessed", async () => {
     const d = deps();
     const gw = createBandGateway(d.base);
     const { ctx, controller } = makeCtx();
@@ -325,36 +348,42 @@ describe("gateway lifecycle", () => {
     await new Promise((r) => setTimeout(r, 0));
 
     cacheRoomType("default", "room-1", "group");
-    // simulate an inbound message via the registered handler
-    await (d.presence.onRoomEvent as (r: string, e: unknown) => Promise<void>)("room-1", msgEvent());
+    // simulate an inbound message via the captured onExecute (as AgentRuntime would call it)
+    await d.runtime.opts!.onExecute({}, msgEvent());
 
     expect(d.dispatch).toHaveBeenCalledOnce();
     const arg = d.dispatch.mock.calls[0][0] as { roomId: string; ctx: { To?: string } };
     expect(arg.roomId).toBe("room-1");
     expect(arg.ctx.To).toBe("room-1");
-    expect(d.link.markProcessed).toHaveBeenCalledWith("room-1", "msg-1", { bestEffort: true });
+    // Band's message status is sent -> processing -> processed; markProcessed alone
+    // 422s, so markProcessing must be called first.
+    expect(d.link.markProcessing).toHaveBeenCalledWith("room-1", "msg-1");
+    expect(d.link.markProcessed).toHaveBeenCalledWith("room-1", "msg-1");
+    const processingOrder = d.link.markProcessing.mock.invocationCallOrder[0];
+    const processedOrder = d.link.markProcessed.mock.invocationCallOrder[0];
+    expect(processingOrder).toBeLessThan(processedOrder);
 
     controller.abort();
     await p;
   });
 
-  it("dispatch-routing: self-authored + non-text are skipped (no dispatch)", async () => {
+  it("onExecute dispatch-routing: self-authored + non-text are skipped (no dispatch)", async () => {
     const d = deps();
     const gw = createBandGateway(d.base);
     const { ctx, controller } = makeCtx();
     const p = gw.startAccount!(ctx);
     await new Promise((r) => setTimeout(r, 0));
 
-    const onRoomEvent = d.presence.onRoomEvent as (r: string, e: unknown) => Promise<void>;
-    await onRoomEvent("room-1", msgEvent({ payload: { sender_id: "agent-self" } }));
-    await onRoomEvent("room-1", msgEvent({ payload: { message_type: "event" } }));
+    const onExecute = d.runtime.opts!.onExecute;
+    await onExecute({}, msgEvent({ payload: { sender_id: "agent-self" } }));
+    await onExecute({}, msgEvent({ payload: { message_type: "event" } }));
     expect(d.dispatch).not.toHaveBeenCalled();
 
     controller.abort();
     await p;
   });
 
-  it("markProcessed best-effort: a failing markProcessed does not throw out of the handler", async () => {
+  it("markProcessed best-effort: a failing markProcessed does not throw, and is logged", async () => {
     const link = makeLink({ markProcessed: vi.fn().mockRejectedValue(new Error("boom")) });
     const d = deps({ createLink: () => link });
     const gw = createBandGateway(d.base);
@@ -363,9 +392,72 @@ describe("gateway lifecycle", () => {
     await new Promise((r) => setTimeout(r, 0));
 
     cacheRoomType("default", "room-1", "group");
-    await expect(
-      (d.presence.onRoomEvent as (r: string, e: unknown) => Promise<void>)("room-1", msgEvent()),
-    ).resolves.toBeUndefined();
+    await expect(d.runtime.opts!.onExecute({}, msgEvent())).resolves.toBeUndefined();
+    expect(d.log).toHaveBeenCalledWith(expect.stringMatching(/markProcessed failed/));
+
+    controller.abort();
+    await p;
+  });
+
+  it("onExecute never throws, even when ctx-building fails; a subsequent good event still dispatches", async () => {
+    const d = deps();
+    const gw = createBandGateway(d.base);
+    const { ctx, controller } = makeCtx();
+    const p = gw.startAccount!(ctx);
+    await new Promise((r) => setTimeout(r, 0));
+
+    cacheRoomType("default", "room-1", "group");
+    const onExecute = d.runtime.opts!.onExecute;
+
+    // A malformed event (missing payload) throws inside the wrapped body.
+    await expect(onExecute({}, { type: "message_created" } as unknown)).resolves.toBeUndefined();
+    expect(d.dispatch).not.toHaveBeenCalled();
+    expect(d.log).toHaveBeenCalledWith(expect.stringMatching(/onExecute failed/));
+
+    // The runtime/consume loop is untouched: a good event on the same room still dispatches.
+    await onExecute({}, msgEvent());
+    expect(d.dispatch).toHaveBeenCalledOnce();
+
+    controller.abort();
+    await p;
+  });
+
+  it("onRoomJoined never throws, same total-try/catch as onExecute", async () => {
+    const d = deps();
+    const gw = createBandGateway(d.base);
+    const { ctx, controller } = makeCtx();
+    const p = gw.startAccount!(ctx);
+    await new Promise((r) => setTimeout(r, 0));
+
+    const onRoomJoined = d.runtime.opts!.onRoomJoined!;
+    // A payload whose `type` getter throws must not propagate (would otherwise
+    // abort the whole account's live-event loop via AgentRuntime's consumeLoop).
+    const throwingPayload = {
+      get type() {
+        throw new Error("boom");
+      },
+    };
+    expect(() => onRoomJoined("room-1", throwingPayload)).not.toThrow();
+    expect(d.log).toHaveBeenCalledWith(expect.stringMatching(/onRoomJoined failed/));
+
+    // Still caches the room type on a well-formed payload.
+    onRoomJoined("room-2", { type: "direct" });
+    expect(getRoomType("default", "room-2")).toBe("direct");
+
+    controller.abort();
+    await p;
+  });
+
+  it("onError is wired into createRuntime and is called by the runtime on a fatal error", async () => {
+    const d = deps();
+    const gw = createBandGateway(d.base);
+    const { ctx, controller } = makeCtx();
+    const p = gw.startAccount!(ctx);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(d.runtime.opts!.onError).toBeInstanceOf(Function);
+    d.runtime.opts!.onError!(new Error("fatal"), msgEvent());
+    expect(d.log).toHaveBeenCalledWith(expect.stringMatching(/fatal runtime error/));
 
     controller.abort();
     await p;
@@ -376,6 +468,127 @@ describe("gateway lifecycle", () => {
     const gw = createBandGateway(d.base);
     const { ctx } = makeCtx();
     await expect(gw.stopAccount!(ctx)).resolves.toBeUndefined();
+  });
+});
+
+// =============================================================================
+// Existing-room hydration / backlog drain (RoomPresence -> AgentRuntime)
+// =============================================================================
+
+describe("buildRuntimeOptions (autoSubscribeExistingRooms flag assertion)", () => {
+  it("enables autoSubscribeExistingRooms and wires the callbacks through unchanged", () => {
+    const onExecute = vi.fn();
+    const onRoomJoined = vi.fn();
+    const onContactEvent = vi.fn();
+    const onError = vi.fn();
+    const opts = buildRuntimeOptions({} as never, {
+      agentId: "agent-self",
+      onExecute,
+      onRoomJoined,
+      onContactEvent,
+      onError,
+    });
+    expect(opts.agentConfig).toEqual({ autoSubscribeExistingRooms: true });
+    expect(opts.agentId).toBe("agent-self");
+    expect(opts.onExecute).toBe(onExecute);
+    expect(opts.onRoomJoined).toBe(onRoomJoined);
+    expect(opts.onContactEvent).toBe(onContactEvent);
+    expect(opts.onError).toBe(onError);
+  });
+});
+
+/** A fake `link` exercising the REAL `AgentRuntime` + `Execution` (no injected
+ * fakes for those two). Seeds one backlog message on "room-1"; `nextEvent`
+ * never resolves a live WS event, so a passing test proves the message was
+ * drained from the backlog, not delivered live. */
+function makeIntegrationLink(overrides: Record<string, unknown> = {}) {
+  const backlogMessage = {
+    id: "backlog-1",
+    roomId: "room-1",
+    content: "backlog message",
+    senderId: "user-bob",
+    senderType: "user",
+    senderName: "Bob",
+    messageType: "text",
+    metadata: {},
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  };
+  let served = false;
+  return {
+    agentId: "agent-self",
+    capabilities: { contacts: false },
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    subscribeAgentRooms: vi.fn().mockResolvedValue(undefined),
+    subscribeAgentContacts: vi.fn().mockResolvedValue(undefined),
+    unsubscribeAgentContacts: vi.fn().mockResolvedValue(undefined),
+    subscribeRoom: vi.fn().mockResolvedValue(undefined),
+    unsubscribeRoom: vi.fn().mockResolvedValue(undefined),
+    listAllChats: vi.fn().mockResolvedValue([{ id: "room-1", type: "group" }]),
+    getStaleProcessingMessages: vi.fn().mockResolvedValue([]),
+    getNextMessage: vi.fn().mockImplementation(async () => {
+      if (served) return null;
+      served = true;
+      return backlogMessage;
+    }),
+    markProcessed: vi.fn().mockResolvedValue(undefined),
+    markFailed: vi.fn().mockResolvedValue(undefined),
+    // Never resolves a live event; resolves null only when the runtime aborts —
+    // proves the test's dispatched message came from backlog drain, not the WS.
+    nextEvent: vi.fn().mockImplementation(
+      (signal: AbortSignal) =>
+        new Promise((resolve) => {
+          if (signal.aborted) return resolve(null);
+          signal.addEventListener("abort", () => resolve(null), { once: true });
+        }),
+    ),
+    rest: {
+      getAgentMe: vi.fn().mockResolvedValue({ id: "agent-self", ownerUuid: "owner-1" }),
+      listChatParticipants: vi.fn().mockResolvedValue([]),
+    },
+    ...overrides,
+  };
+}
+
+describe("real AgentRuntime integration (backlog drain on connect)", () => {
+  beforeEach(() => {
+    resetAccounts();
+    resetGatewayStarting();
+  });
+
+  it("drains and dispatches an existing-room backlog message with no live WS event ever delivered", async () => {
+    const link = makeIntegrationLink();
+    const dispatch = vi.fn().mockResolvedValue(undefined);
+    const log = vi.fn();
+    // NOTE: no createRuntime override — this exercises the real default
+    // AgentRuntime + Execution against the fake link above.
+    const gw = createBandGateway({
+      createLink: () => link as never,
+      createContactHandler: () => ({ handle: vi.fn().mockResolvedValue(undefined) }),
+      dispatch,
+      runLifecycle: ({ abortSignal, stop }) =>
+        new Promise<void>((resolve) => {
+          if (abortSignal.aborted) return void stop().then(resolve);
+          abortSignal.addEventListener("abort", () => void stop().then(resolve), { once: true });
+        }),
+      log,
+    });
+    const { ctx, controller } = makeCtx();
+
+    const started = gw.startAccount!(ctx);
+    // Let the async hydration + backlog drain (network-round-trip-shaped promises) settle.
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(dispatch).toHaveBeenCalledOnce();
+    const arg = dispatch.mock.calls[0][0] as { roomId: string; ctx: { To?: string; CommandBody?: string } };
+    expect(arg.roomId).toBe("room-1");
+    expect(arg.ctx.To).toBe("room-1");
+    expect(arg.ctx.CommandBody).toBe("backlog message");
+    // No live event delivery happened (nextEvent only ever resolves via abort).
+    expect(link.nextEvent).toHaveBeenCalled();
+
+    controller.abort();
+    await started;
   });
 });
 


### PR DESCRIPTION
* fix(openclaw): drain Band backlog via AgentRuntime instead of RoomPresence

Messages sent to a Band account while disconnected were silently dropped: RoomPresence only streams live WebSocket events forward. Swap in AgentRuntime (one Execution per room), which already drains the REST backlog + recovers stale-processing messages on connect, so no SDK-side reinvention is needed.

Also wraps onExecute and onRoomJoined in a total try/catch (a throw from either would otherwise abort the whole account's live-event loop), gives runtime.stop() a finite timeout instead of blocking indefinitely on an in-flight dispatch, and logs markProcessed failures instead of swallowing them silently.

Reviewed and approved by the architect peer (Band collaboration).



* chore(openclaw): drop PLAN-INT-876.md from the PR

The design doc served its purpose during review; not needed in the merged diff.



* fix(openclaw): unblock stuck Band message backlog via markProcessing + local dedup

Band's message status is sent -> processing -> processed; calling markProcessed directly from sent 422s. Since the SDK swallowed that failure via a NoopLogger, the server-side cursor never advanced and getNextMessage got stuck on the oldest unacked message per room, starving every message sent after it on each reconnect. Wire a real logger into ThenvoiLink, call markProcessing before markProcessed, and add a persisted local dedup guard (processed-store.ts) so a message that still fails to transition is never re-dispatched and re-answered.



* fix(openclaw): drop noisy debug/info SDK log forwarding, keep warn/error

Forwarding every SDK debug/info event (WS topic joins, socket open/close) into the account log was connection-plumbing chatter with no diagnostic value in steady state. Only warn/error carry signal (that's what surfaced the markProcessed 422 in the first place) — keep forwarding those, drop the rest.



* fix(openclaw): drop local processed-message dedup store, ban ticket refs in code

Live testing (real gateway, real Band account, multiple stop/restart cycles) confirms markProcessing-before-markProcessed alone prevents backlog redelivery — the extra on-disk dedup guard was unneeded belt-and-suspenders for a bug this same change already fixes.

Also strips issue-tracker references from code comments across the package and codifies the rule in AGENTS.md (mirrors thenvoi-sdk-python): ticket IDs belong in commits/PRs, not in code.



* refactor(openclaw): drop SDK logger forwarding, trim excess comments in transport

sdkLogger forwarding is no longer needed for diagnosing the backlog-drain issue this branch already fixes; also cuts verbose/redundant comments and internal review labels (HIGH-1/HIGH-2) that added noise without explaining non-obvious behavior.



* fix(openclaw): address PR review feedback on backlog-drain transport

Stop bestEffort from masking markProcessing/markProcessed REST failures behind ThenvoiLink's no-op logger, make the runtime.stop() teardown timeout configurable instead of a hardcoded 5s, and split onExecute into prepare/dispatch/ack steps for a clearer error boundary.



---------