### PR TITLE
feat: fix LangGraph streaming adapter event parsing and history … (#121)

### DIFF
--- a/packages/sdk/src/adapters/langgraph/LangGraphAdapter.ts
+++ b/packages/sdk/src/adapters/langgraph/LangGraphAdapter.ts
@@ -139,14 +139,29 @@ export class LangGraphAdapter extends SimpleAdapter<HistoryProvider, AdapterTool
 
     const graph = await this.resolveGraph(sdk, langGraphTools);
 
-    const messages = this.buildMessages(
-      history,
-      message,
-      participantsMessage,
-      contactsMessage,
-      context.isSessionBootstrap,
-      context.roomId,
-    );
+    const usesCheckpointer = Boolean(this.checkpointer);
+
+    // First bootstrap for a room (not a later reconnect of the same room).
+    const isFirstBootstrap =
+      context.isSessionBootstrap && !this.bootstrappedRooms.has(context.roomId);
+
+    // Stateless graphs replay history every turn; with a checkpointer, seed once on first bootstrap
+    // and rely on persisted state after. The guard is in-memory, so a durable checkpointer reused
+    // across restarts may re-seed once.
+    const replayHistory = !usesCheckpointer || isFirstBootstrap;
+
+    // createReactAgent gets the prompt via `prompt`; only custom graphs need it as a message —
+    // every turn when stateless, once per room when checkpointed (same signal as replay).
+    const includeSystemPrompt = this.usesCustomGraph && (!usesCheckpointer || isFirstBootstrap);
+
+    if (context.isSessionBootstrap) {
+      this.bootstrappedRooms.add(context.roomId);
+    }
+
+    const messages = this.buildMessages(history, message, participantsMessage, contactsMessage, {
+      replayHistory,
+      includeSystemPrompt,
+    });
     const input = { messages };
     const graphConfig = {
       configurable: {
@@ -176,6 +191,11 @@ export class LangGraphAdapter extends SimpleAdapter<HistoryProvider, AdapterTool
 
   public async onCleanup(roomId: string): Promise<void> {
     this.bootstrappedRooms.delete(roomId);
+  }
+
+  /** A caller-supplied graph rather than the built-in createReactAgent. */
+  private get usesCustomGraph(): boolean {
+    return Boolean(this.graph || this.graphFactory);
   }
 
   private resolveGraph(
@@ -210,18 +230,20 @@ export class LangGraphAdapter extends SimpleAdapter<HistoryProvider, AdapterTool
     message: PlatformMessage,
     participantsMessage: string | null,
     contactsMessage: string | null,
-    isSessionBootstrap: boolean,
-    roomId: string,
+    options: { replayHistory: boolean; includeSystemPrompt: boolean },
   ): LangGraphTupleMessage[] {
     const messages: LangGraphTupleMessage[] = [];
 
-    if (isSessionBootstrap && !this.bootstrappedRooms.has(roomId)) {
+    if (options.includeSystemPrompt) {
       messages.push(["system", this.renderedSystemPrompt]);
-      this.bootstrappedRooms.add(roomId);
     }
 
-    if (isSessionBootstrap && history.length > 0) {
-      const historical = history.raw.slice(-this.maxHistoryMessages);
+    if (options.replayHistory && history.length > 0) {
+      // Drop the triggering message before truncating so the limit counts only prior turns;
+      // the current message is appended exactly once, last.
+      const historical = history.raw
+        .filter((item) => item.id !== message.id)
+        .slice(-this.maxHistoryMessages);
       for (const item of historical) {
         const role = String(item.sender_type ?? "") === "Agent" ? "assistant" : "user";
         const content = String(item.content ?? "");
@@ -239,6 +261,7 @@ export class LangGraphAdapter extends SimpleAdapter<HistoryProvider, AdapterTool
       messages.push(["user", `[System]: ${contactsMessage}`]);
     }
 
+    // The current turn always appears exactly once, as the last message.
     messages.push(["user", message.content]);
     return messages;
   }
@@ -249,7 +272,8 @@ export class LangGraphAdapter extends SimpleAdapter<HistoryProvider, AdapterTool
     config: Record<string, unknown>,
     tools: AdapterToolsProtocol,
   ): Promise<string | null> {
-    const stream = graph.streamEvents?.(input, config, { version: "v2" });
+    // version belongs on config (arg 2), not the optional third arg.
+    const stream = graph.streamEvents?.(input, { ...config, version: "v2" });
     if (!stream) {
       return null;
     }
@@ -278,6 +302,12 @@ export class LangGraphAdapter extends SimpleAdapter<HistoryProvider, AdapterTool
         );
       }
       if (eventType === "on_chain_end") {
+        const chainName = String(data.name ?? "");
+        // For the built-in createReactAgent path, ignore intermediate chains that emit routing
+        // markers rather than replies. Custom graphs use arbitrary chain names, so don't filter them.
+        if (!this.usesCustomGraph && chainName !== "LangGraph" && chainName !== "agent") {
+          continue;
+        }
         const output = asOptionalRecord(data.data) ?? {};
         const text = extractAssistantText(output.output);
         if (text) {
@@ -359,20 +389,30 @@ function stringifyToolResult(
 }
 
 function extractAssistantText(result: unknown): string | null {
-  if (typeof result === "string" && result.trim().length > 0) {
-    return result.trim();
+  if (typeof result === "string") {
+    const trimmed = result.trim();
+    // createReactAgent streams "__end__"/"__start__" markers as plain strings.
+    return trimmed.length > 0 && !isInternalLangGraphMarker(trimmed) ? trimmed : null;
   }
 
   const record = asOptionalRecord(result) ?? {};
+  // createReactAgent returns LangChain AIMessage objects, not tuples.
+  if (isLangChainAssistantMessage(record)) {
+    const text = asLangChainMessageContent(record);
+    if (text && !isInternalLangGraphMarker(text)) {
+      return text;
+    }
+  }
+
   const directContent = asMessageContent(record.content);
-  if (directContent) {
+  if (directContent && !isInternalLangGraphMarker(directContent)) {
     return directContent;
   }
 
   const messages = Array.isArray(record.messages) ? record.messages : [];
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const text = asMessageText(messages[index]);
-    if (text) {
+    if (text && !isInternalLangGraphMarker(text)) {
       return text;
     }
   }
@@ -392,12 +432,51 @@ function asMessageText(value: unknown): string | null {
   if (!record) {
     return null;
   }
+
+  if (isLangChainAssistantMessage(record)) {
+    return asLangChainMessageContent(record);
+  }
+
   const role = String(record.role ?? "");
   if (role !== "assistant") {
     return null;
   }
 
   return asMessageContent(record.content);
+}
+
+// Detects a LangChain assistant message in either shape:
+//  - serialized: { id: [..., "AIMessage" | "AIMessageChunk"], kwargs: { content } }
+//  - in-memory instance (real createReactAgent stream): getType() === "ai", content on the instance
+function isLangChainAssistantMessage(record: Record<string, unknown>): boolean {
+  const id = record.id;
+  if (Array.isArray(id)) {
+    const typeName = String(id[id.length - 1] ?? "");
+    if (typeName === "AIMessage" || typeName === "AIMessageChunk") {
+      return true;
+    }
+  }
+
+  const getType = (record as { getType?: unknown }).getType;
+  if (typeof getType === "function") {
+    try {
+      return (getType as () => unknown).call(record) === "ai";
+    } catch {
+      return false;
+    }
+  }
+
+  return false;
+}
+
+// Serialized messages carry text under kwargs.content; instances expose it directly.
+function asLangChainMessageContent(record: Record<string, unknown>): string | null {
+  const kwargs = asOptionalRecord(record.kwargs);
+  return asMessageContent(kwargs?.content ?? record.content);
+}
+
+function isInternalLangGraphMarker(text: string): boolean {
+  return text === "__end__" || text === "__start__";
 }
 
 function asMessageContent(value: unknown): string | null {

--- a/packages/sdk/tests/langgraph-adapter.test.ts
+++ b/packages/sdk/tests/langgraph-adapter.test.ts
@@ -124,6 +124,170 @@ describe("LangGraphAdapter", () => {
     expect(tools.messages).toEqual(["LangGraph reply"]);
   });
 
+  it("replays history on follow-ups with the triggering message kept exactly once, last", async () => {
+    const invokeCalls: Array<{ messages?: Array<[string, string]> }> = [];
+    const graph = {
+      async invoke(input: Record<string, unknown>) {
+        invokeCalls.push(input as { messages?: Array<[string, string]> });
+        return { messages: [["assistant", "ack"]] };
+      },
+    };
+
+    const adapter = new LangGraphAdapter({ graph });
+    await adapter.onStarted("LangGraph Agent", "Graph-backed assistant");
+
+    const tools = new FakeTools();
+    // The platform records the triggering message before snapshotting history, so on follow-up
+    // turns history.raw already contains it (id === message.id). It must not be dropped or doubled.
+    await adapter.onMessage(
+      { ...makeMessage("what is the status?"), id: "msg-3" },
+      tools,
+      new HistoryProvider([
+        { id: "msg-1", sender_type: "User", content: "deploy the service" },
+        { id: "msg-2", sender_type: "Agent", content: "Working on it." },
+        { id: "msg-3", sender_type: "User", content: "what is the status?" },
+      ]),
+      null,
+      null,
+      { isSessionBootstrap: false, roomId: "room-dedup" },
+    );
+
+    const messages = invokeCalls[0]?.messages ?? [];
+    // Stateless custom graph: system prompt is re-sent every turn (not just bootstrap).
+    expect(messages[0]?.[0]).toBe("system");
+    const replayed = messages.filter((e) => e[0] !== "system").map((e) => e[1]);
+    // Prior turns replayed, then the triggering message exactly once as the final entry.
+    expect(replayed).toEqual(["deploy the service", "Working on it.", "what is the status?"]);
+    expect(tools.messages).toEqual(["ack"]);
+  });
+
+  it("with a checkpointer, seeds context once on bootstrap and never re-feeds it", async () => {
+    const invokeCalls: Array<{ messages?: Array<[string, string]> }> = [];
+    const graph = {
+      async invoke(input: Record<string, unknown>) {
+        invokeCalls.push(input as { messages?: Array<[string, string]> });
+        return { messages: [["assistant", "ok"]] };
+      },
+    };
+
+    const adapter = new LangGraphAdapter({ graph, checkpointer: {} });
+    await adapter.onStarted("LangGraph Agent", "Graph-backed assistant");
+
+    const tools = new FakeTools();
+    const history = new HistoryProvider([{ id: "h1", sender_type: "User", content: "earlier turn" }]);
+    const roomId = "room-ckpt";
+    const send = (id: string, content: string, isSessionBootstrap: boolean) =>
+      adapter.onMessage({ ...makeMessage(content), id }, tools, history, null, null, {
+        isSessionBootstrap,
+        roomId,
+      });
+
+    await send("m1", "first", true); // first bootstrap → seed system prompt + history
+    await send("m2", "second", false); // follow-up → checkpoint persists; no replay
+    await send("m3", "third", true); // re-bootstrap (reconnect) → must not re-seed
+
+    const turn = (i: number) => invokeCalls[i]?.messages ?? [];
+    const nonSystem = (i: number) => turn(i).filter((e) => e[0] !== "system").map((e) => e[1]);
+
+    // Bootstrap seeds once: system prompt + replayed history + current message.
+    expect(turn(0)[0]?.[0]).toBe("system");
+    expect(nonSystem(0)).toEqual(["earlier turn", "first"]);
+    // Follow-up and re-bootstrap both rely on persisted state: no system prompt, no replayed history.
+    expect(turn(1).some((e) => e[0] === "system")).toBe(false);
+    expect(nonSystem(1)).toEqual(["second"]);
+    expect(turn(2).some((e) => e[0] === "system")).toBe(false);
+    expect(nonSystem(2)).toEqual(["third"]);
+  });
+
+  it("treats a disabled checkpointer (false) as stateless and replays history", async () => {
+    const invokeCalls: Array<{ messages?: Array<[string, string]> }> = [];
+    const graph = {
+      async invoke(input: Record<string, unknown>) {
+        invokeCalls.push(input as { messages?: Array<[string, string]> });
+        return { messages: [["assistant", "ok"]] };
+      },
+    };
+
+    const adapter = new LangGraphAdapter({ graph, checkpointer: false });
+    await adapter.onStarted("LangGraph Agent", "Graph-backed assistant");
+
+    const tools = new FakeTools();
+    // checkpointer:false disables persistence, so follow-ups must still replay room history.
+    await adapter.onMessage(
+      { ...makeMessage("now"), id: "m2" },
+      tools,
+      new HistoryProvider([{ id: "m1", sender_type: "User", content: "earlier turn" }]),
+      null,
+      null,
+      { isSessionBootstrap: false, roomId: "room-disabled-ckpt" },
+    );
+
+    const replayed = (invokeCalls[0]?.messages ?? []).filter((e) => e[0] !== "system");
+    expect(replayed.map((e) => e[1])).toEqual(["earlier turn", "now"]);
+  });
+
+  it("counts only prior turns against maxHistoryMessages, excluding the current message", async () => {
+    const invokeCalls: Array<{ messages?: Array<[string, string]> }> = [];
+    const graph = {
+      async invoke(input: Record<string, unknown>) {
+        invokeCalls.push(input as { messages?: Array<[string, string]> });
+        return { messages: [["assistant", "ok"]] };
+      },
+    };
+
+    const adapter = new LangGraphAdapter({ graph, maxHistoryMessages: 2 });
+    await adapter.onStarted("LangGraph Agent", "Graph-backed assistant");
+
+    const tools = new FakeTools();
+    // Follow-up: raw history already includes the current message (id m3). With maxHistoryMessages=2,
+    // the current message must not consume a history slot, so both prior turns survive truncation.
+    await adapter.onMessage(
+      { ...makeMessage("now"), id: "m3" },
+      tools,
+      new HistoryProvider([
+        { id: "m1", sender_type: "User", content: "one" },
+        { id: "m2", sender_type: "Agent", content: "two" },
+        { id: "m3", sender_type: "User", content: "now" },
+      ]),
+      null,
+      null,
+      { isSessionBootstrap: false, roomId: "room-truncate" },
+    );
+
+    const replayed = (invokeCalls[0]?.messages ?? []).filter((e) => e[0] !== "system");
+    expect(replayed.map((e) => e[1])).toEqual(["one", "two", "now"]);
+  });
+
+  it("extracts a reply from a custom graph whose chain name is not LangGraph/agent", async () => {
+    const graph = {
+      streamEvents() {
+        return streamFrom([
+          { event: "on_chain_end", name: "RunnableLambda", data: { output: "__end__" } },
+          {
+            event: "on_chain_end",
+            name: "my_graph",
+            data: { output: { messages: [["assistant", "custom graph reply"]] } },
+          },
+        ]);
+      },
+    };
+
+    const adapter = new LangGraphAdapter({ graph, emitExecutionEvents: true });
+    await adapter.onStarted("LangGraph Agent", "Graph-backed assistant");
+
+    const tools = new FakeTools();
+    await adapter.onMessage(
+      makeMessage("hello"),
+      tools,
+      new HistoryProvider([]),
+      null,
+      null,
+      { isSessionBootstrap: false, roomId: "room-custom-chain" },
+    );
+
+    expect(tools.messages).toEqual(["custom graph reply"]);
+  });
+
   it("reports tool stream events when enabled and extracts final text from stream", async () => {
     const graph = {
       streamEvents() {
@@ -132,7 +296,17 @@ describe("LangGraphAdapter", () => {
           { event: "on_tool_end", name: "thenvoi_send_message" },
           {
             event: "on_chain_end",
-            data: { output: { messages: [["assistant", "streamed reply"]] } },
+            name: "RunnableLambda",
+            data: { output: "__end__" },
+          },
+          {
+            event: "on_chain_end",
+            name: "LangGraph",
+            data: {
+              output: {
+                messages: [["assistant", "streamed reply"]],
+              },
+            },
           },
         ]);
       },
@@ -160,7 +334,7 @@ describe("LangGraphAdapter", () => {
     expect(tools.messages).toEqual(["streamed reply"]);
   });
 
-  it("re-injects system prompt after room cleanup", async () => {
+  it("re-injects the system prompt after room cleanup (checkpointed graph)", async () => {
     const invokeCalls: Array<{ messages?: Array<[string, string]> }> = [];
     const graph = {
       async invoke(input: Record<string, unknown>) {
@@ -169,31 +343,28 @@ describe("LangGraphAdapter", () => {
       },
     };
 
-    const adapter = new LangGraphAdapter({ graph });
+    // A checkpointer makes the bootstrap guard meaningful: the prompt is seeded once per room and
+    // not re-sent on a re-bootstrap, unless onCleanup resets the guard. (A stateless graph would
+    // re-send every turn, so the cleanup behavior would be untestable.)
+    const adapter = new LangGraphAdapter({ graph, checkpointer: {} });
     await adapter.onStarted("LangGraph Agent", "Graph-backed assistant");
 
     const tools = new FakeTools();
-    await adapter.onMessage(
-      makeMessage("first", "room-3"),
-      tools,
-      new HistoryProvider([]),
-      null,
-      null,
-      { isSessionBootstrap: true, roomId: "room-3" },
-    );
-    await adapter.onCleanup("room-3");
-    await adapter.onMessage(
-      makeMessage("second", "room-3"),
-      tools,
-      new HistoryProvider([]),
-      null,
-      null,
-      { isSessionBootstrap: true, roomId: "room-3" },
-    );
+    const send = () =>
+      adapter.onMessage(makeMessage("hi", "room-3"), tools, new HistoryProvider([]), null, null, {
+        isSessionBootstrap: true,
+        roomId: "room-3",
+      });
 
-    expect(invokeCalls).toHaveLength(2);
-    expect(invokeCalls[0]?.messages?.[0]?.[0]).toBe("system");
-    expect(invokeCalls[1]?.messages?.[0]?.[0]).toBe("system");
+    await send(); // first bootstrap → seed system prompt
+    await send(); // re-bootstrap, no cleanup → not re-seeded
+    await adapter.onCleanup("room-3");
+    await send(); // bootstrap after cleanup → re-seeded
+
+    const hasSystem = (i: number) => (invokeCalls[i]?.messages ?? []).some((e) => e[0] === "system");
+    expect(hasSystem(0)).toBe(true);
+    expect(hasSystem(1)).toBe(false);
+    expect(hasSystem(2)).toBe(true);
   });
 
   it("logs stream event serialization fallbacks instead of swallowing them", async () => {
@@ -209,6 +380,7 @@ describe("LangGraphAdapter", () => {
           circularEvent,
           {
             event: "on_chain_end",
+            name: "LangGraph",
             data: { output: { messages: [["assistant", "done"]] } },
           },
         ]);
@@ -251,5 +423,46 @@ describe("LangGraphAdapter", () => {
         eventType: "on_tool_start",
       }),
     );
+  });
+
+  it("ignores LangGraph routing markers and parses LangChain assistant messages", async () => {
+    const aiMessage = {
+      lc: 1,
+      type: "constructor",
+      id: ["langchain_core", "messages", "AIMessage"],
+      kwargs: { content: "Hello there!" },
+    };
+
+    const graph = {
+      streamEvents() {
+        return streamFrom([
+          {
+            event: "on_chain_end",
+            name: "RunnableLambda",
+            data: { output: "__end__" },
+          },
+          {
+            event: "on_chain_end",
+            name: "LangGraph",
+            data: { output: { messages: [aiMessage] } },
+          },
+        ]);
+      },
+    };
+
+    const adapter = new LangGraphAdapter({ graph, emitExecutionEvents: true });
+    await adapter.onStarted("LangGraph Agent", "Graph-backed assistant");
+
+    const tools = new FakeTools();
+    await adapter.onMessage(
+      makeMessage("hello"),
+      tools,
+      new HistoryProvider([]),
+      null,
+      null,
+      { isSessionBootstrap: false, roomId: "room-lc" },
+    );
+
+    expect(tools.messages).toEqual(["Hello there!"]);
   });
 });


### PR DESCRIPTION
* feat(sdk): fix LangGraph streaming adapter event parsing and history replay (INT-853)

Fixes six adapter bugs that left `createReactAgent`-backed agents silent or context-blind at runtime:

- streamEvents: pass `version: "v2"` on the config arg (arg 2), not the unused third arg, so v2 events are actually emitted (previously threw "Only versions v1 and v2 are supported").
- on_chain_end: only accept "LangGraph"/"agent" chains; ignore intermediate routing chains so their markers aren't mistaken for replies.
- message parsing: handle LangChain AIMessage/AIMessageChunk objects in both the serialized (`id: [..., "AIMessage"]`) and in-memory (`getType() === "ai"`) shapes that @langchain/langgraph@1.2.x emits, not just role tuples.
- filter internal `__end__`/`__start__` markers out of extracted assistant text.
- replay room history on every turn (with triggering-message dedup) so follow-ups retain context, instead of only on bootstrap.
- inject the system prompt as a message only for custom graphs; createReactAgent already receives it via `prompt` (avoids a double system prompt).

Tests:
- unit coverage in langgraph-adapter.test.ts for chain filtering, marker/AIMessage parsing, and follow-up history replay.
- gated live e2e (tests/integration/int-853-langgraph-streaming.test.ts, run via `pnpm test:e2e`) that drives a real Claude createReactAgent as a real platform agent; skipped by default. Adds @langchain/anthropic as a dev dependency.



* fix(sdk): address LangGraph adapter review findings (INT-853)

Follow-up to the INT-853 fix, resolving issues from code review:

- Drop bug (P1): the triggering message was skipped in the history replay AND not re-appended, so follow-up turns lost the user's actual request. Now it is skipped during replay and always appended exactly once, as the last message.
- Checkpointer (P1): history is no longer replayed unconditionally. Replay is gated to stateless graphs (or the first bootstrap of a room with a checkpointer), avoiding double-feeding context that the checkpointer persists.
- Custom stateless graphs (P2): the system prompt is now re-sent every turn (createReactAgent still receives it via `prompt`); system-prompt and history seeding use one shared first-bootstrap signal so they stay consistent across reconnects.
- on_chain_end filter (P2): the "LangGraph"/"agent" chain-name restriction now applies only to the built-in createReactAgent path; custom graphs (arbitrary chain names) are no longer silently dropped.
- Disabled checkpointer (P2): use Boolean(this.checkpointer) so `checkpointer: false`/`null` is correctly treated as stateless.
- History limit (P3): drop the triggering message before applying maxHistoryMessages so the limit counts only prior turns.

Refactor: policy (`replayHistory`, `includeSystemPrompt`) is decided in onMessage; buildMessages is now a pure consumer of those flags.

Tests: lean, fix-mapped unit coverage (drop/replay/ordering, checkpointer seed-once + re-bootstrap, disabled-checkpointer stateless, history-limit exclusion, custom-graph chain name); the cleanup test now uses a checkpointer so the bootstrap guard is actually exercised.



* docs(sdk): note LangGraph durable checkpoint caveat

* docs(sdk): document checkpointer-restart limitation; tighten LangGraph adapter comments (INT-853)

- Note that the in-memory bootstrap guard can re-seed once when a durable checkpointer is reused across process restarts.
- Condense the replay/system-prompt policy comments in onMessage.
- Fix a stale unit-test name reference in the e2e header and trim it.



* refactor(sdk): extract usesCustomGraph getter in LangGraph adapter (INT-853)

Replace the duplicated Boolean(this.graph || this.graphFactory) check in onMessage and forwardStreamEvents with a single private getter.



* test(sdk): drop INT-853 live e2e test; rely on deterministic unit coverage

The LangGraph streaming fix is fully covered deterministically in langgraph-adapter.test.ts. The live e2e showcase required .env.test creds, two real platform agents, and an @langchain/anthropic devDependency, and couldn't run in CI — net liability over the unit guards. Remove it along with the test:e2e script, the devDependency, and the README e2e section.



---------