### PR TITLE
fix(release): pass the publish tarball to npm as an absolute path

### DIFF
--- a/scripts/publish-if-needed.mjs
+++ b/scripts/publish-if-needed.mjs
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
+import { resolve } from "node:path";
 
 function runNpm(args) {
   return spawnSync("npm", args, { encoding: "utf8" });
@@ -17,6 +18,10 @@ try {
   if (!existsSync(tarball)) {
     throw new Error(`Tarball not found at ${tarball}; cannot publish`);
   }
+  // npm-package-arg only reads a spec as a file when it starts with ./, /, ~/,
+  // or a drive letter; a bare "dir/pkg.tgz" is parsed as a GitHub shorthand and
+  // publish then tries to git-clone it. Hand npm an absolute path instead.
+  const tarballPath = resolve(tarball);
 
   const spec = `${name}@${version}`;
   const lookup = runNpm(["view", spec, "version", "--json"]);
@@ -34,7 +39,7 @@ try {
 
     const publish = runNpm([
       "publish",
-      tarball,
+      tarballPath,
       "--ignore-scripts",
       "--provenance",
       "--access",

--- a/scripts/release-hardening.test.mjs
+++ b/scripts/release-hardening.test.mjs
@@ -375,8 +375,12 @@ async function withFakeNpm(viewMode, callback, { createTarball = true } = {}) {
     join(directory, "package.json"),
     `${JSON.stringify({ name: "@band-ai/example", version: "1.2.3" })}\n`,
   );
+  await mkdir(join(directory, "release-artifacts"));
   if (createTarball) {
-    await writeFile(join(directory, "band-ai-example-1.2.3.tgz"), "fake tarball\n");
+    await writeFile(
+      join(directory, "release-artifacts/band-ai-example-1.2.3.tgz"),
+      "fake tarball\n",
+    );
   }
   await writeFile(
     join(bin, "npm"),
@@ -390,7 +394,8 @@ async function withFakeNpm(viewMode, callback, { createTarball = true } = {}) {
       FAKE_NPM_VIEW: viewMode,
       PUBLISH_PACKAGE_NAME: "@band-ai/example",
       PUBLISH_PACKAGE_VERSION: "1.2.3",
-      PUBLISH_TARBALL: "band-ai-example-1.2.3.tgz",
+      // Relative, nested path: exactly what the publish job passes in CI.
+      PUBLISH_TARBALL: "release-artifacts/band-ai-example-1.2.3.tgz",
     }, log);
   } finally {
     await rm(directory, { recursive: true, force: true });
@@ -410,9 +415,11 @@ test("idempotent publisher publishes only when npm confirms the version is absen
   await withFakeNpm("missing", async (directory, env, log) => {
     const result = run(publishScript, directory, env);
     assert.equal(result.status, 0, result.stderr);
+    // The tarball must reach npm as an absolute path; a bare "dir/pkg.tgz" is
+    // parsed as a GitHub shorthand and publish tries to git-clone it instead.
     assert.match(
       await readFile(log, "utf8"),
-      /^publish band-ai-example-1\.2\.3\.tgz --ignore-scripts --provenance --access public$/m,
+      /^publish \/\S*\/release-artifacts\/band-ai-example-1\.2\.3\.tgz --ignore-scripts --provenance --access public$/m,
     );
   });
 });


### PR DESCRIPTION
## Problem

The `publish` job in [run 31313851676](https://github.com/band-ai/band-sdk-typescript/actions/runs/31313851676/job/93245948011) failed with:

```
npm error command git --no-replace-objects ls-remote ssh://git@github.com/release-artifacts/band-ai-sdk-0.1.8.tgz.git
npm error git@github.com: Permission denied (publickey).
```

`PUBLISH_TARBALL` is a bare relative path (`release-artifacts/band-ai-sdk-0.1.8.tgz`). `npm-package-arg` only treats a spec as a file when it starts with `./`, `/`, `~/`, or a drive letter — anything else containing `/` is parsed as GitHub shorthand, so `npm publish` tried to git-clone it and exited 128. The tarball was present the whole time; the script's `existsSync` guard passed because Node resolves relative paths normally.

Net effect: `sdk-v0.1.8` is tagged but was never published to npm.

## Fix

- `scripts/publish-if-needed.mjs`: resolve the tarball to an absolute path before passing it to `npm publish`.
- `scripts/release-hardening.test.mjs`: stage the fake tarball under `release-artifacts/` and pass the same nested relative path CI uses, then assert npm receives an absolute path. This regression test fails against the old script.

All 45 tests in `scripts/release-hardening.test.mjs` pass.

## Recovering 0.1.8

Re-running the failed job won't work — it checks out `source_commit`, which still carries the old script. After this merges, use the workflow's recovery path: **Release → Run workflow** with `recover-package: sdk` and `release-commit` set to the merge commit SHA on `main` (`packages/sdk/package.json` is still at 0.1.8 there). The publisher is idempotent, so it's safe to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)