### PR TITLE
fix(release): point package repository URLs at band-ai/band-sdk-typescript

### DIFF
--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/thenvoi/thenvoi-sdk-typescript.git",
+    "url": "git+https://github.com/band-ai/band-sdk-typescript.git",
     "directory": "packages/openclaw"
   },
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/thenvoi/thenvoi-sdk-typescript.git",
+    "url": "git+https://github.com/band-ai/band-sdk-typescript.git",
     "directory": "packages/sdk"
   },
   "type": "module",

--- a/scripts/release-hardening.test.mjs
+++ b/scripts/release-hardening.test.mjs
@@ -724,6 +724,22 @@ test("releases and new dependency updates target main, not the dev compatibility
   assert.doesNotMatch(dependabot, /thenvoi\/integrations-team/);
 });
 
+test("published packages point at the repository that signs their provenance", async () => {
+  // npm validates repository.url against the provenance statement, so a stale
+  // URL (e.g. the pre-rename thenvoi remote) fails publish with a 422.
+  for (const pkg of ["packages/sdk", "packages/openclaw"]) {
+    const manifest = JSON.parse(
+      await readFile(join(root, pkg, "package.json"), "utf8"),
+    );
+    assert.equal(
+      manifest.repository?.url,
+      "git+https://github.com/band-ai/band-sdk-typescript.git",
+      `${pkg} must declare the repository that builds and signs it`,
+    );
+    assert.equal(manifest.repository?.directory, pkg);
+  }
+});
+
 test("CI exposes one always-reporting aggregate status covering every job", async () => {
   const workflow = await readFile(join(root, ".github/workflows/ci.yml"), "utf8");
 


### PR DESCRIPTION
## Problem

With the tarball-path fix from #151 in place, `npm publish` now reaches the registry — and is rejected there ([run 31315763898](https://github.com/band-ai/band-sdk-typescript/actions/runs/31315763898/job/93250769803)):

```
npm error code E422
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@band-ai%2fsdk -
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "git+https://github.com/thenvoi/thenvoi-sdk-typescript.git",
expected to match "https://github.com/band-ai/band-sdk-typescript" from provenance
```

Both `packages/sdk` and `packages/openclaw` still declare the pre-rename remote. npm cross-checks `repository.url` against the provenance statement the workflow signs, and the repo is now `band-ai/band-sdk-typescript`. OpenClaw hasn't tripped over this yet only because its last publish (0.1.10, 2026-07-14) predates the rename — it would fail on its next release.

## Fix

- Point `repository.url` in both manifests at `git+https://github.com/band-ai/band-sdk-typescript.git`.
- Add a guard test asserting both packages declare the repository that builds and signs them (plus the correct `repository.directory`), so this can't silently drift again.

All 46 tests in `scripts/release-hardening.test.mjs` pass.

## State of the release

`@band-ai/sdk` is at 0.1.6 on npm; 0.1.8 and 0.1.9 are tagged but unpublished. After this merges, run **Release → Run workflow** with `recover-package: sdk` and `release-commit` = this PR's merge commit SHA — `packages/sdk/package.json` is at 0.1.9 there, so it repacks and publishes 0.1.9 with a matching provenance statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)