### PR TITLE
docs: Thenvoi→Band TypeScript SDK rename plan

### DIFF
--- a/docs/plans/rename-00-overview.md
+++ b/docs/plans/rename-00-overview.md
@@ -1,0 +1,295 @@
+# Thenvoi to Band: TypeScript SDK decision plan
+
+| Field | Value |
+|---|---|
+| Status | **APPROVED at round 3 — ready to implement; approval does not authorize implementation, and PREFLIGHT/O-01 remain preconditions** |
+| Audience | SDK implementer, release owner, reviewing architect |
+| Repository | `band-ai/band-sdk-typescript` |
+| Base and research commit | `main` at `ec988c00a786c1c68ed83aa231d8c2cdc4c17c3d` |
+| Plan revision | Working-tree revision on PR 139 |
+| Delivery | One preflight release operation, **one implementation PR** of seven ordered commits, and one release operation |
+| Linked specifications | [Delivery specification](rename-01-implementation-spec.md) · [Storage compatibility](rename-02-storage-compatibility-spec.md) · [Tool and MCP rename](rename-03-tool-mcp-spec.md) · [Cross-repository dependencies](rename-04-cross-repo.md) |
+
+This document is authoritative for scope, decisions, compatibility, sequencing,
+and approval. The linked specifications are authoritative only for their named
+implementation seams. Rejected designs and review-round transcripts are kept in
+git history, not in the executable plan.
+
+## Human summary
+
+The repository publishes `@band-ai/sdk`, but its source package name, public
+symbols, configuration, URLs, storage vocabulary, and model-visible tools still
+use Thenvoi. The release workflow hides part of this mismatch by rewriting the
+package name during publication. The two packages in the workspace also use
+different default platform URLs, and CI currently runs empty OpenClaw filters
+while reporting success.
+
+The result of this work is one coherent Band-branded 1.0.0 release. Existing
+`THENVOI_*` and example-specific `LINEAR_THENVOI_*` environment configuration
+continues to start agents with a warning. Existing Linear state databases retain
+their path, physical schema, and bindings. TypeScript symbols, platform tool
+names, and MCP allowlists are intentional major-version breaks documented in the
+release notes. The rename does not move files or rewrite private storage names.
+
+This plan does not rename the platform API, endpoint paths, historical database
+migrations in other repositories, GitHub organizations, or Python packages.
+Cursor-pagination migration and Fern publishing hardening are important but
+independent follow-ups, not steps in this rename.
+
+## Current failures
+
+| ID | Confirmed current behavior | Consequence |
+|---|---|---|
+| C-01 | CI filters OpenClaw as `@thenvoi/openclaw-channel-thenvoi`; `pnpm --filter` finds no project and exits zero. | OpenClaw typecheck, lint, and tests are false-green. The ungated `packaging` job runs a root `pnpm build` and does still verify OpenClaw dist artifacts, so build coverage is degraded rather than absent. |
+| C-02 | `packages/sdk/package.json` says `@thenvoi/sdk`; release publication rewrites it with `sed`. | Source, workspace filters, and published identity disagree. |
+| C-03 | The Linear SQLite store creates missing files and initializes empty tables. | Mechanically renaming the default filename would silently abandon live bindings. |
+| C-04 | Tool names and `mcp__thenvoi__` are model/host contracts, not ordinary internal symbols. | Misses can remove capabilities without a compile error. |
+| C-05 | `.release-please-manifest.json` records SDK 0.1.7 while npm latest is 0.1.6; the current SDK OIDC path has not published successfully. | The major release requires a proven preflight and cannot be the first test of the pipeline. |
+| C-06 | The SDK default platform host is `wss://app.thenvoi.com/api/v1/socket` (`platform/ThenvoiLink.ts:49`), and the REST URL is derived from it; OpenClaw already defaults to `app.band.ai`. | Changing the SDK default retargets every consumer that never passed an explicit URL, with no compile error and no warning. |
+| C-07 | Root `package.json` carries `pnpm.overrides`, but pnpm 10.22.0 (the pinned `packageManager`) ignores the `pnpm` field and prints a warning on every invocation. | Five security overrides are inert; 1.0.0 would ship with a dependency control that reports nothing and enforces nothing. |
+
+## Desired result and requirements
+
+| ID | Requirement |
+|---|---|
+| R-01 | CI must fail when a package filter matches nothing and must run both packages' real gates before rename work begins. |
+| R-02 | The breaking tree may not publish. The implementation PR installs the repository-owned guard and the hold marker, and the release operation removes the marker only after preconditions pass. |
+| R-03 | Source and published package identity must both be `@band-ai/sdk`; publication must not rewrite package metadata. |
+| R-04 | Existing Linear SQLite files must retain their physical table, column, and index names and all rows. Public SDK fields may change at the storage mapping boundary; opening under new or old code performs no rename DDL. |
+| R-05 | The default example DB path remains `.linear-thenvoi-example.sqlite`. Every renamed `LINEAR_BAND_*` setting falls back per field to its `LINEAR_THENVOI_*` predecessor with a warning, so custom state paths are never silently abandoned. |
+| R-06 | Default env loading reads `BAND_*` first, falls back per field to `THENVOI_*`, and warns once per legacy variable used. An explicit custom `prefix` remains exact and gets no implicit fallback. |
+| R-07 | Public TypeScript identifiers use Band names with no deprecated aliases. All breaks are collected for the 1.0.0 changelog. |
+| R-08 | All six outbound `thenvoi_*` metadata keys and the three brand values in scope move atomically to `band_*`/Band values. No payload may contain a mixed namespace. |
+| R-09 | The 17 platform tools advertise and accept only `band_*`; MCP uses `mcp__band__`; every server-name site derives from one constant. Old direct calls, prompts, MCP hosts, and allowlists require an explicit 1.0 migration. |
+| R-10 | `app.band.ai` becomes the SDK default. Existing explicit URLs continue unchanged. |
+| R-11 | 1.0.0 is published only after trusted-publisher ownership is confirmed, a patch release proves both package paths, package contents are verified, and every subpath is import-tested with required optional peers. |
+| R-12 | The six remaining adapter identity strings sent to or published for third parties move to Band in the same unit as R-08: Codex `clientName` and `clientTitle`, Google ADK `APP_NAME` and default agent name, the A2A agent-card skill tag, and the OpenCode `sessionTitlePrefix`. No `thenvoi` brand string may remain reachable on an outbound path without an explicit exclusion row. |
+| R-13 | The default-platform-host change is a documented 1.0 runtime break: it must appear in the compatibility contract and lead the release notes. Its `app.thenvoi.com` disposition is recorded in O-04. |
+
+## Scope
+
+Included:
+
+- CI package filters, release hold, and migration of the inert `pnpm.overrides`
+  block to a location pnpm 10 actually reads;
+- `@band-ai/rest-client@0.0.118` as an isolated dependency swap;
+- Linear bridge public names, examples, config vocabulary, and SQLite schema;
+- package identity, remaining public Thenvoi symbols, environment configuration,
+  defaults, documentation, metadata, adapter identity strings, platform tools,
+  MCP prefix, and server name;
+- release verification, 1.0.0, and deprecation of the three old-scope packages.
+
+Excluded and tracked separately:
+
+- cursor pagination required before the server's 2026-10-01 sunset;
+- Fern generator/publishing hardening and deprecation of the broken exact
+  `@band-ai/rest-client@0.0.113` version;
+- GitHub organization consolidation and the Python SDK rename/tool mismatch;
+- the 82 `linear_thenvoi_bridge.*` observability event names, owned by the
+  observability rebrand;
+- historical migrations, platform API paths, and `gateway_*`/`a2a_*` routing keys;
+- the pre-existing MCP peers-capability enforcement gap.
+
+These exclusions do not gate the rename PR. Cursor pagination and npm
+trusted-publisher access both gate REL-01: do not publish a 1.0 whose supported
+pagination path has a known 2026-10-01 server sunset.
+
+## Decision ledger
+
+| ID | Decision | Status | Reason |
+|---|---|---|---|
+| D-01 | Keep the old example DB filename as the compatibility default; do not perform an inferred file move. | Recommended, selected | A missing path is not proof that no state exists. Keeping the filename is safe and reversible. |
+| D-02 | Retain legacy physical SQLite table, column, and index names indefinitely; map them to Band public fields at the store boundary. | Revised after review, selected | The store accepts caller-provided databases and does not own database-global versioning. Private branding has no runtime benefit sufficient to justify irreversible DDL. |
+| D-03 | Env vars get field-level fallback; symbols do not get aliases. | Selected | Env misses fail silently at runtime; symbol misses fail loudly at compile time. |
+| D-04 | Advertise and accept only Band tools; platform tool and MCP names are a clean 1.0 break. | Revised after review, selected | Partial aliases were unreachable on several adapters and conflicted with custom-tool precedence. One explicit migration contract is simpler and testable. |
+| D-05 | Rename all outbound brand metadata together. | Directed | The keys are write-only within this SDK; unknown third-party readers are accepted as a major-version risk and called out in release notes. |
+| D-06 | PREFLIGHT proves current OIDC on unmodified `main` first; the rename PR's first commit then adds one checked-in guard command used by both publish steps, together with the hold marker. | Revised after review, revised again in round 3 for the single-PR shape, selected | This still proves the real pipeline without ever bypassing a hold, and enforces the hold at the publishing chokepoint. Ordering is preserved by running PREFLIGHT before the PR rather than by splitting the PR. |
+| D-11 | Ship the whole rename as one pull request of ordered, unsquashed commits rather than seven PRs. | Directed by the product owner in round 3 | Reviewer preference. Accepted with the rollback-granularity and review-burden costs recorded in the delivery section; the per-unit proof matrix is preserved as per-commit proof so no verification is lost. |
+| D-07 | Release with `Release-As: 1.0.0`; do not move the manifest backward. | Selected | Pre-1.0 conventional commits otherwise yield 0.2.0, and 0.1.7 already has a tag. |
+| D-08 | Rename the six adapter identity strings rather than retaining them. | Added after review round 2, corrected in round 3, selected | Unlike the SQLite names, none of these is a lookup key for state this SDK later reads back. `GoogleADKAdapter` creates a fresh `randomUUID()` session on every bootstrap and never calls a resume/`getSession` path, so `APP_NAME` partitions only newly created sessions; Codex `clientInfo` and the A2A skill tag are write-only identity. Retention would leave a permanent mixed-brand outbound surface for no compatibility benefit. |
+| D-09 | Fix the inert `pnpm.overrides` block inside commit C1 instead of excluding it. | Added after review round 2, selected | It is the same defect class as C-01 — a control reporting success while enforcing nothing — it sits in the workflow files C1 already owns, and shipping 1.0.0 with inert security overrides is worse than a small scope addition. |
+| D-10 | Treat the default-host change as a break requiring a recorded disposition for `app.thenvoi.com`, not as a silent default swap. | Added after review round 2, selected | Both hosts answer today, so nothing forces the issue at build or test time; the failure would appear only in a consumer's production traffic after upgrade. |
+
+## Compatibility contract
+
+| Surface | 0.x consumer behavior on upgrade | Migration |
+|---|---|---|
+| TypeScript imports | Compile failure for renamed symbols | Replace `Thenvoi` with `Band`; use release mapping. |
+| Default env variables | Continues working with one warning per legacy field | Set the corresponding `BAND_*` variable. Band wins when both exist. |
+| Explicit config prefix | No behavior change | None; caller owns the prefix. |
+| YAML Linear example key | New key wins; old key is accepted with a warning for the example runtime | Rename to `linear_band_bridge`. |
+| Existing SQLite file | Same path and physical schema open; rows map to Band public fields | No operator action. Old binaries remain able to reopen the file. |
+| Direct tool-calling adapter | Old name is rejected as unknown | Update prompts/few-shot examples to `band_*` before upgrading. |
+| MCP tool or host allowlist | Old prefix stops exposing the tool | Update `mcp__thenvoi__*` to `mcp__band__*` before upgrading. |
+| Outbound metadata reader | Receives Band keys/values only | Update external readers atomically with 1.0.0. |
+| Default platform host (no explicit URL passed) | **Silently retargets** from `app.thenvoi.com` to `app.band.ai`; the REST URL follows because it is derived from the WS URL | Pass an explicit `wsUrl`/`restUrl` to pin the old host, or confirm the account is served on `app.band.ai`. Called out first in the release notes because no compile error or warning surfaces it. |
+| Explicit platform URL | No behavior change | None; caller owns the URL. |
+| A2A agent-card consumer filtering on skill tag `thenvoi` | Tag becomes `band`; the skill stops matching an old tag filter | Update discovery filters to `band` before upgrading. |
+| Codex / Google ADK operator dashboards keyed on client or app name | Names change to `band_codex_adapter` / `band`; new sessions group under the new name | Update saved queries. No in-SDK state is keyed on these values. |
+| OpenCode / Parlant session titles | New sessions are titled `Band: …` / `Band Room …`; existing titles are unchanged | None. Both are display strings, and OpenCode's prefix stays caller-overridable. |
+
+## Ownership and invariants
+
+| ID | Invariant and owner |
+|---|---|
+| I-01 | `.github/workflows/ci.yml` owns package-match enforcement; no command relying on a package filter may accept zero matches. |
+| I-02 | `.github/workflows/release.yml` owns publication safety and must refuse publishing while the release-hold file exists. |
+| I-03 | The SQLite store owns the mapping from retained legacy physical names to Band public fields; rename work executes no schema-changing DDL. |
+| I-04 | The runtime tool schema owns canonical tool names; adapters, prompts, and comparisons use only those Band names. |
+| I-05 | The config loader owns default-prefix precedence and warnings; custom prefixes retain caller ownership. |
+| I-06 | After every implementation PR, both package test counts may stay equal or increase; any decrease requires an explicit reviewed explanation. |
+| I-07 | After the first breaking PR, the release hold remains present until the verified release operation removes it. |
+
+## Delivery and release sequence
+
+The rename ships as **one pull request**. Its internal units survive as ordered
+commits inside that PR, so the proof matrix, boundaries, and review order are
+preserved without splitting delivery.
+
+```text
+PREFLIGHT   release operation on current `main` — publish/install-check one
+            nonbreaking patch of both packages, proving OIDC before any break
+   |
+   `---- PR-RENAME  one pull request, seven ordered commits:
+            C1  CI repair + zero-match enforcement + guard + hold marker
+                + pnpm override migration
+            C2  rest-client scope swap to 0.0.118
+            C3  Linear symbols/examples/config fallback
+            C4  public room-id fields + outbound metadata + adapter identity;
+                no DDL
+            C5  package identity + all remaining public symbols
+            C6  BAND_* config + Band URLs + docs
+            C7  platform tools + MCP prefix
+               |
+               `---- REL-01  verified 1.0.0 release
+```
+
+Why PREFLIGHT is not part of the PR. PREFLIGHT must publish a **nonbreaking**
+patch of both packages to prove the OIDC path, and it cannot do that from a tree
+that already contains the rename. It is therefore a release operation on current
+`main`, run before the PR opens — not a second pull request. REL-01 is likewise
+not hand-authored: release-please generates the release PR mechanically.
+
+Commit order inside the PR is load-bearing and must be preserved on merge. Use a
+merge commit or rebase; **do not squash**, because C1 must remain independently
+identifiable as the commit that introduces the hold marker, and because the
+per-commit proof matrix is the review unit. INT-404's remaining public symbols are
+absorbed by C5. Exact units and proof are in the delivery spec.
+
+Consequences accepted with the single-PR shape:
+
+- rollback is all-or-nothing before REL-01; there is no partial revert of, say,
+  the tool rename while keeping the storage mapping;
+- the review burden concentrates into one large diff spanning CI, storage, public
+  API, tools, and docs, so per-commit review is required rather than optional;
+- I-06's test-count comparison is evaluated once against the PREFLIGHT baseline
+  rather than seven times.
+
+## Rollout and rollback
+
+- PREFLIGHT proves both package publish paths with nonbreaking contents on current
+  `main`, before the rename PR exists. C1 then installs the guard **and** the hold
+  marker in the same commit, so the tree is never publishable while it carries a
+  break.
+- Every commit must leave the tree green; the merged PR must be green and coherent
+  on `main`. Coherence does not imply publishability while the hold exists.
+- A rollback before REL-01 reverts the whole PR. This is the main cost of the
+  single-PR shape and is accepted deliberately. Retained SQLite names allow old and
+  new binaries to reopen the same file; no storage restore is introduced by this
+  rename.
+- REL-01 removes the already-proven hold in the 1.0.0 release PR, publishes,
+  install-checks, and only afterward deprecates old packages.
+- A failed publish does not remove or deprecate anything. Fix the pipeline,
+  restore/retain the hold, and retry with a new immutable version.
+
+## Open owner assignments
+
+These do not change the design, but must be assigned before their step:
+
+| ID | Needed owner | Gate |
+|---|---|---|
+| O-01 | npm organization owner who can inspect/update trusted-publisher entries for both Band packages | PREFLIGHT, therefore the entire rename PR |
+| O-02 | Owner with publish rights to deprecate the three `@thenvoi` packages | Post-publish deprecation only |
+| O-03 | Engineering owner for cursor pagination | REL-01 and the 2026-10-01 service deadline; separate implementation plan |
+| O-04 | **Answered by the platform team — no owner needed.** Platform routing redirects only browser traffic from the legacy host; API requests and WebSocket upgrades on `app.thenvoi.com` continue to be served unchanged, deliberately, because published SDKs carry that host as their default. The old default therefore keeps working for SDK traffic, making the default change a convenience rather than a hard cutover. | Closed |
+| O-05 | **Decided by the product owner during review round 2: `app.band.ai`.** R-10 stands unchanged. Confirmed against `BandEnvironment.Default` in `@band-ai/rest-client@0.0.118`, OpenClaw's existing defaults, and the platform team; `app.band.ai` also resolves live. `platform.*.band.ai` names are internal deployment hostnames, not the SDK-facing host. | Closed |
+
+## Approval criteria
+
+| ID | Observable criterion |
+|---|---|
+| A-01 | A deliberately invalid package filter fails CI with non-zero status, and real SDK/OpenClaw filters execute non-zero test counts. |
+| A-02 | A simulated release-created output cannot reach `npm publish` while the hold exists. |
+| A-03 | A pre-rename SQLite fixture reopens with every row exposed under Band public fields while its logical schema dump remains unchanged. |
+| A-04 | A legacy env-only fixture starts, warns once per used field, and Band values win field-by-field when both prefixes exist. |
+| A-05 | Exact emitted metadata and tool-schema snapshots contain only the selected Band names; no mixed namespace is possible. |
+| A-06 | Legacy direct tool calls and old MCP allowlists fail in the documented way; migrated Band calls preserve reporting and reply-delivery behavior. |
+| A-07 | A clean install of 1.0.0 resolves all exports under ESM and CJS, with optional peers installed for gated subpaths. |
+| A-08 | Old packages are deprecated only after 1.0.0 is confirmed installable; healthy latest packages remain non-deprecated. |
+| A-09 | A repository-wide scan of outbound paths finds no reachable `thenvoi` brand string without a matching exclusion row, and every renamed adapter identity string appears in the compatibility contract. |
+| A-10 | `pnpm install` emits no ignored-`pnpm`-field warning, and each declared override resolves to the required version in the installed tree. |
+
+## Review findings and status
+
+Rounds 1 and 2 predate D-11, so their dispositions name the old seven-PR units.
+Read `PR-00`…`PR-06` as commits `C1`…`C7` of the single rename PR, and proof ids
+`P-00-*`…`P-05-*` as `P-C1-*`…`P-C6-*`. The dispositions themselves are unchanged.
+
+Round 1 independently reviewed product/compatibility, persistence/reliability,
+and the whole artifact. All three returned REVISE/HELD. Material findings:
+
+| Finding | Disposition |
+|---|---|
+| PC-01 / WP-01: patch preflight was impossible while the hold existed | **Revised:** PR-00 installs an inactive guard; PREFLIGHT proves both packages; PR-02 activates the hold. |
+| PC-02 / WP-02: legacy custom `LINEAR_THENVOI_STATE_DB` could be silently abandoned | **Revised:** all renamed Linear env fields get Band-first legacy fallback and custom-path proof. |
+| PC-03 / SQL-PERSIST-01: `user_version` is database-global but the store does not own the database | **Revised:** no physical schema rename or migration version. |
+| PC-05 / SQL-PERSIST-02/03/04: migration was irreversible, under-modeled, and hard to prove | **Revised:** retain the physical schema; require a no-DDL logical-schema proof. |
+| PC-04 / WP-03: partial tool aliases conflicted with custom tools and were unreachable on LangGraph/MCP | **Revised:** clean 1.0 break on every tool path; no aliases. |
+| PC-06: a duplicate release-hold test could be false-green | **Revised:** both real publish steps invoke one tested guard command immediately before `npm publish`. |
+| RV-01: OpenClaw env/E2E consumers were outside PR-05 | **Revised:** PR-05 owns both shipped env readers and the E2E-only `BAND_API_KEY_USER` fallback. |
+| RV-02: no authoritative public-export migration map survived the rewrite | **Revised:** PR-04 contains the reviewed mapping and generates a declaration/export audit consumed by release notes. |
+
+Because these changes alter persistence, compatibility, and rollout, the complete
+revision received a fresh independent whole-artifact review. That round returned
+**APPROVE** after verifying the release order, workspace env owners, built public
+export inventory, retained SQLite schema, tool and MCP break, pagination release
+gate, links, and named filter/build probes.
+
+### Round 2 (repository-verified)
+
+Round 2 re-derived every load-bearing claim from the working tree rather than from
+the plan text. Confirmed accurate: C-02 through C-05, the 17-tool count, the six
+outbound metadata keys and three brand values, the 82 observability event names,
+the retained SQLite identifiers, and the completeness of the C5 export map
+(verified by confirming no barrel uses `export *`, so the reachable public surface
+is exactly the explicitly re-exported set).
+
+| Finding | Disposition |
+|---|---|
+| R2-01: outbound adapter identity strings — Codex `clientName`/`clientTitle`, Google ADK `APP_NAME` and default agent name, A2A agent-card skill tag — belonged to no unit and no exclusion, so P-TOOL-08 and the Linear completeness scan could not pass as written | **Revised:** R-12, D-08, the C4 boundary and P-C4-5. Round 3 found this fix itself incomplete and corrected the count from four to six (see R3-01). The round's initial claim that renaming `APP_NAME` would orphan durable ADK sessions was **withdrawn**: the adapter creates a fresh `randomUUID()` session per bootstrap and has no resume path, so this is a scope hole, not a state-compatibility decision. |
+| R2-02: the default-host flip was absent from the compatibility contract | **Revised:** C-06, R-13, D-10, three new contract rows, and P-C6-4. O-04 was then **closed by the platform team** (API and WebSocket traffic on the legacy host stays served), and O-05 was **decided by the product owner** in favour of `app.band.ai`. |
+| R2-03: PREFLIGHT gated the entire train but named no mechanism for forcing a two-package patch | **Revised:** PREFLIGHT now specifies the mechanism and records that 0.1.7 stays tagged-but-unpublished. |
+| R2-04: `pnpm.overrides` silently ignored by the pinned pnpm 10.22.0 | **Revised:** C-07, D-09, folded into C1 with P-C1-5. |
+| R2-05: publish-time `cp README.md` defeats the "pack without mutation" proof | **Revised:** C1 defines the README as a required packed entry asserted after the copy, and records the known local/CI packing delta in its own boundary section. |
+| R2-06: the rest-client unit's "no REST contract change" was inaccurate | **Revised:** C2 now names the renamed and removed generated symbols and identifies P-C2-1 as the load-bearing proof. |
+
+Baselines measured on the round-2 base (`ec988c0`), for I-06: SDK **696 tests / 88
+files**, OpenClaw **156 tests / 9 files**, both green, with typecheck and lint
+exiting zero. The previously never-executed OpenClaw suite is not concealing
+failures, which confirms PR-00's stated two-workflow boundary.
+
+### Round 3 (repository-verified, single-PR shape)
+
+Round 3 re-reviewed the round-2 revision and the D-11 restructure, and probed the
+round-2 fixes themselves.
+
+| Finding | Disposition |
+|---|---|
+| R3-01: R-12/D-08 said "four" adapter identity strings while listing five sites, and both missed OpenCode `sessionTitlePrefix: "Thenvoi"` (`OpencodeAdapter.ts:138`), which belonged to no unit — the same defect R2-01 was meant to close | **Revised:** count corrected to six, OpenCode added to R-12/D-08/C4 with an explicit note that its neighbouring `mcpServerName` stays with C7. |
+| R3-02: the C4 boundary attributed the session title to Parlant only | **Confirmed accurate and extended:** `ParlantAdapter.ts:287` does set `title: "Thenvoi Room …"`, so the original attribution was right; OpenCode's separate prefix is now listed alongside it. |
+| R3-03: round 2 asserted "C-01 through C-05 confirmed accurate", but C-01 overstates the build case | **Revised:** C-01 now scopes false-green to typecheck, lint, and test; the ungated `packaging` job runs a root `pnpm build` and does verify OpenClaw dist artifacts. |
+| R3-04: PREFLIGHT's mechanism was unverified against the release-please config | **Confirmed:** `release-please-config.json` sets `bump-patch-for-minor-pre-major: true` for both packages and declares no `separate-pull-requests`, so two path-scoped `fix:` commits produce one release PR bumping both. Recorded in PREFLIGHT. |
+| R3-05: D-11 (single PR) is incompatible with PREFLIGHT as previously sequenced | **Revised:** PREFLIGHT is reclassified as a release operation on unmodified `main` that runs before the PR opens; the hold marker moves from C3 to C1. REL-01's PR is release-please-generated and does not count against D-11. |
+
+Round 3 verdict is recorded by the reviewer separately; this table records only the
+artifact changes made in response.

--- a/docs/plans/rename-01-implementation-spec.md
+++ b/docs/plans/rename-01-implementation-spec.md
@@ -1,0 +1,387 @@
+# Thenvoi to Band: delivery and proof specification
+
+| Field | Value |
+|---|---|
+| Status | **APPROVED at round 3 — executable as one PR after PREFLIGHT and O-01** |
+| Decision authority | [Decision plan](rename-00-overview.md) |
+| Specialized specifications | [Storage compatibility](rename-02-storage-compatibility-spec.md) · [Tool and MCP rename](rename-03-tool-mcp-spec.md) · [Cross-repository dependencies](rename-04-cross-repo.md) |
+
+This file defines executable units and proof. It does not redefine compatibility
+or scope decisions from the decision plan.
+
+## Required gate after every commit
+
+Run from the repository root:
+
+```bash
+pnpm -r build
+pnpm -r typecheck
+pnpm -r lint
+pnpm -r test
+```
+
+Record each command's exit status and per-package test counts. Also run each
+unit's focused proof. A package filter that executes zero tests is a failure.
+
+All seven units below are **ordered commits inside one pull request** (D-11), not
+separate PRs. Every commit must leave the tree green on its own so the per-commit
+proof matrix stays meaningful and `git bisect` remains usable; do not squash on
+merge. PREFLIGHT is a release operation that runs on unmodified `main` **before**
+the PR opens.
+
+## C1 — restore truthful CI and harden the publish path
+
+Outcome:
+
+- replace all stale OpenClaw package filters with
+  `@band-ai/openclaw-channel-band`;
+- add `--fail-if-no-match` before every CI `--filter` invocation;
+- add one checked-in release-guard command that exits non-zero when the hold
+  marker exists;
+- invoke that exact command immediately before each real `npm publish`;
+- add pre-publish package-content assertions for required entries and a reviewed
+  file-count floor, evaluated **after** the `cp README.md packages/sdk/README.md`
+  step (`release.yml:71`) so the assertion sees the bytes that are actually
+  published; `README.md` is a required packed entry;
+- move the root `pnpm.overrides` block into `pnpm-workspace.yaml`, which pnpm 10
+  reads, and fail CI on the ignored-`pnpm`-field warning;
+- add the release-hold marker in this same commit, so the branch is never
+  publishable from the moment it carries a break.
+
+Boundary: `.github/workflows/ci.yml`, `.github/workflows/release.yml`, one guard
+script, root `package.json`/`pnpm-workspace.yaml` override migration, and focused
+workflow tests/static workflow assertions.
+
+Known local/CI delta: `packages/sdk/README.md` is not checked in, so a local
+`npm pack` omits it. Any local packing proof must either copy the README first or
+record the omission explicitly; it must not assert a file-count floor that only
+holds locally.
+
+Failure behavior: when the marker is later present, the release job may still
+create/update a release-please PR, but no package bytes may be published. A
+missing filter or invalid package content must fail instead of warning/succeeding.
+
+Proof:
+
+| ID | Old failure and executable proof | Expected | Status |
+|---|---|---|---|
+| P-C1-1 | Run `pnpm --fail-if-no-match --filter definitely-no-such-package exec node -e ""`. | Exit non-zero. | **Pass at research time** |
+| P-C1-2 | Run the exact SDK and OpenClaw filters used by CI with a command printing a sentinel. | Both print the sentinel once. | Planned |
+| P-C1-3 | Execute the real guard with and without the marker; statically assert both workflow publish steps call that command immediately before `npm publish`. | Marker fails; absence passes; neither publish step can bypass the shared command. | Planned |
+| P-C1-4 | Run both package test suites. | Non-zero tests, no failures. | **Pass at research time**: SDK 696 tests / 88 files, OpenClaw 156 tests / 9 files, both green; typecheck and lint exit zero. These are the I-06 baselines. |
+| P-C1-5 | Run `pnpm install` and inspect the installed tree for each declared override. | No ignored-`pnpm`-field warning; every override resolves to its required version. | Planned |
+
+Handoff: PREFLIGHT below must already have passed before this commit is written,
+because it cannot be run from a tree carrying the hold marker or the rename.
+
+## PREFLIGHT — prove current trusted publishing before the rename PR
+
+This runs on current `main`, before the rename PR is opened. An npm organization
+owner confirms both trusted-publisher entries against
+`band-ai/band-sdk-typescript` and `release.yml`. Prepare one nonbreaking patch
+release that exercises both package-specific publish branches. Install-check both
+outputs and verify provenance and required packed entries.
+
+It cannot be folded into the PR: proving the publish path requires actually
+publishing, and the PR's first commit installs a hold that forbids exactly that.
+This is the one piece of sequencing the single-PR shape cannot absorb.
+
+Mechanism. `release.yml` gates each publish step on that package's own
+`packages/<pkg>--release_created` output, so a preflight that exercises both
+branches requires release-please to cut a release for **both** packages in one
+run. Land one `fix:` commit that touches a file inside `packages/sdk` and a second
+`fix:` commit that touches a file inside `packages/openclaw`. `release-please-config.json`
+sets `bump-patch-for-minor-pre-major: true` for both packages, so a `fix:` yields a
+patch bump pre-1.0, and the config declares no `separate-pull-requests`, so both
+bumps arrive in one release PR. Confirm the resulting release-please
+PR bumps both manifest entries before merging it; a PR that bumps only one package
+has not proven the other publish branch and must not be accepted as P-PRE-1.
+
+Version note. The manifest records `packages/sdk: 0.1.7` while npm latest is
+0.1.6, so the preflight patch publishes **0.1.8**. Version 0.1.7 keeps its git tag
+and is never published. This is expected and consistent with D-07; do not attempt
+to publish 0.1.7 or move the manifest backward to reconcile the gap.
+
+If either publish path fails, fix it while no release hold or breaking rename is
+present and repeat with a new immutable patch version. The rename PR must not be
+opened for merge until this proof passes.
+
+| ID | Proof | Expected | Status |
+|---|---|---|---|
+| P-PRE-1 | Patch release of both packages under current OIDC on unmodified `main`. | Both versions advance, install, carry provenance, and include required files. | Blocked on npm owner (O-01) |
+
+## C2 — swap the generated REST-client package scope
+
+Outcome: SDK source and lockfile use `@band-ai/rest-client@0.0.118`, with no
+operation this SDK consumes removed or altered. This commit introduces no public
+SDK break and is independent of the naming work in C3 onward.
+
+The generated surface does change between `@thenvoi/rest-client@0.0.113` and
+`@band-ai/rest-client@0.0.118`, so "scope swap" understates the unit:
+
+- root exports renamed: `ThenvoiClient`→`BandClient`, `ThenvoiError`→`BandError`,
+  `ThenvoiTimeoutError`→`BandTimeoutError`, namespace `Thenvoi`→`Band`,
+  `ThenvoiEnvironment`→`BandEnvironment`;
+- resources `system` and `test` removed; `agentApiActivity` added;
+- types `Memory`/`MemoryCreateRequest` renamed to
+  `AgentMemory`/`AgentMemoryCreateRequest`; `HealthCheck`/`TestResponse` removed.
+
+At the research commit the SDK touches this dependency at exactly one site
+(`platform/ThenvoiLink.ts:35` and `:122`, importing `ThenvoiClient`) and uses none
+of the removed resources or types, so the change is internal. `FernThenvoiClientLike`
+is defined structurally by the SDK, not imported from the generated package, so it
+stays with C5. If a future base introduces a use of a removed resource, P-C2-1
+is the proof that catches it — **not** P-C2-2, which runs against a structural fake
+and cannot observe a removed generated resource.
+
+Boundary: SDK package metadata, lockfile, generated-client imports/types, and a
+Fern adapter conformance test. Do not take 0.0.119 or later in this unit.
+
+Proof:
+
+| ID | Proof | Expected | Status |
+|---|---|---|---|
+| P-C2-1 | Typecheck and run the SDK suite after the exact dependency swap. | No TypeScript errors; baseline tests pass. | Planned; previously probed, must rerun on implementation base |
+| P-C2-2 | Invoke every REST operation the adapter claims to support against a structural fake. | No operation rejects with `UnsupportedFeatureError`; zero network calls. | Planned |
+| P-C2-3 | Inspect the packed SDK dependency graph. | No runtime dependency on `@thenvoi/rest-client`; exactly 0.0.118 selected. | Planned |
+
+## C3 — Linear names, examples, and configuration compatibility
+
+Outcome:
+
+- rename the two exported `LinearThenvoi*` types and example/test-only symbols;
+- rename the example directory and scripts coherently;
+- use `linear_band_bridge`/`linear_band_transport` and `LINEAR_BAND_*` names;
+- accept the old YAML key with a one-time warning in every documented example
+  entry path;
+- read every renamed Linear env setting Band-first with per-field
+  `LINEAR_THENVOI_*` fallback and once-per-variable warnings;
+- retain `.linear-thenvoi-example.sqlite` as the compatibility default;
+- remove the dead recovered-room env test knob rather than renaming it;
+- leave `linear_thenvoi_bridge.*` observability event names untouched.
+
+Boundary: Linear integration barrels/types, examples, tests,
+package scripts, and all documentation links to the renamed example path. The
+private SQLite names remain unchanged; public `thenvoiRoomId` fields belong to
+C4.
+
+Proof:
+
+| ID | Proof | Expected | Status |
+|---|---|---|---|
+| P-C3-1 | Compile ESM and CJS consumers importing the new exported names, and compile a fixture using old names. | New succeeds; old fails at compile time. | Planned |
+| P-C3-2 | Start each example config entry path with only `linear_thenvoi_bridge`. | Starts and warns once; no silent miss. | Planned |
+| P-C3-3 | Open an existing default-path fixture and run one dispatch. | Existing binding is reused; no second room is requested. | Planned |
+| P-C3-3B | Configure a non-default live DB only through `LINEAR_THENVOI_STATE_DB`, plus table-driven old-only/mixed/both cases for every renamed Linear env setting. | Exact custom path is reused; Band wins per field; warnings are once per legacy field; no empty default DB is opened. | Planned |
+| P-C3-4 | Search scoped source, examples, scripts, tests, and docs with explicit exclusions for DB schema, metadata, and log events owned elsewhere. | No unowned Linear naming hit; every exclusion maps to a later unit or explicit exclusion. | Planned |
+
+The release-hold marker is added by C1, so it is already present here. CI/proof
+must demonstrate that the merged tree containing renamed exports cannot publish
+either package.
+
+## C4 — public room-id fields, outbound metadata, adapter identity; retain storage schema
+
+Outcome: execute the linked storage compatibility specification; rename
+`thenvoiRoomId` to `bandRoomId` in public Linear contracts without aliases while
+mapping retained `thenvoi_room_id` rows at the store boundary; rename the six
+outbound metadata keys and three brand values as an atomic payload change.
+
+Also rename the six adapter identity strings required by R-12 and D-08:
+
+| Site | Old | 1.0 |
+|---|---|---|
+| `adapters/codex/CodexAdapter.ts:158,463` | `clientName: "thenvoi_codex_adapter"` | `"band_codex_adapter"` |
+| `adapters/codex/CodexAdapter.ts:159,464` | `clientTitle: "Thenvoi Codex Adapter"` | `"Band Codex Adapter"` |
+| `adapters/google-adk/GoogleADKAdapter.ts:22` | `APP_NAME = "thenvoi"` | `"band"` |
+| `adapters/google-adk/GoogleADKAdapter.ts:308` | default agent name `"thenvoi_agent"` | `"band_agent"` |
+| `adapters/a2a-gateway/server.ts:406` | skill `tags: ["thenvoi", "gateway"]` | `["band", "gateway"]` |
+| `adapters/opencode/OpencodeAdapter.ts:138` | `sessionTitlePrefix: "Thenvoi"` | `"Band"` |
+
+All are write-only identity: Codex `clientInfo` is sent once in `initialize`, the
+A2A tag is published discovery metadata, the OpenCode prefix only formats new
+session titles (`:986`), and `GoogleADKAdapter` passes `APP_NAME` only to
+`createRunner` and `createSession` alongside a fresh `randomUUID()` session id
+(`:239-247`) with no resume or `getSession` path. Renaming therefore abandons no
+state this SDK later reads back. The Codex fields and the OpenCode prefix all
+remain caller-overridable.
+
+Note that OpenCode's neighbouring `mcpServerName: "thenvoi"` (`:139`) is **not**
+part of this unit — it is an MCP server name owned by C7's `MCP_SERVER_NAME`
+constant. Rename the prefix here and leave the server name to C7.
+
+Boundary: Linear store mapping/types/callers, A2A gateway outbound metadata and
+agent-card skill tags, Parlant metadata and session title (`ParlantAdapter.ts:287`),
+Linear bridge brand metadata, Codex/Google ADK/OpenCode adapter identity strings,
+tests, and changelog input. Do not rename physical SQLite identifiers, `gateway_*`,
+`a2a_*`, API paths, observability events, or any MCP server name.
+
+Proof:
+
+| ID | Proof | Expected | Status |
+|---|---|---|---|
+| P-C4-1 | Run the complete no-DDL matrix in the linked spec. | Existing and fresh stores keep the identical legacy physical schema while exposing Band public fields. | Planned |
+| P-C4-2 | Compile external fixtures against old/new public room-id field names. | Band succeeds; Thenvoi fails. | Planned |
+| P-C4-3 | Snapshot each outbound payload owner. | Exact Band key/value set; no mixed namespace. | Planned |
+| P-C4-4 | Re-run message-history/routing tests. | Routing still reads unchanged `gateway_*`/`a2a_*` keys. | Planned |
+| P-C4-5 | Assert the Codex `clientInfo` sent at `initialize`, the generated A2A agent card, and the ADK runner/session/agent names; then scan every outbound path for a reachable `thenvoi` brand string. | Exact Band values at all five sites; caller `options.config` overrides still win for Codex; no unowned outbound `thenvoi` hit remains. | Planned |
+
+## C5 — package identity and remaining public symbols
+
+Outcome:
+
+- source package identity becomes `@band-ai/sdk`;
+- remove the publish-time `sed` rewrite;
+- update workspace filters, imports, exports, package repository metadata, and
+  all remaining public `Thenvoi*` identifiers, including the scope previously
+  assigned to INT-404;
+- retain the release hold.
+
+Boundary: package metadata, barrels, adapter/core/MCP/ACP type names, consumers,
+tests, examples, CI/release filters, and documentation. Tool names, MCP prefix,
+env vars, URL defaults, and metadata are owned by other units.
+
+Authoritative public migration map at the research commit:
+
+| Old export | 1.0 export |
+|---|---|
+| `ThenvoiLink` | `BandLink` |
+| `LinearThenvoiBridgeConfig` | `LinearBandBridgeConfig` |
+| `LinearThenvoiBridgeDeps` | `LinearBandBridgeDeps` |
+| `ThenvoiACPServerAdapter` | `BandACPServerAdapter` |
+| `ThenvoiACPServerAdapterOptions` | `BandACPServerAdapterOptions` |
+| `ThenvoiMcpBackend` | `BandMcpBackend` |
+| `ThenvoiMcpBackendKind` | `BandMcpBackendKind` |
+| `CreateThenvoiMcpBackendOptions` | `CreateBandMcpBackendOptions` |
+| `createThenvoiMcpBackend` | `createBandMcpBackend` |
+| `getThenvoiSdkMcpServerConfig` | `getBandSdkMcpServerConfig` |
+| `ThenvoiMcpServer` | `BandMcpServer` |
+| `ThenvoiMcpServerOptions` | `BandMcpServerOptions` |
+| `ThenvoiMcpSseServer` | `BandMcpSseServer` |
+| `ThenvoiMcpSseServerOptions` | `BandMcpSseServerOptions` |
+| `ThenvoiMcpStdioServer` | `BandMcpStdioServer` |
+| `ThenvoiMcpStdioServerOptions` | `BandMcpStdioServerOptions` |
+| `ThenvoiSdkMcpServer` | `BandSdkMcpServer` |
+| `CreateThenvoiSdkMcpServerOptions` | `CreateBandSdkMcpServerOptions` |
+| `createThenvoiSdkMcpServer` | `createBandSdkMcpServer` |
+| `ThenvoiSdkError` | `BandSdkError` |
+| `FernThenvoiClientLike` | `FernBandClientLike` |
+
+C3 establishes the two Linear rows; C5 owns the remainder and the final
+audit. Generate a machine-readable before/after inventory from every declared
+package export's built ESM keys and `.d.ts` named exports. Review any additional
+`Thenvoi` export found against this table: add a replacement or an explicit
+removal disposition before merge. The same artifact generates the 1.0 migration
+section so release notes cannot drift from the package surface.
+
+Proof:
+
+| ID | Proof | Expected | Status |
+|---|---|---|---|
+| P-C5-1 | Build and pack without mutation, then import every export subpath under ESM and CJS with optional peers as required. | Packed name is `@band-ai/sdk`; all intended exports resolve. | Planned |
+| P-C5-2 | Compare generated before/after runtime and declaration export inventories with the authoritative mapping; compile one consumer fixture per mapped export. | Every removed public export has exactly one replacement/removal disposition; every replacement resolves; old names fail. | Planned |
+| P-C5-3 | Inspect release workflow. | No `sed` or equivalent package mutation; hold still blocks publication. | Planned |
+
+## C6 — environment configuration, URLs, and documentation
+
+Outcome across both shipped packages and the operational E2E harness:
+
+- default env prefix becomes `BAND_` with per-field legacy fallback;
+- a custom prefix remains exact, including an explicitly empty prefix;
+- Band wins independently for `AGENT_ID`, `API_KEY`, `WS_URL`, and `REST_URL`;
+- warnings identify each legacy variable and replacement once per process;
+- OpenClaw's account-field precedence remains above env values, but its legacy
+  env fallback now emits the same once-per-variable warnings;
+- OpenClaw E2E reads `BAND_API_KEY_USER` first and falls back to the E2E-only
+  legacy `THENVOI_API_KEY_USER`, alongside Band-first credential/URL fields;
+- default service URLs and user-facing docs use `app.band.ai`, aligning the SDK
+  with OpenClaw's existing defaults and with `BandEnvironment.Default` in
+  `@band-ai/rest-client@0.0.118`;
+- explicit caller URLs remain untouched.
+
+Default-host change (R-13, C-06, D-10). `platform/ThenvoiLink.ts:49` currently
+defaults to `wss://app.thenvoi.com/api/v1/socket`, and `:112` derives the REST URL
+from it via `deriveDefaultRestUrl`, so changing the WS default moves both. Also
+update `integrations/linear/bridge/handler.ts:37`
+(`DEFAULT_THENVOI_APP_BASE_URL`), which builds user-visible Linear deep links.
+
+This retargets any consumer that never passed an explicit URL, with no compile
+error and no warning, so it must lead the release notes. Per O-04 it is not a hard
+cutover: platform routing redirects only browser traffic off the legacy host and
+continues to serve API requests and WebSocket upgrades on `app.thenvoi.com`,
+specifically because published SDKs carry that host as their default. Pinning the
+old host by passing an explicit `wsUrl`/`restUrl` therefore remains a valid escape
+hatch, and the release notes must say so.
+
+Boundary: SDK config loader/types/tests, OpenClaw `src/config.ts` and unit tests,
+OpenClaw E2E setup, both packages' defaults, examples, root/package docs, and
+error text. Operational test setup is included in completeness scans. Secrets
+must never appear in warnings.
+
+Proof:
+
+| ID | Proof | Expected | Status |
+|---|---|---|---|
+| P-C6-1 | Table-driven SDK and OpenClaw env tests: Band only, Thenvoi only, mixed fields, both for one field, account override, missing required, custom prefix, empty prefix. | Required precedence and validation; exact once-per-variable warning cardinality without secret values. | Planned |
+| P-C6-2 | Construct clients with defaults and explicit URLs. | Defaults use `app.band.ai`; explicit values are byte-preserved. | Planned |
+| P-C6-4 | Assert the derived REST URL follows the changed WS default, that an explicit legacy `wsUrl`/`restUrl` still pins `app.thenvoi.com` end to end, and that SDK and OpenClaw defaults are now byte-identical. | Both defaults resolve to `app.band.ai`; `deriveDefaultRestUrl` tracks the WS host; the documented legacy escape hatch works; Linear deep links use the Band host. | Planned |
+| P-C6-3 | Exercise OpenClaw E2E configuration with Band-only, legacy-only, and mixed values including `BAND_API_KEY_USER`; scan published docs, runtime messages, and operational test setup. | E2E eligibility/config agree on precedence and Band defaults; no stale instruction outside migration notes. | Planned |
+
+## C7 — platform tools and MCP contract
+
+Outcome: execute the linked tool/MCP specification, update every prompt and
+comparison, and retain the release hold.
+
+Proof: the complete proof matrix is in the linked specification. In addition,
+run the broad repository gate and pack/import proof from P-C5-1.
+
+## REL-01 — release 1.0.0, verify, then deprecate
+
+This is an operator sequence. Its pull request is generated by release-please, not hand-authored, so it does not count against the single-PR shape in D-11.
+
+Preconditions:
+
+1. The rename PR (commits C1 through C7) is merged and green; the hold is present.
+2. P-PRE-1 passed on `main` before the rename PR, and its evidence is attached to the release handoff.
+3. The release workflow still contains the tested guard and package-content gate.
+4. The separately owned cursor-pagination migration is complete and verified
+   against the server contract that survives the 2026-10-01 sunset.
+
+Operation:
+
+1. Prepare the release PR with `Release-As: 1.0.0`, the complete breaking-change
+   guide, and removal of the release-hold marker.
+2. Confirm the release guard changes only in that reviewed PR.
+3. Publish 1.0.0.
+4. In a clean temporary directory, install and import every declared subpath under
+   ESM and CJS. Install declared optional peers before testing gated subpaths.
+5. Confirm npm version, provenance, required files, and non-empty exports.
+6. Only then deprecate `@thenvoi/sdk`, `@thenvoi/rest-client`, and
+   `@thenvoi/openclaw-channel-thenvoi`, each naming its replacement.
+
+Failure and rollback:
+
+- if preflight or patch publish fails, keep the hold and do not attempt 1.0.0;
+- if 1.0.0 publication fails, do not deprecate anything and never reuse a
+  published version number;
+- if installation proof fails after publication, mark the version deprecated as
+  broken, restore the hold, fix forward, and publish a new patch;
+- never deprecate unversioned `@band-ai/rest-client`; its latest is healthy.
+
+Proof:
+
+| ID | Proof | Expected | Status |
+|---|---|---|---|
+| P-REL-2 | Clean 1.0.0 ESM/CJS import matrix. | Every declared subpath resolves under its declared peer conditions. | Planned |
+| P-REL-3 | Query deprecation fields for three old packages and healthy Band latest packages. | Old scopes point to replacements; healthy latest remains non-deprecated. | Planned |
+
+## Requirement trace
+
+| Requirement | Unit and proof |
+|---|---|
+| R-01, R-02 | PREFLIGHT/C1; P-C1-1 through P-C1-5, P-PRE-1 |
+| R-03, R-07 | C5; P-C5-1 through P-C5-3 |
+| R-04, R-05, R-08 | C3/C4; P-C3-3, P-C3-3B, P-C4-1 through P-C4-4 |
+| R-06, R-10, R-13 | C6; P-C6-1 through P-C6-4 |
+| R-09 | C7; linked tool/MCP proof |
+| R-12 | C4; P-C4-5, and P-TOOL-08 as backstop |
+| R-11 | PREFLIGHT/REL-01; P-PRE-1, P-REL-2, P-REL-3 |

--- a/docs/plans/rename-02-storage-compatibility-spec.md
+++ b/docs/plans/rename-02-storage-compatibility-spec.md
@@ -1,0 +1,66 @@
+# Linear SQLite rename: storage compatibility specification
+
+| Field | Value |
+|---|---|
+| Status | **APPROVED** |
+| Decision authority | [Decision plan](rename-00-overview.md), D-01 and D-02 |
+| Delivery unit | [C4](rename-01-implementation-spec.md#c4--public-room-id-fields-outbound-metadata-adapter-identity-retain-storage-schema), a commit in the single rename PR |
+
+## Decision
+
+Retain these private physical identifiers indefinitely:
+
+- `linear_thenvoi_session_rooms`;
+- `linear_thenvoi_bootstrap_requests`;
+- both `thenvoi_room_id` columns;
+- their existing named indexes.
+
+The store accepts any caller-provided SQLite path and does not claim exclusive
+ownership of the database. This rename therefore must not write
+`PRAGMA user_version`, create a migration ledger, rename/drop a table or index,
+or infer a file move. Private storage vocabulary is treated like historical
+migration vocabulary: stable persistence format, not public branding.
+
+## Public mapping
+
+The public `SessionRoomRecord`, `PendingBootstrapRequest`, `SessionRoomStore`,
+and their callers use `bandRoomId`. Internal row types and SQL retain
+`thenvoi_room_id`. The mapping is explicit at the storage boundary in both
+directions:
+
+```text
+public bandRoomId -> SQL parameter bound to thenvoi_room_id
+row thenvoi_room_id -> public bandRoomId
+```
+
+Do not expose the physical name through exported TypeScript types. Do not add a
+second physical column or dual-write; one durable value keeps old/new binary
+interop and rollback straightforward.
+
+## Compatibility and lifecycle
+
+- An existing custom or default database opens with no schema-changing DDL beyond
+  the pre-existing additive-column initialization behavior.
+- A fresh database still uses the legacy physical schema.
+- Old and new binaries can alternately open the same database because both speak
+  the same physical schema.
+- A failed initialization retains current poison-eviction behavior; this rename
+  introduces no new transaction, backup, lock, or recovery path.
+- Unrelated tables, indexes, triggers, pragmas, and `user_version` are untouched.
+
+## Executable proof
+
+Use the real `createSqliteSessionRoomStore` entry point and logical schema/data
+dumps before and after operations.
+
+| ID | Fixture / action | Expected | Status |
+|---|---|---|---|
+| P-STO-01 | Existing database with both Linear tables, representative rows, and unrelated objects/`user_version=42`; open and perform read/write through new public types. | Band public fields round-trip; all physical names, unrelated objects, and version remain unchanged. | Planned |
+| P-STO-02 | Fresh path opened by the new code. | It creates the established legacy physical schema and exposes Band public fields. | Planned |
+| P-STO-03 | Alternate old-code fixture operations and new-code operations on one file. | Both reuse the same bindings and bootstrap records; no duplicate rooms/rows. | Planned |
+| P-STO-04 | Existing `.linear-thenvoi-example.sqlite` selected by default. | Same path and binding reused; no `.linear-band-example.sqlite` is created. | Planned |
+| P-STO-05 | Custom path supplied only by `LINEAR_THENVOI_STATE_DB`. | Fallback selects the exact path, warns once, and does not create/open the default path. | Planned |
+| P-STO-06 | Search the C4 commit diff for schema-changing SQL and Band physical identifiers. | No rename/drop/version DDL and no `linear_band_*`/`band_room_id` physical identifier. | Planned |
+
+Acceptance compares `sqlite_master`, `PRAGMA user_version`, and selected row
+values. A row-count-only assertion is insufficient.

--- a/docs/plans/rename-03-tool-mcp-spec.md
+++ b/docs/plans/rename-03-tool-mcp-spec.md
@@ -1,0 +1,85 @@
+# Platform tool and MCP rename specification
+
+| Field | Value |
+|---|---|
+| Status | **APPROVED** |
+| Decision authority | [Decision plan](rename-00-overview.md), D-04 |
+| Delivery unit | [C7](rename-01-implementation-spec.md#c7--platform-tools-and-mcp-contract), the final commit in the single rename PR |
+
+## Contract
+
+The canonical tool registry advertises the same 17 capabilities under `band_*`
+names. Contact and memory group membership remains unchanged. MCP-qualified names
+use `mcp__band__<band_tool_name>`.
+
+The mapping is mechanical by prefix:
+
+```text
+thenvoi_<operation>  -> band_<operation>
+mcp__thenvoi__<tool> -> mcp__band__<tool>
+```
+
+This changes names only, not tool arguments, result schemas, capability policy,
+or handler behavior.
+
+## Canonical ownership
+
+- `TOOL_MODELS` and its exported key type own canonical unqualified names.
+- `MCP_TOOL_PREFIX = "mcp__band__"` owns qualification.
+- one exported `MCP_SERVER_NAME = "band"` owns all MCP server-name defaults and
+  integrations; no independent `"thenvoi"` server literal remains.
+- prompts, silent-reporting sets, reply-delivery checks, schema groups, and tests
+  consume canonical constants instead of copying strings where practical.
+
+Completeness tests assert exact sets. A grep is a backstop, not the primary proof.
+
+## Clean 1.0 compatibility break
+
+Advertise and accept Band names only. Do not normalize or register legacy
+`thenvoi_*` calls on any adapter. A raw legacy name that reaches the SDK follows
+the existing unknown-tool path; registration-based adapters never expose it.
+
+This intentionally matches TypeScript symbol and MCP-prefix behavior. It avoids
+an adapter-specific compatibility promise that is impossible on LangGraph,
+Google ADK, ACP/OpenCode, and MCP, and it preserves current custom-tool lookup and
+collision semantics. Release notes must describe prompts and saved tool-call
+examples as upgrade prerequisites, not as temporarily compatible inputs.
+
+## Intentional MCP break
+
+An old host allowlist such as `mcp__thenvoi__*` will expose no renamed tools. The
+SDK cannot repair a capability the host never sends to it. Release notes must put
+this migration before prompt changes:
+
+1. change host allowlists to `mcp__band__*`;
+2. update explicit server name `thenvoi` to `band` where configured;
+3. update prompts and examples from `thenvoi_*` to `band_*`;
+4. deploy SDK 1.0.0.
+
+Do not register both prefixes. Dual registration doubles model-visible tools and
+still does not fix host policies that allow only the old server.
+
+## Failure and security boundaries
+
+- Argument validation and handler authorization/capability behavior do not move.
+- Custom-tool lookup and collision rules remain unchanged; no alias can redirect
+  a legacy custom-tool name to a platform handler.
+- Execution events and errors use the Band canonical name for Band calls.
+- `band_send_message` must suppress duplicate reporting and count as reply
+  delivered in Codex; legacy `thenvoi_send_message` is rejected/unknown.
+- Capability enforcement gaps discovered during this rename are separate fixes;
+  do not imply that renaming closes them.
+
+## Executable proof matrix
+
+| ID | Input/path | Expected | Status |
+|---|---|---|---|
+| P-TOOL-01 | Enumerate `TOOL_MODELS`, contact group, and memory group. | Exactly 17 unique `band_*` keys; group members are valid keys and counts unchanged. | Planned |
+| P-TOOL-02 | Generate MCP registrations/backends. | Every qualified name is `mcp__band__band_*`; no old prefix advertised. | Planned |
+| P-TOOL-03 | Instantiate every MCP/server bridge with default name. | All report the one Band server constant. | Planned |
+| P-TOOL-04 | Call raw-name adapters with every old name, then every new name. | Old names follow unknown-tool behavior; new names execute the corresponding existing handler. | Planned |
+| P-TOOL-05 | Codex Band `send_message` and `send_event` calls with execution reporting enabled. | No spurious report; send_message marks reply delivered; no duplicate fallback reply. | Planned |
+| P-TOOL-06 | Legacy-named and canonical-name-colliding custom tools under current adapter rules. | Custom-tool precedence/collision behavior is unchanged by the platform rename. | Planned |
+| P-TOOL-07 | MCP host configured only with `mcp__thenvoi__*`, then with `mcp__band__*`. | Old configuration exposes none; migrated configuration exposes intended tools. | Planned |
+| P-TOOL-08 | Search runtime prompts, tool comparisons, server literals, docs, and tests. | No unowned legacy tool/prefix/server hit outside migration notes. Adapter identity strings (Codex `clientName`/`clientTitle`, ADK `APP_NAME`/agent name, A2A skill tag, OpenCode `sessionTitlePrefix`) are owned by C4 and must already be Band by the time this runs; the 82 `linear_thenvoi_bridge.*` event names and the retained SQLite physical identifiers are the only permitted legacy hits. | Planned |
+| P-TOOL-09 | Run all adapter, MCP, runtime-tool, and Claude bridge tests plus broad gate. | Non-zero tests, no failures, no reduced baseline without explanation. | Planned |

--- a/docs/plans/rename-04-cross-repo.md
+++ b/docs/plans/rename-04-cross-repo.md
@@ -1,0 +1,136 @@
+# Thenvoi to Band: cross-repository dependencies
+
+| Field | Value |
+|---|---|
+| Status | **Reference — not executable in this repository** |
+| Decision authority | [Decision plan](rename-00-overview.md) |
+| Purpose | Record every rename-adjacent change that lives outside `band-ai/band-sdk-typescript`, so the single-PR scope in D-11 stays honest |
+
+This file exists because the TypeScript SDK rename ships as one pull request
+(D-11) in this repository only. Work that must happen in another repository is
+listed here with its owner and its relationship to the SDK release. Nothing in
+this file is a commit in the rename PR.
+
+Platform behavior recorded here was confirmed with the platform team during review
+round 3. The platform is closed source, so this file states only the externally
+observable contract the SDK depends on — no internal module names, file paths, or
+implementation detail. Where a claim is unconfirmed, it says so.
+
+## Owners in play
+
+| Owner | Role |
+|---|---|
+| `band-ai/band-sdk-typescript` | This repo. Owns the rename PR and the 1.0.0 release. |
+| Platform team (closed source) | Owns the API, the OpenAPI source of truth, host routing, and the pagination contract. |
+| `@band-ai/rest-client` generator/publisher | Owns the generated REST client the SDK depends on. Regenerating it requires a local platform instance, so it is platform-side work. |
+| Python SDK repository | Separate rename with its own tool-name mismatch. |
+| npm organization `band-ai` | Trusted-publisher configuration. Not a repository. |
+
+## X-01 — platform host routing: no change required
+
+**Owner:** platform · **Blocks:** nothing · **Status:** verified, closed
+
+The platform contract the SDK relies on, confirmed with the platform team:
+
+- browser traffic on the legacy `thenvoi.com` hosts is redirected to `band.ai`;
+- **API requests and WebSocket upgrades on the legacy hosts are not redirected and
+  continue to be served**, deliberately, because published SDKs carry the legacy
+  host as their default and WebSocket clients do not follow redirects during the
+  handshake;
+- both `thenvoi.com` and `band.ai` origins are accepted for the socket;
+- the socket path is `/api/v1/socket` on both hosts, matching the SDK and OpenClaw
+  defaults.
+
+Consequence for the SDK: R-10's default-host change is a convenience, not a
+cutover. Consumers who pin the old host with an explicit `wsUrl`/`restUrl` keep
+working. This is what closes O-04.
+
+Do not remove the `*.thenvoi.com` API/WS pass-through until published SDKs
+carrying the legacy default are out of support. That retirement is a platform
+decision with an SDK-version precondition, not part of this rename.
+
+## X-02 — `@band-ai/rest-client` generator and publishing hardening
+
+**Owner:** unassigned · **Blocks:** nothing in the rename PR · **Status:** open
+
+The SDK's C2 commit pins `@band-ai/rest-client@0.0.118`. One item sits upstream of
+that pin:
+
+- **Broken exact version.** `@band-ai/rest-client@0.0.113` is recorded as broken in
+  the decision plan's exclusions and must be deprecated. Only that exact version —
+  never the unversioned package, whose latest is healthy.
+
+Regeneration is platform-side work: it requires running a local platform instance,
+so it cannot be done from this repository.
+
+Two notes for whoever picks this up. The published `0.0.118` declares
+`BandEnvironment.Default = "https://app.band.ai"`, which agrees with R-10 and with
+OpenClaw's defaults — the SDK does not consume it (it always passes an explicit
+base URL), but it should stay correct for anyone who does. And the generated
+surface changed between `0.0.113` and `0.0.118`; see C2 in the delivery spec for
+the full list of renamed and removed symbols.
+
+## X-03 — cursor pagination before the 2026-10-01 sunset
+
+**Owner:** O-03, engineering owner for cursor pagination · **Blocks:** REL-01 ·
+**Status:** open, separate implementation plan
+
+The server sunsets the SDK's current pagination path on 2026-10-01. The decision
+plan gates REL-01 on this: do not publish a 1.0 whose supported pagination path
+has a known server sunset. This is the only cross-repository item that blocks the
+release, and it is not part of the rename PR.
+
+## X-04 — observability event rebrand
+
+**Owner:** observability rebrand · **Blocks:** nothing · **Status:** excluded by
+the decision plan
+
+The 82 `linear_thenvoi_bridge.*` event names emitted by this SDK are deliberately
+retained by the rename (they are dashboard and alert keys). Renaming them requires
+coordinated changes to whatever consumes them, which lives outside this
+repository. `P-TOOL-08` lists them as permitted legacy hits so the completeness
+scan does not fail on them.
+
+## X-05 — Python SDK rename and tool-name mismatch
+
+**Owner:** unassigned · **Blocks:** nothing in this repo · **Status:** open
+
+The Python SDK has its own Thenvoi→Band rename. It matters here for one reason:
+after this SDK's C7 commit, the TypeScript SDK advertises `band_*` tools and
+`mcp__band__`, while an unrenamed Python SDK still advertises `thenvoi_*`. Agents
+built on both would present two differently-named tool sets for the same
+capabilities.
+
+That is a coordination cost, not a correctness break in either SDK. Record the
+skew in the 1.0.0 release notes so users of both are not surprised.
+
+## X-06 — GitHub organization consolidation
+
+**Owner:** unassigned · **Blocks:** nothing · **Status:** excluded
+
+The repository already lives at `band-ai/band-sdk-typescript` (confirmed via
+`git remote`). Remaining organization consolidation is tracked separately and has
+no effect on the rename or the release.
+
+## X-07 — npm trusted-publisher configuration
+
+**Owner:** O-01, npm organization owner · **Blocks:** PREFLIGHT, therefore the
+entire rename PR · **Status:** open
+
+Not a repository change, but the hardest external precondition. Both
+`@band-ai/sdk` and `@band-ai/openclaw-channel-band` need trusted-publisher entries
+matching `band-ai/band-sdk-typescript` and `release.yml`. The manifest records SDK
+`0.1.7` while npm latest is `0.1.6`, which is the evidence that the current SDK
+OIDC path has not published successfully.
+
+PREFLIGHT cannot be satisfied without this, and PREFLIGHT must pass before the
+rename PR is opened for merge.
+
+## Ordering summary
+
+```text
+X-07 (npm trusted publisher)  ──> PREFLIGHT ──> rename PR (C1..C7) ──> REL-01
+X-03 (cursor pagination)      ─────────────────────────────────────────^
+X-01  closed, no action
+X-02, X-04, X-05, X-06        parallel, gate nothing
+```


### PR DESCRIPTION
# Thenvoi to Band rename plan

## Status: APPROVED for implementation planning

This PR is documentation only. It does not change product code and does not authorize implementation by itself.

The original nine-document draft was reduced from 3,349 lines to four authoritative documents totaling 643 lines:

- [Decision plan](https://github.com/band-ai/band-sdk-typescript/blob/c9942deb3beb283a4203102840786996d95fa231/docs/plans/rename-00-overview.md) — scope, decisions, compatibility, sequencing, rollout, and approval
- [Delivery and proof specification](https://github.com/band-ai/band-sdk-typescript/blob/c9942deb3beb283a4203102840786996d95fa231/docs/plans/rename-01-implementation-spec.md) — seven PR units, preflight, release operation, and requirement trace
- [Storage compatibility specification](https://github.com/band-ai/band-sdk-typescript/blob/c9942deb3beb283a4203102840786996d95fa231/docs/plans/rename-02-storage-compatibility-spec.md) — retained physical SQLite schema and old/new binary interoperability
- [Tool and MCP specification](https://github.com/band-ai/band-sdk-typescript/blob/c9942deb3beb283a4203102840786996d95fa231/docs/plans/rename-03-tool-mcp-spec.md) — canonical Band names and the explicit 1.0 compatibility break

## Resulting plan

1. **PR-00:** repair false-green CI filters and harden the real npm publish chokepoints.
2. **PREFLIGHT:** prove both package publish paths with a nonbreaking patch under current OIDC.
3. **PR-01:** independently swap to `@band-ai/rest-client@0.0.118` without a REST contract change.
4. **PR-02:** activate the release hold; rename Linear symbols/examples/config while retaining every legacy env fallback and the existing DB path.
5. **PR-03:** rename public room-id fields and outbound metadata, while keeping private SQLite tables, columns, and indexes unchanged.
6. **PR-04:** make source/package identity `@band-ai/sdk` and apply the reviewed 21-export migration map.
7. **PR-05:** migrate SDK and OpenClaw env/default URL behavior, including E2E configuration and per-field legacy fallbacks.
8. **PR-06:** rename all 17 platform tools, the MCP prefix, prompts, and server-name sites as one clean 1.0 break.
9. **REL-01:** remove the hold in a reviewed release PR, publish/install-check 1.0.0, then deprecate old packages.

Cursor pagination remains separately owned but explicitly gates the 1.0 release because the current server pagination path sunsets on 2026-10-01.

## Important decisions

- **No SQLite rename migration.** Physical table, column, index, and default file names remain stable. New public Band field names map at the storage boundary. This preserves existing bindings, shared-database ownership, and ordinary rollback.
- **No partial tool aliases.** TypeScript symbols, direct platform tool names, and MCP names use one documented clean 1.0 migration contract.
- **Complete env compatibility.** SDK, OpenClaw, Linear example, and E2E readers prefer Band variables and fall back per field to legacy Thenvoi variables with secret-safe warnings.
- **Enforced release hold.** One tested guard command sits immediately before both real `npm publish` calls. It is proven before activation and remains active from the first breaking PR through the release.
- **Authoritative export mapping.** Every current Thenvoi-named public export has a reviewed Band replacement and generated before/after audit.

## Review outcome

Independent review rounds covered product/compatibility, persistence/reliability, and the complete artifact. Initial rounds returned HELD and found contradictions in release ordering, custom DB env fallback, SQLite ownership/rollback, partial tool aliases, OpenClaw env ownership, and export-map completeness. Each finding was addressed through simplification or explicit ownership.

The final independent whole-artifact revision review returned **APPROVE with no blocking findings**.

## Verification

Fresh local verification on the committed revision:

- `pnpm -r test`: **696 SDK tests + 156 OpenClaw tests passed**
- `pnpm -r build`: passed
- `pnpm -r typecheck`: passed
- `pnpm -r lint`: passed, with existing SDK warnings only
- `git diff --check`: passed
- Plan links: checked, no broken local targets
- Built declaration audit: the documented 21-entry public export map matches the package subpaths

## Linear coordination

- [INT-405](https://linear.app/thenvoi/issue/INT-405) — Linear bridge symbols
- [INT-416](https://linear.app/thenvoi/issue/INT-416) — Linear room-id vocabulary; physical SQLite rename deliberately excluded after review
- [INT-414](https://linear.app/thenvoi/issue/INT-414) — package identity and REST-client scope
- [INT-415](https://linear.app/thenvoi/issue/INT-415) — env vars, URLs, docs, and major release
- [INT-404](https://linear.app/thenvoi/issue/INT-404) — remaining public symbols, absorbed into PR-04
- [INT-269](https://linear.app/thenvoi/issue/INT-269) — old-package deprecations after verified 1.0 publication

Separate follow-ups remain required for cursor pagination, Fern publishing hardening, GitHub org consolidation, Python SDK naming/tool divergence, observability event names, and the pre-existing MCP peers-capability gap.