### PR TITLE
fix(sdk): normalize participant handle prefixes

### DIFF
--- a/packages/sdk/src/runtime/formatters.ts
+++ b/packages/sdk/src/runtime/formatters.ts
@@ -1,11 +1,8 @@
 import type { MetadataMap, ToolModelMessage } from "../contracts/dtos";
+import { ensureHandlePrefix } from "./types";
 
 function isMetadataMap(value: unknown): value is MetadataMap {
   return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function formatHandle(handle: string): string {
-  return handle.startsWith("@") ? handle : `@${handle}`;
 }
 
 export function replaceUuidMentions(
@@ -21,7 +18,7 @@ export function replaceUuidMentions(
     const participantId = participant.id;
     const handle = participant.handle;
     if (typeof participantId === "string" && typeof handle === "string") {
-      next = next.replaceAll(`@[[${participantId}]]`, formatHandle(handle));
+      next = next.replaceAll(`@[[${participantId}]]`, ensureHandlePrefix(handle) ?? "");
     }
   }
 
@@ -73,7 +70,9 @@ export function buildParticipantsMessage(participants: Array<Record<string, unkn
     const participantType = String(participant.type ?? "Unknown");
     const participantName = String(participant.name ?? "Unknown");
     const participantHandle = String(participant.handle ?? "Unknown");
-    lines.push(`- ${formatHandle(participantHandle)} — ${participantName} (${participantType})`);
+    lines.push(
+      `- ${ensureHandlePrefix(participantHandle) ?? ""} — ${participantName} (${participantType})`,
+    );
   }
 
   lines.push("");

--- a/packages/sdk/src/runtime/formatters.ts
+++ b/packages/sdk/src/runtime/formatters.ts
@@ -4,6 +4,10 @@ function isMetadataMap(value: unknown): value is MetadataMap {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+function formatHandle(handle: string): string {
+  return handle.startsWith("@") ? handle : `@${handle}`;
+}
+
 export function replaceUuidMentions(
   content: string,
   participants: Array<Record<string, unknown>>,
@@ -17,7 +21,7 @@ export function replaceUuidMentions(
     const participantId = participant.id;
     const handle = participant.handle;
     if (typeof participantId === "string" && typeof handle === "string") {
-      next = next.replaceAll(`@[[${participantId}]]`, `@${handle}`);
+      next = next.replaceAll(`@[[${participantId}]]`, formatHandle(handle));
     }
   }
 
@@ -69,7 +73,7 @@ export function buildParticipantsMessage(participants: Array<Record<string, unkn
     const participantType = String(participant.type ?? "Unknown");
     const participantName = String(participant.name ?? "Unknown");
     const participantHandle = String(participant.handle ?? "Unknown");
-    lines.push(`- @${participantHandle} — ${participantName} (${participantType})`);
+    lines.push(`- ${formatHandle(participantHandle)} — ${participantName} (${participantType})`);
   }
 
   lines.push("");

--- a/packages/sdk/tests/runtime-utils.test.ts
+++ b/packages/sdk/tests/runtime-utils.test.ts
@@ -24,6 +24,13 @@ describe("runtime utilities", () => {
     expect(replaced).toBe("hello @john");
   });
 
+  it("preserves exactly one prefix when replacing a UUID with a prefixed handle", () => {
+    const replaced = replaceUuidMentions("hello @[[u1]]", [
+      { id: "u1", handle: "@john" },
+    ]);
+    expect(replaced).toBe("hello @john");
+  });
+
   it("formats message and history for llm", () => {
     const msg = formatMessageForLlm({
       id: "m1",
@@ -48,6 +55,14 @@ describe("runtime utilities", () => {
     const message = buildParticipantsMessage([{ type: "User", name: "Jane", handle: "jane" }]);
     expect(message).toContain("Current Participants");
     expect(message).toContain("@jane");
+  });
+
+  it("preserves exactly one prefix for a prefixed participant handle", () => {
+    const message = buildParticipantsMessage([
+      { type: "User", name: "Jane", handle: "@jane" },
+    ]);
+    expect(message).toContain("- @jane — Jane (User)");
+    expect(message).not.toContain("@@jane");
   });
 
   it("renders system prompt", () => {


### PR DESCRIPTION
## Why

SDK participant handles can arrive in either supported server representation: bare (alice) or already prefixed (@alice). Both runtime formatter paths blindly added another prefix, so prefixed inputs became @@alice in UUID mention replacement and participant prompts.

## What changed

- Normalize participant handles through one private formatter helper that preserves one existing leading @ or adds one to a bare handle.
- Apply that helper to replaceUuidMentions and buildParticipantsMessage.
- Add SDK regression coverage for already-prefixed handles in both paths while preserving the existing bare-handle cases.

This is an SDK-only package change. The diff is limited to packages/sdk/src/runtime/formatters.ts and packages/sdk/tests/runtime-utils.test.ts.

## RED / GREEN

- RED: the two new assertions failed on the pre-fix implementation with hello @@john and - @@jane; the other 696 SDK tests passed.
- Focused GREEN: pnpm exec vitest run tests/runtime-utils.test.ts passed 10/10.

## Full local gate

- pnpm -r lint: exit 0; SDK 0 errors and 12 pre-existing warnings; OpenClaw clean.
- pnpm -r typecheck: both packages passed.
- pnpm -r test: SDK 698/698 across 88 files; OpenClaw 156/156 across 9 files.
- pnpm -r build: both packages passed.
- git diff --check: passed.

Existing non-blocking output remains unchanged: the ignored root pnpm.overrides warning, 12 pre-existing SDK lint warnings, expected Linear fallback-test stderr, and the existing OpenClaw zod side-effect build warning.

## Explicit exclusions

This PR does not change OpenClaw. It does not merge, tag, dispatch workflows, publish to npm, or mutate npm trusted-publisher configuration. Those actions remain separately gated.