### PR TITLE
feat(openclaw): include handles in participant tool response

### DIFF
--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -149,20 +149,20 @@ after editing.
 
 The plugin registers the following `band_*` management tools:
 
-| Tool                           | Purpose                                                |
-| -------------------------------- | -------------------------------------------------------- |
-| `band_lookup_peers`            | Find reachable peers                                   |
-| `band_create_chatroom`         | Create a Band room                                     |
-| `band_send_event`              | Send a structured event to a room                      |
-| `band_list_chats`              | List chats                                             |
-| `band_get_participants`        | List participants in a room, with handles for @mention |
-| `band_add_participant`         | Add a participant to a room                            |
-| `band_remove_participant`      | Remove a participant from a room                       |
-| `band_list_contacts`           | List contacts                                          |
-| `band_add_contact`             | Add a contact                                          |
-| `band_remove_contact`          | Remove a contact                                       |
-| `band_list_contact_requests`   | List incoming contact requests                         |
-| `band_respond_contact_request` | Accept or decline a contact request                    |
+| Tool                           | Purpose                                                          |
+| -------------------------------- | ------------------------------------------------------------------ |
+| `band_lookup_peers`            | Find reachable peers                                             |
+| `band_create_chatroom`         | Create a Band room                                               |
+| `band_send_event`              | Send a structured event to a room                                |
+| `band_list_chats`              | List chats                                                       |
+| `band_get_participants`        | List participants in a room, with available handles for @mention |
+| `band_add_participant`         | Add a participant to a room                                      |
+| `band_remove_participant`      | Remove a participant from a room                                 |
+| `band_list_contacts`           | List contacts                                                    |
+| `band_add_contact`             | Add a contact                                                    |
+| `band_remove_contact`          | Remove a contact                                                 |
+| `band_list_contact_requests`   | List incoming contact requests                                   |
+| `band_respond_contact_request` | Accept or decline a contact request                              |
 
 ## Local development
 

--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -149,20 +149,20 @@ after editing.
 
 The plugin registers the following `band_*` management tools:
 
-| Tool                            | Purpose                              |
-| ------------------------------- | ------------------------------------ |
-| `band_lookup_peers`             | Find reachable peers                 |
-| `band_create_chatroom`          | Create a Band room                   |
-| `band_send_event`               | Send a structured event to a room    |
-| `band_list_chats`               | List chats                           |
-| `band_get_participants`         | List participants in a room          |
-| `band_add_participant`          | Add a participant to a room          |
-| `band_remove_participant`       | Remove a participant from a room     |
-| `band_list_contacts`            | List contacts                        |
-| `band_add_contact`              | Add a contact                        |
-| `band_remove_contact`           | Remove a contact                     |
-| `band_list_contact_requests`    | List incoming contact requests       |
-| `band_respond_contact_request`  | Accept or decline a contact request  |
+| Tool                           | Purpose                                                |
+| -------------------------------- | -------------------------------------------------------- |
+| `band_lookup_peers`            | Find reachable peers                                   |
+| `band_create_chatroom`         | Create a Band room                                     |
+| `band_send_event`              | Send a structured event to a room                      |
+| `band_list_chats`              | List chats                                             |
+| `band_get_participants`        | List participants in a room, with handles for @mention |
+| `band_add_participant`         | Add a participant to a room                            |
+| `band_remove_participant`      | Remove a participant from a room                       |
+| `band_list_contacts`           | List contacts                                          |
+| `band_add_contact`             | Add a contact                                          |
+| `band_remove_contact`          | Remove a contact                                       |
+| `band_list_contact_requests`   | List incoming contact requests                         |
+| `band_respond_contact_request` | Accept or decline a contact request                    |
 
 ## Local development
 

--- a/packages/openclaw/src/tools.ts
+++ b/packages/openclaw/src/tools.ts
@@ -213,7 +213,7 @@ const removeParticipantTool: BandTool = {
 
 const getParticipantsTool: BandTool = {
   name: "band_get_participants",
-  description: "List all participants in a Band chat room, including each participant's handle for @mention discovery.",
+  description: "List all participants in a Band chat room, including available participant handles for @mention discovery.",
   inputSchema: {
     type: "object",
     properties: {

--- a/packages/openclaw/src/tools.ts
+++ b/packages/openclaw/src/tools.ts
@@ -213,7 +213,7 @@ const removeParticipantTool: BandTool = {
 
 const getParticipantsTool: BandTool = {
   name: "band_get_participants",
-  description: "List all participants in a Band chat room.",
+  description: "List all participants in a Band chat room, including each participant's handle for @mention discovery.",
   inputSchema: {
     type: "object",
     properties: {
@@ -225,7 +225,7 @@ const getParticipantsTool: BandTool = {
     const { room_id } = params as GetParticipantsParams;
     const participants = await ctx.rest.listChatParticipants(room_id);
     return {
-      participants: participants.map((p) => ({ id: p.id, name: p.name, type: p.type })),
+      participants: participants.map((p) => ({ id: p.id, name: p.name, type: p.type, handle: p.handle ?? null })),
       count: participants.length,
     };
   },

--- a/packages/openclaw/tests/unit/channel.test.ts
+++ b/packages/openclaw/tests/unit/channel.test.ts
@@ -7,6 +7,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { ChannelSetupInput } from "openclaw/plugin-sdk/channel-setup";
 import { createBandChannelPlugin, BAND_CHANNEL_ID } from "../../src/channel.js";
 import { setAccount, resetAccounts, trackLastSender } from "../../src/state.js";
 
@@ -20,6 +22,21 @@ const stubGateway = {
 const plugin = createBandChannelPlugin(stubGateway as any);
 
 beforeEach(() => resetAccounts());
+
+function connectAccount(createChatMessage = vi.fn().mockResolvedValue({ id: "msg-7" })) {
+  const rest = {
+    listChatParticipants: vi.fn().mockResolvedValue([
+      { id: "agent-self", name: "AgentBot", type: "agent" },
+      { id: "u-bob", name: "Bob", type: "user" },
+    ]),
+    createChatMessage,
+  };
+  setAccount("default", {
+    link: { rest } as unknown as Parameters<typeof setAccount>[1]["link"],
+    selfAgentId: "agent-self",
+  });
+  return { rest, createChatMessage };
+}
 
 describe("channel factory contract", () => {
   it("has the band id, meta, and chat-type capabilities", () => {
@@ -64,21 +81,6 @@ describe("channel factory contract", () => {
 });
 
 describe("outbound adapter mapping ({ messageId } -> OutboundDeliveryResult)", () => {
-  function connectAccount(createChatMessage = vi.fn().mockResolvedValue({ id: "msg-7" })) {
-    const rest = {
-      listChatParticipants: vi.fn().mockResolvedValue([
-        { id: "agent-self", name: "AgentBot", type: "agent" },
-        { id: "u-bob", name: "Bob", type: "user" },
-      ]),
-      createChatMessage,
-    };
-    setAccount("default", {
-      link: { rest } as unknown as Parameters<typeof setAccount>[1]["link"],
-      selfAgentId: "agent-self",
-    });
-    return { rest, createChatMessage };
-  }
-
   it("maps the messageId and adds the channel field at the adapter boundary", async () => {
     const { createChatMessage } = connectAccount();
     trackLastSender("default", "room-1", { senderId: "u-bob", senderName: "Bob" });
@@ -137,5 +139,110 @@ describe("outbound adapter mapping ({ messageId } -> OutboundDeliveryResult)", (
 
     expect(result).toMatchObject({ channel: BAND_CHANNEL_ID, messageId: "msg-9" });
     expect(rest.createChatMessage).toHaveBeenCalled();
+  });
+
+  it("appends the mediaUrl to the text and maps { messageId } like sendText (sendMedia)", async () => {
+    const { createChatMessage } = connectAccount();
+    trackLastSender("default", "room-1", { senderId: "u-bob", senderName: "Bob" });
+
+    const result = await plugin.outbound!.sendMedia!({
+      cfg: {} as never,
+      to: "room-1",
+      text: "look",
+      mediaUrl: "https://example.com/img.png",
+      accountId: "default",
+    });
+
+    expect(result).toMatchObject({ channel: BAND_CHANNEL_ID, messageId: "msg-7" });
+    expect(createChatMessage).toHaveBeenCalledWith("room-1", {
+      content: "look\n\nhttps://example.com/img.png",
+      mentions: [{ id: "u-bob", name: "Bob" }],
+    });
+  });
+});
+
+describe("config adapter delegates to config.ts helpers (asPluginConfig boundary)", () => {
+  const cfg = {
+    channels: {
+      [BAND_CHANNEL_ID]: {
+        accounts: { default: { apiKey: "k", agentId: "a" }, second: {} },
+      },
+    },
+  } as unknown as OpenClawConfig;
+
+  it("listAccountIds returns every configured account id", () => {
+    expect(plugin.config!.listAccountIds!(cfg)).toEqual(["default", "second"]);
+  });
+
+  it("resolveAccount defaults accountId to the default account", () => {
+    expect(plugin.config!.resolveAccount!(cfg)).toMatchObject({ apiKey: "k", agentId: "a" });
+    expect(plugin.config!.resolveAccount!(cfg, "second")).toMatchObject({});
+  });
+
+  it("inspectAccount reports configured only when apiKey + agentId are both present", () => {
+    expect(plugin.config!.inspectAccount!(cfg, "default")).toMatchObject({ configured: true, agentId: "a" });
+    expect(plugin.config!.inspectAccount!(cfg, "second")).toMatchObject({ configured: false });
+  });
+});
+
+describe("mentions.stripMentions", () => {
+  const cfgWithAgent = {
+    agents: { list: [{ id: "agent1", identity: { name: "AgentBot" } }] },
+  } as unknown as OpenClawConfig;
+
+  it("strips the configured agent's name token and trims the remainder (F2)", () => {
+    const out = plugin.mentions!.stripMentions!({
+      text: "AgentBot   do the thing",
+      cfg: cfgWithAgent,
+      agentId: "agent1",
+    });
+    expect(out).toBe("do the thing");
+  });
+
+  it("leaves text untouched when the agent id has no configured identity", () => {
+    const out = plugin.mentions!.stripMentions!({
+      text: "just a message",
+      cfg: cfgWithAgent,
+      agentId: "unknown-agent",
+    });
+    expect(out).toBe("just a message");
+  });
+});
+
+/** Structural view for reading the account this test writes via applyAccountConfig. */
+type ConfigWithBandAccounts = {
+  channels: Record<string, { accounts: Record<string, Record<string, unknown>> }>;
+};
+
+describe("setup.applyAccountConfig delegates non-interactive channels-add input", () => {
+  it("maps token/userId/httpUrl into the account and enables the channel", () => {
+    const cfg = {} as unknown as OpenClawConfig;
+    const input: ChannelSetupInput = { token: "band_a_x", userId: "agent-1", httpUrl: "wss://custom/socket" };
+    const next = plugin.setup!.applyAccountConfig!({ cfg, accountId: "default", input });
+    const view = next as unknown as ConfigWithBandAccounts;
+    const account = view.channels[BAND_CHANNEL_ID].accounts.default;
+    expect(account).toMatchObject({ apiKey: "band_a_x", agentId: "agent-1", wsUrl: "wss://custom/socket" });
+  });
+});
+
+describe("agentPrompt.messageToolHints", () => {
+  it("returns the static Band instructions", () => {
+    const hints = plugin.agentPrompt!.messageToolHints!();
+    expect(hints).toHaveLength(1);
+    expect(hints[0]).toContain("Band");
+  });
+});
+
+describe("security.dm", () => {
+  it("is always open — Band already gates delivery (L3)", async () => {
+    // resolveDmPolicy is the public surface createChatChannelPlugin exposes;
+    // it closes over our resolvePolicy/resolveAllowFrom callbacks internally.
+    const resolveDmPolicy = plugin.security!.resolveDmPolicy!;
+    const result = await resolveDmPolicy({
+      cfg: {} as never,
+      accountId: "default",
+      account: { accountId: "default" } as never,
+    });
+    expect(result).toMatchObject({ policy: "open", allowFrom: [] });
   });
 });

--- a/packages/openclaw/tests/unit/setup-entry.test.ts
+++ b/packages/openclaw/tests/unit/setup-entry.test.ts
@@ -1,0 +1,18 @@
+/**
+ * Unit test for the setup-only plugin entry (setup-entry.ts).
+ *
+ * The point of this module is to build the channel plugin with NO gateway so
+ * the setup wizard never imports the WS transport or opens a connection.
+ * Importing it here exercises that (transport-free) module-load path.
+ */
+
+import { describe, it, expect } from "vitest";
+import bandSetupEntry from "../../src/setup-entry.js";
+import { BAND_CHANNEL_ID } from "../../src/config.js";
+
+describe("setup-entry default export", () => {
+  it("wraps the Band channel plugin (built with no gateway) via defineSetupPluginEntry", () => {
+    expect(bandSetupEntry.plugin.id).toBe(BAND_CHANNEL_ID);
+    expect(bandSetupEntry.plugin.gateway).toEqual({});
+  });
+});

--- a/packages/openclaw/tests/unit/setup-wizard.test.ts
+++ b/packages/openclaw/tests/unit/setup-wizard.test.ts
@@ -2,8 +2,8 @@
  * Unit tests for the Band setup wizard's config-mutation logic.
  */
 
-import { describe, it, expect } from "vitest";
-import { setBandAccountConfig, ensureBandToolsAllowed, bandSetupWizard } from "../../src/setup-wizard.js";
+import { describe, it, expect, afterEach } from "vitest";
+import { setBandAccountConfig, ensureBandToolsAllowed, bandSetupWizard, applyBandAccountConfig } from "../../src/setup-wizard.js";
 import { BAND_CHANNEL_ID } from "../../src/config.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -104,5 +104,106 @@ describe("bandSetupWizard", () => {
     const enabled = setBandAccountConfig(asCfg({}), "default", { apiKey: "k" });
     const disabled = bandSetupWizard.disable!(enabled);
     expect(band(disabled).enabled).toBe(false);
+  });
+});
+
+describe("applyBandAccountConfig (non-interactive `channels add --flags` mapping)", () => {
+  it("maps token/userId/baseUrl onto apiKey/agentId/restUrl", () => {
+    const cfg = applyBandAccountConfig(asCfg({}), "default", {
+      token: "band_a_x",
+      userId: "agent-1",
+      baseUrl: "https://custom.example",
+    });
+    expect(band(cfg).accounts.default).toMatchObject({
+      apiKey: "band_a_x",
+      agentId: "agent-1",
+      restUrl: "https://custom.example",
+    });
+  });
+
+  it("prefers httpUrl over url for wsUrl when both are given", () => {
+    const cfg = applyBandAccountConfig(asCfg({}), "default", {
+      httpUrl: "wss://from-http-url",
+      url: "wss://from-url",
+    });
+    expect(band(cfg).accounts.default.wsUrl).toBe("wss://from-http-url");
+  });
+
+  it("falls back to url for wsUrl when httpUrl is absent", () => {
+    const cfg = applyBandAccountConfig(asCfg({}), "default", { url: "wss://from-url" });
+    expect(band(cfg).accounts.default.wsUrl).toBe("wss://from-url");
+  });
+
+  it("writes no fields (but still enables the channel) when input is empty", () => {
+    const cfg = applyBandAccountConfig(asCfg({}), "default", {});
+    expect(band(cfg).accounts.default).toEqual({});
+    expect(band(cfg).enabled).toBe(true);
+  });
+});
+
+describe("bandSetupWizard credentials[0] (token) allowEnv + inspect", () => {
+  const originalEnv = process.env.BAND_API_KEY;
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.BAND_API_KEY;
+    else process.env.BAND_API_KEY = originalEnv;
+  });
+
+  it("allows the env fallback only for the default account", () => {
+    const token = bandSetupWizard.credentials[0];
+    expect(token.allowEnv!({ cfg: asCfg({}), accountId: "default" })).toBe(true);
+    expect(token.allowEnv!({ cfg: asCfg({}), accountId: "secondary" })).toBe(false);
+  });
+
+  it("inspect resolves the configured value, falling back to BAND_API_KEY for the default account", () => {
+    process.env.BAND_API_KEY = "env-key";
+    const token = bandSetupWizard.credentials[0];
+
+    const unconfigured = token.inspect!({ cfg: asCfg({}), accountId: "default" });
+    expect(unconfigured).toMatchObject({ hasConfiguredValue: false, resolvedValue: "env-key", envValue: "env-key" });
+
+    const withStoredKey = setBandAccountConfig(asCfg({}), "default", { apiKey: "stored-key" });
+    const configured = token.inspect!({ cfg: withStoredKey, accountId: "default" });
+    expect(configured).toMatchObject({ hasConfiguredValue: true, resolvedValue: "stored-key" });
+
+    const nonDefault = token.inspect!({ cfg: asCfg({}), accountId: "secondary" });
+    expect(nonDefault).toMatchObject({ hasConfiguredValue: false, resolvedValue: undefined, envValue: undefined });
+  });
+});
+
+describe("bandSetupWizard textInputs currentValue + truthy applySet", () => {
+  it("httpUrl/baseUrl currentValue read back the stored wsUrl/restUrl", () => {
+    const httpUrl = (bandSetupWizard.textInputs ?? []).find((t) => t.inputKey === "httpUrl")!;
+    const baseUrl = (bandSetupWizard.textInputs ?? []).find((t) => t.inputKey === "baseUrl")!;
+    const empty = asCfg({});
+    expect(httpUrl.currentValue!({ cfg: empty, accountId: "default" })).toBeUndefined();
+    expect(baseUrl.currentValue!({ cfg: empty, accountId: "default" })).toBeUndefined();
+
+    const cfg = setBandAccountConfig(empty, "default", { wsUrl: "wss://stored", restUrl: "https://stored" });
+    expect(httpUrl.currentValue!({ cfg, accountId: "default" })).toBe("wss://stored");
+    expect(baseUrl.currentValue!({ cfg, accountId: "default" })).toBe("https://stored");
+  });
+
+  it("userId currentValue reads back the stored agentId", () => {
+    const userId = (bandSetupWizard.textInputs ?? []).find((t) => t.inputKey === "userId")!;
+    expect(userId.currentValue!({ cfg: asCfg({}), accountId: "default" })).toBeUndefined();
+    const cfg = setBandAccountConfig(asCfg({}), "default", { agentId: "a-7" });
+    expect(userId.currentValue!({ cfg, accountId: "default" })).toBe("a-7");
+  });
+
+  it("userId validate requires a non-blank value", () => {
+    const userId = (bandSetupWizard.textInputs ?? []).find((t) => t.inputKey === "userId")!;
+    expect(userId.validate!({ value: "  " })).toBe("Agent id is required");
+    expect(userId.validate!({ value: "a-1" })).toBeUndefined();
+  });
+
+  it("httpUrl/baseUrl applySet write the trimmed value when non-blank", () => {
+    const httpUrl = (bandSetupWizard.textInputs ?? []).find((t) => t.inputKey === "httpUrl")!;
+    const baseUrl = (bandSetupWizard.textInputs ?? []).find((t) => t.inputKey === "baseUrl")!;
+
+    const withWs = httpUrl.applySet!({ cfg: asCfg({}), accountId: "default", value: "  wss://new  " });
+    expect(band(withWs).accounts.default.wsUrl).toBe("wss://new");
+
+    const withRest = baseUrl.applySet!({ cfg: asCfg({}), accountId: "default", value: "  https://new  " });
+    expect(band(withRest).accounts.default.restUrl).toBe("https://new");
   });
 });

--- a/packages/openclaw/tests/unit/tools.test.ts
+++ b/packages/openclaw/tests/unit/tools.test.ts
@@ -142,10 +142,20 @@ describe("band_remove_participant", () => {
 });
 
 describe("band_get_participants / band_create_chatroom / band_send_event", () => {
-  it("get_participants maps and counts", async () => {
-    const listChatParticipants = vi.fn().mockResolvedValue([{ id: "a", name: "A", type: "user" }]);
-    const res = (await run("band_get_participants", makeCtx({ listChatParticipants }), { room_id: "r1" })) as { count: number };
-    expect(res.count).toBe(1);
+  it("get_participants maps id/name/type/handle exactly, preserving a present handle and nulling an absent one", async () => {
+    const listChatParticipants = vi.fn().mockResolvedValue([
+      { id: "a", name: "A", type: "user", handle: "a-handle" },
+      { id: "b", name: "B", type: "agent" },
+    ]);
+    const res = (await run("band_get_participants", makeCtx({ listChatParticipants }), { room_id: "r1" })) as {
+      participants: Array<{ id: string; name: string; type: string; handle: string | null }>;
+      count: number;
+    };
+    expect(res.participants).toEqual([
+      { id: "a", name: "A", type: "user", handle: "a-handle" },
+      { id: "b", name: "B", type: "agent", handle: null },
+    ]);
+    expect(res.count).toBe(2);
   });
 
   it("create_chatroom returns the new room id", async () => {

--- a/packages/sdk/tests/contact-tools.test.ts
+++ b/packages/sdk/tests/contact-tools.test.ts
@@ -1,0 +1,541 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ContactCallbackTools } from "../src/runtime/tools/ContactCallbackTools";
+import { ContactToolsImpl } from "../src/runtime/tools/ContactToolsImpl";
+import { UnsupportedFeatureError, ValidationError } from "../src/core/errors";
+
+describe("ContactToolsImpl", () => {
+  describe("listContacts", () => {
+    it("delegates with default pagination", async () => {
+      const listContacts = vi.fn().mockResolvedValue({ items: [], page: 1, pageSize: 50, total: 0 });
+      const impl = new ContactToolsImpl({ listContacts } as never);
+
+      await impl.listContacts();
+
+      expect(listContacts).toHaveBeenCalledWith({ page: 1, pageSize: 50 }, expect.anything());
+    });
+
+    it("passes through an explicit page/pageSize", async () => {
+      const listContacts = vi.fn().mockResolvedValue({ items: [], page: 2, pageSize: 10, total: 0 });
+      const impl = new ContactToolsImpl({ listContacts } as never);
+
+      await impl.listContacts({ page: 2, pageSize: 10 });
+
+      expect(listContacts).toHaveBeenCalledWith({ page: 2, pageSize: 10 }, expect.anything());
+    });
+
+    it("throws UnsupportedFeatureError when the REST adapter has no listContacts", async () => {
+      const impl = new ContactToolsImpl({} as never);
+      await expect(impl.listContacts()).rejects.toThrow(UnsupportedFeatureError);
+    });
+  });
+
+  describe("addContact", () => {
+    it("trims the handle and omits message when absent", async () => {
+      const addContact = vi.fn().mockResolvedValue({ success: true });
+      const impl = new ContactToolsImpl({ addContact } as never);
+
+      await impl.addContact({ handle: "  bob  " });
+
+      expect(addContact).toHaveBeenCalledWith({ handle: "bob" }, expect.anything());
+    });
+
+    it("includes a non-empty message", async () => {
+      const addContact = vi.fn().mockResolvedValue({ success: true });
+      const impl = new ContactToolsImpl({ addContact } as never);
+
+      await impl.addContact({ handle: "bob", message: "hi" });
+
+      expect(addContact).toHaveBeenCalledWith({ handle: "bob", message: "hi" }, expect.anything());
+    });
+
+    it("throws ValidationError for a blank handle", async () => {
+      const impl = new ContactToolsImpl({ addContact: vi.fn() } as never);
+      await expect(impl.addContact({ handle: "   " })).rejects.toThrow(ValidationError);
+    });
+
+    it("throws UnsupportedFeatureError when the REST adapter has no addContact", async () => {
+      const impl = new ContactToolsImpl({} as never);
+      await expect(impl.addContact({ handle: "bob" })).rejects.toThrow(UnsupportedFeatureError);
+    });
+  });
+
+  describe("removeContact", () => {
+    it("removes by trimmed handle", async () => {
+      const removeContact = vi.fn().mockResolvedValue({ success: true });
+      const impl = new ContactToolsImpl({ removeContact } as never);
+
+      await impl.removeContact({ target: "handle", handle: "  bob  " });
+
+      expect(removeContact).toHaveBeenCalledWith({ target: "handle", handle: "bob" }, expect.anything());
+    });
+
+    it("throws ValidationError for a blank handle", async () => {
+      const impl = new ContactToolsImpl({ removeContact: vi.fn() } as never);
+      await expect(impl.removeContact({ target: "handle", handle: "  " })).rejects.toThrow(ValidationError);
+    });
+
+    it("removes by trimmed contactId", async () => {
+      const removeContact = vi.fn().mockResolvedValue({ success: true });
+      const impl = new ContactToolsImpl({ removeContact } as never);
+
+      await impl.removeContact({ target: "contactId", contactId: "  c-1  " });
+
+      expect(removeContact).toHaveBeenCalledWith({ target: "contactId", contactId: "c-1" }, expect.anything());
+    });
+
+    it("throws ValidationError for a blank contactId", async () => {
+      const impl = new ContactToolsImpl({ removeContact: vi.fn() } as never);
+      await expect(impl.removeContact({ target: "contactId", contactId: "  " })).rejects.toThrow(ValidationError);
+    });
+
+    it("throws UnsupportedFeatureError when the REST adapter has no removeContact", async () => {
+      const impl = new ContactToolsImpl({} as never);
+      await expect(impl.removeContact({ target: "handle", handle: "bob" })).rejects.toThrow(UnsupportedFeatureError);
+    });
+  });
+
+  describe("listContactRequests", () => {
+    it("defaults sentStatus to 'pending' and applies default pagination", async () => {
+      const listContactRequests = vi.fn().mockResolvedValue({ items: [], page: 1, pageSize: 50, total: 0 });
+      const impl = new ContactToolsImpl({ listContactRequests } as never);
+
+      await impl.listContactRequests();
+
+      expect(listContactRequests).toHaveBeenCalledWith(
+        { page: 1, pageSize: 50, sentStatus: "pending" },
+        expect.anything(),
+      );
+    });
+
+    it("throws UnsupportedFeatureError when the REST adapter has no listContactRequests", async () => {
+      const impl = new ContactToolsImpl({} as never);
+      await expect(impl.listContactRequests()).rejects.toThrow(UnsupportedFeatureError);
+    });
+  });
+
+  describe("respondContactRequest", () => {
+    it("responds by trimmed handle", async () => {
+      const respondContactRequest = vi.fn().mockResolvedValue({ success: true });
+      const impl = new ContactToolsImpl({ respondContactRequest } as never);
+
+      await impl.respondContactRequest({ action: "approve", target: "handle", handle: "  bob  " });
+
+      expect(respondContactRequest).toHaveBeenCalledWith(
+        { action: "approve", target: "handle", handle: "bob" },
+        expect.anything(),
+      );
+    });
+
+    it("throws ValidationError for a blank handle", async () => {
+      const impl = new ContactToolsImpl({ respondContactRequest: vi.fn() } as never);
+      await expect(
+        impl.respondContactRequest({ action: "approve", target: "handle", handle: "  " }),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it("responds by trimmed requestId", async () => {
+      const respondContactRequest = vi.fn().mockResolvedValue({ success: true });
+      const impl = new ContactToolsImpl({ respondContactRequest } as never);
+
+      await impl.respondContactRequest({ action: "reject", target: "requestId", requestId: "  r-1  " });
+
+      expect(respondContactRequest).toHaveBeenCalledWith(
+        { action: "reject", target: "requestId", requestId: "r-1" },
+        expect.anything(),
+      );
+    });
+
+    it("throws ValidationError for a blank requestId", async () => {
+      const impl = new ContactToolsImpl({ respondContactRequest: vi.fn() } as never);
+      await expect(
+        impl.respondContactRequest({ action: "approve", target: "requestId", requestId: "  " }),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it("throws UnsupportedFeatureError when the REST adapter has no respondContactRequest", async () => {
+      const impl = new ContactToolsImpl({} as never);
+      await expect(
+        impl.respondContactRequest({ action: "approve", target: "handle", handle: "bob" }),
+      ).rejects.toThrow(UnsupportedFeatureError);
+    });
+  });
+});
+
+describe("ContactCallbackTools", () => {
+  describe("capabilities projection", () => {
+    it("is false across the board with a bare rest adapter", () => {
+      const tools = new ContactCallbackTools({ createChat: vi.fn() } as never, "room-1");
+      expect(tools.capabilities).toEqual({ peers: false, contacts: false, memory: false });
+    });
+
+    it("flips on peers/contacts/memory when the underlying methods exist", () => {
+      const tools = new ContactCallbackTools(
+        { createChat: vi.fn(), listPeers: vi.fn(), addContact: vi.fn(), listMemories: vi.fn() } as never,
+        "room-1",
+      );
+      expect(tools.capabilities).toEqual({ peers: true, contacts: true, memory: true });
+    });
+  });
+
+  describe("sendMessage", () => {
+    it("throws when there is no room context", async () => {
+      const tools = new ContactCallbackTools({ createChat: vi.fn(), createChatMessage: vi.fn() } as never, null);
+      await expect(tools.sendMessage("hi")).rejects.toThrow(UnsupportedFeatureError);
+    });
+
+    it("throws when the REST adapter has no createChatMessage", async () => {
+      const tools = new ContactCallbackTools({ createChat: vi.fn() } as never, "room-1");
+      await expect(tools.sendMessage("hi")).rejects.toThrow(UnsupportedFeatureError);
+    });
+
+    it("rejects string mentions (unavailable for contact callbacks)", async () => {
+      const createChatMessage = vi.fn();
+      const tools = new ContactCallbackTools({ createChat: vi.fn(), createChatMessage } as never, "room-1");
+      await expect(tools.sendMessage("hi", ["@bob"])).rejects.toThrow(UnsupportedFeatureError);
+      expect(createChatMessage).not.toHaveBeenCalled();
+    });
+
+    it("sends structured mentions and plain content", async () => {
+      const createChatMessage = vi.fn().mockResolvedValue({ success: true });
+      const tools = new ContactCallbackTools({ createChat: vi.fn(), createChatMessage } as never, "room-1");
+
+      await tools.sendMessage("hi", [{ id: "u-1", name: "Bob" }]);
+
+      expect(createChatMessage).toHaveBeenCalledWith(
+        "room-1",
+        { content: "hi", mentions: [{ id: "u-1", name: "Bob" }] },
+        expect.anything(),
+      );
+    });
+
+    it("omits mentions entirely when none are given", async () => {
+      const createChatMessage = vi.fn().mockResolvedValue({ success: true });
+      const tools = new ContactCallbackTools({ createChat: vi.fn(), createChatMessage } as never, "room-1");
+
+      await tools.sendMessage("hi");
+
+      expect(createChatMessage).toHaveBeenCalledWith("room-1", { content: "hi" }, expect.anything());
+    });
+  });
+
+  describe("sendEvent", () => {
+    it("throws when there is no room context", async () => {
+      const tools = new ContactCallbackTools({ createChat: vi.fn() } as never, null);
+      await expect(tools.sendEvent("hi", "task")).rejects.toThrow(UnsupportedFeatureError);
+    });
+
+    it("throws when the REST adapter has no createChatEvent", async () => {
+      const tools = new ContactCallbackTools({ createChat: vi.fn() } as never, "room-1");
+      await expect(tools.sendEvent("hi", "task")).rejects.toThrow(UnsupportedFeatureError);
+    });
+
+    it("includes metadata when given, omits it otherwise", async () => {
+      const createChatEvent = vi.fn().mockResolvedValue({ success: true });
+      const tools = new ContactCallbackTools({ createChat: vi.fn(), createChatEvent } as never, "room-1");
+
+      await tools.sendEvent("hi", "task", { key: "value" });
+      expect(createChatEvent).toHaveBeenCalledWith(
+        "room-1",
+        { content: "hi", messageType: "task", metadata: { key: "value" } },
+        expect.anything(),
+      );
+
+      await tools.sendEvent("hi", "task");
+      expect(createChatEvent).toHaveBeenLastCalledWith(
+        "room-1",
+        { content: "hi", messageType: "task" },
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("participant management", () => {
+    it("addParticipant and removeParticipant are always unsupported for contact callbacks", async () => {
+      const tools = new ContactCallbackTools({ createChat: vi.fn() } as never, "room-1");
+      await expect(tools.addParticipant()).rejects.toThrow(UnsupportedFeatureError);
+      await expect(tools.removeParticipant()).rejects.toThrow(UnsupportedFeatureError);
+    });
+
+    it("getParticipants throws with no room context", async () => {
+      const tools = new ContactCallbackTools({ createChat: vi.fn() } as never, null);
+      await expect(tools.getParticipants()).rejects.toThrow(UnsupportedFeatureError);
+    });
+
+    it("getParticipants throws when the REST adapter has no listChatParticipants", async () => {
+      const tools = new ContactCallbackTools({ createChat: vi.fn() } as never, "room-1");
+      await expect(tools.getParticipants()).rejects.toThrow(UnsupportedFeatureError);
+    });
+
+    it("getParticipants maps handle present/null (rename regression guard)", async () => {
+      const listChatParticipants = vi.fn().mockResolvedValue([
+        { id: "u-1", name: "Bob", type: "user", handle: "bob.h" },
+        { id: "u-2", name: "Ann", type: "user" },
+      ]);
+      const tools = new ContactCallbackTools({ createChat: vi.fn(), listChatParticipants } as never, "room-1");
+
+      const participants = await tools.getParticipants();
+
+      expect(participants).toEqual([
+        { id: "u-1", name: "Bob", type: "user", handle: "bob.h" },
+        { id: "u-2", name: "Ann", type: "user", handle: null },
+      ]);
+    });
+  });
+
+  describe("createChatroom", () => {
+    it("returns the created chat's id", async () => {
+      const createChat = vi.fn().mockResolvedValue({ id: "room-9" });
+      const tools = new ContactCallbackTools({ createChat } as never, null);
+
+      await expect(tools.createChatroom("task-1")).resolves.toBe("room-9");
+      expect(createChat).toHaveBeenCalledWith("task-1", expect.anything());
+    });
+  });
+
+  describe("lookupPeers", () => {
+    it("throws when the REST adapter has no listPeers", async () => {
+      const tools = new ContactCallbackTools({ createChat: vi.fn() } as never, "room-1");
+      await expect(tools.lookupPeers()).rejects.toThrow(UnsupportedFeatureError);
+    });
+
+    it("normalizes page/pageSize defaults and excludes the current room", async () => {
+      const listPeers = vi.fn().mockResolvedValue({ items: [], page: 1, pageSize: 50, total: 0 });
+      const tools = new ContactCallbackTools({ createChat: vi.fn(), listPeers } as never, "room-1");
+
+      await tools.lookupPeers();
+
+      expect(listPeers).toHaveBeenCalledWith(
+        { page: 1, pageSize: 50, notInChat: "room-1" },
+        expect.anything(),
+      );
+    });
+
+    it("normalizes invalid page/pageSize (zero, negative, non-integer) back to defaults", async () => {
+      const listPeers = vi.fn().mockResolvedValue({ items: [], page: 1, pageSize: 50, total: 0 });
+      const tools = new ContactCallbackTools({ createChat: vi.fn(), listPeers } as never, null);
+
+      await tools.lookupPeers(0, -5);
+
+      expect(listPeers).toHaveBeenCalledWith(
+        { page: 1, pageSize: 50, notInChat: "" },
+        expect.anything(),
+      );
+    });
+
+    it("passes through explicit valid page/pageSize", async () => {
+      const listPeers = vi.fn().mockResolvedValue({ items: [], page: 3, pageSize: 20, total: 0 });
+      const tools = new ContactCallbackTools({ createChat: vi.fn(), listPeers } as never, "room-1");
+
+      await tools.lookupPeers(3, 20);
+
+      expect(listPeers).toHaveBeenCalledWith(
+        { page: 3, pageSize: 20, notInChat: "room-1" },
+        expect.anything(),
+      );
+    });
+  });
+
+  it("exposes empty tool schema arrays", () => {
+    const tools = new ContactCallbackTools({ createChat: vi.fn() } as never, "room-1");
+    expect(tools.getToolSchemas()).toEqual([]);
+    expect(tools.getAnthropicToolSchemas()).toEqual([]);
+    expect(tools.getOpenAIToolSchemas()).toEqual([]);
+  });
+
+  describe("contact target validation/dispatch", () => {
+    it("throws UnsupportedFeatureError for every contact method when no contact REST methods exist", async () => {
+      const tools = new ContactCallbackTools({ createChat: vi.fn() } as never, "room-1");
+      await expect(tools.listContacts()).rejects.toThrow(UnsupportedFeatureError);
+      await expect(tools.addContact({ handle: "bob" })).rejects.toThrow(UnsupportedFeatureError);
+      await expect(tools.removeContact({ target: "handle", handle: "bob" })).rejects.toThrow(UnsupportedFeatureError);
+      await expect(tools.listContactRequests()).rejects.toThrow(UnsupportedFeatureError);
+      await expect(
+        tools.respondContactRequest({ action: "approve", target: "handle", handle: "bob" }),
+      ).rejects.toThrow(UnsupportedFeatureError);
+    });
+
+    it("delegates every contact method to the internal ContactToolsImpl once contact REST methods exist", async () => {
+      const listContacts = vi.fn().mockResolvedValue({ items: [], page: 1, pageSize: 50, total: 0 });
+      const addContact = vi.fn().mockResolvedValue({ success: true });
+      const removeContact = vi.fn().mockResolvedValue({ success: true });
+      const listContactRequests = vi.fn().mockResolvedValue({ items: [], page: 1, pageSize: 50, total: 0 });
+      const respondContactRequest = vi.fn().mockResolvedValue({ success: true });
+      const tools = new ContactCallbackTools(
+        { createChat: vi.fn(), listContacts, addContact, removeContact, listContactRequests, respondContactRequest } as never,
+        "room-1",
+      );
+
+      await tools.listContacts();
+      expect(listContacts).toHaveBeenCalled();
+
+      await tools.addContact({ handle: "bob" });
+      expect(addContact).toHaveBeenCalled();
+
+      await tools.removeContact({ target: "handle", handle: "bob" });
+      expect(removeContact).toHaveBeenCalled();
+
+      await tools.listContactRequests();
+      expect(listContactRequests).toHaveBeenCalled();
+
+      await tools.respondContactRequest({ action: "approve", target: "handle", handle: "bob" });
+      expect(respondContactRequest).toHaveBeenCalled();
+    });
+  });
+
+  describe("memory dispatch", () => {
+    it("throws UnsupportedFeatureError for every memory method when unavailable", async () => {
+      const tools = new ContactCallbackTools({ createChat: vi.fn() } as never, "room-1");
+      await expect(tools.listMemories()).rejects.toThrow(UnsupportedFeatureError);
+      await expect(tools.storeMemory({ content: "x", system: "s", type: "note", segment: "seg" } as never)).rejects.toThrow(
+        UnsupportedFeatureError,
+      );
+      await expect(tools.getMemory("m-1")).rejects.toThrow(UnsupportedFeatureError);
+      await expect(tools.supersedeMemory("m-1")).rejects.toThrow(UnsupportedFeatureError);
+      await expect(tools.archiveMemory("m-1")).rejects.toThrow(UnsupportedFeatureError);
+    });
+
+    it("delegates every memory method to the REST adapter once available", async () => {
+      const listMemories = vi.fn().mockResolvedValue({ items: [], page: 1, pageSize: 50, total: 0 });
+      const storeMemory = vi.fn().mockResolvedValue({ id: "m-1" });
+      const getMemory = vi.fn().mockResolvedValue({ id: "m-1" });
+      const supersedeMemory = vi.fn().mockResolvedValue({ success: true });
+      const archiveMemory = vi.fn().mockResolvedValue({ success: true });
+      const tools = new ContactCallbackTools(
+        { createChat: vi.fn(), listMemories, storeMemory, getMemory, supersedeMemory, archiveMemory } as never,
+        "room-1",
+      );
+
+      await tools.listMemories();
+      expect(listMemories).toHaveBeenCalled();
+
+      await tools.storeMemory({ content: "x", system: "s", type: "note", segment: "seg" } as never);
+      expect(storeMemory).toHaveBeenCalled();
+
+      await tools.getMemory("m-1");
+      expect(getMemory).toHaveBeenCalledWith("m-1", expect.anything());
+
+      await tools.supersedeMemory("m-1");
+      expect(supersedeMemory).toHaveBeenCalledWith("m-1", expect.anything());
+
+      await tools.archiveMemory("m-1");
+      expect(archiveMemory).toHaveBeenCalledWith("m-1", expect.anything());
+    });
+  });
+
+  describe("executeToolCall", () => {
+    function toolsWithFullRest() {
+      const rest = {
+        createChat: vi.fn().mockResolvedValue({ id: "room-1" }),
+        createChatMessage: vi.fn().mockResolvedValue({ success: true }),
+        createChatEvent: vi.fn().mockResolvedValue({ success: true }),
+        listChatParticipants: vi.fn().mockResolvedValue([]),
+        listPeers: vi.fn().mockResolvedValue({ items: [], page: 1, pageSize: 50, total: 0 }),
+        listContacts: vi.fn().mockResolvedValue({ items: [], page: 1, pageSize: 50, total: 0 }),
+        addContact: vi.fn().mockResolvedValue({ success: true }),
+        removeContact: vi.fn().mockResolvedValue({ success: true }),
+        listContactRequests: vi.fn().mockResolvedValue({ items: [], page: 1, pageSize: 50, total: 0 }),
+        respondContactRequest: vi.fn().mockResolvedValue({ success: true }),
+        listMemories: vi.fn().mockResolvedValue({ items: [], page: 1, pageSize: 50, total: 0 }),
+        storeMemory: vi.fn().mockResolvedValue({ id: "m-1" }),
+        getMemory: vi.fn().mockResolvedValue({ id: "m-1" }),
+        supersedeMemory: vi.fn().mockResolvedValue({ success: true }),
+        archiveMemory: vi.fn().mockResolvedValue({ success: true }),
+      };
+      return { rest, tools: new ContactCallbackTools(rest as never, "room-1") };
+    }
+
+    it("dispatches band_send_message", async () => {
+      const { rest, tools } = toolsWithFullRest();
+      await tools.executeToolCall("band_send_message", { content: "hi" });
+      expect(rest.createChatMessage).toHaveBeenCalled();
+    });
+
+    it("dispatches band_send_event with default message_type", async () => {
+      const { rest, tools } = toolsWithFullRest();
+      await tools.executeToolCall("band_send_event", { content: "hi" });
+      expect(rest.createChatEvent).toHaveBeenCalledWith(
+        "room-1",
+        { content: "hi", messageType: "task" },
+        expect.anything(),
+      );
+    });
+
+    it("dispatches band_get_participants, band_create_chatroom, band_lookup_peers", async () => {
+      const { rest, tools } = toolsWithFullRest();
+      await tools.executeToolCall("band_get_participants", {});
+      expect(rest.listChatParticipants).toHaveBeenCalled();
+
+      await tools.executeToolCall("band_create_chatroom", { task_id: "t-1" });
+      expect(rest.createChat).toHaveBeenCalledWith("t-1", expect.anything());
+
+      await tools.executeToolCall("band_lookup_peers", { page: 2, page_size: 5 });
+      expect(rest.listPeers).toHaveBeenCalledWith({ page: 2, pageSize: 5, notInChat: "room-1" }, expect.anything());
+    });
+
+    it("dispatches band_list_contacts and band_add_contact", async () => {
+      const { rest, tools } = toolsWithFullRest();
+      await tools.executeToolCall("band_list_contacts", { page: 1, page_size: 10 });
+      expect(rest.listContacts).toHaveBeenCalledWith({ page: 1, pageSize: 10 }, expect.anything());
+
+      await tools.executeToolCall("band_add_contact", { handle: "bob", message: "hi" });
+      expect(rest.addContact).toHaveBeenCalledWith({ handle: "bob", message: "hi" }, expect.anything());
+    });
+
+    it("dispatches band_remove_contact by contact_id when given, else by handle", async () => {
+      const { rest, tools } = toolsWithFullRest();
+      await tools.executeToolCall("band_remove_contact", { contact_id: "c-1" });
+      expect(rest.removeContact).toHaveBeenCalledWith({ target: "contactId", contactId: "c-1" }, expect.anything());
+
+      await tools.executeToolCall("band_remove_contact", { handle: "bob" });
+      expect(rest.removeContact).toHaveBeenLastCalledWith({ target: "handle", handle: "bob" }, expect.anything());
+    });
+
+    it("dispatches band_list_contact_requests", async () => {
+      const { rest, tools } = toolsWithFullRest();
+      await tools.executeToolCall("band_list_contact_requests", { page: 1, page_size: 10, sent_status: "pending" });
+      expect(rest.listContactRequests).toHaveBeenCalledWith(
+        { page: 1, pageSize: 10, sentStatus: "pending" },
+        expect.anything(),
+      );
+    });
+
+    it("dispatches band_respond_contact_request by request_id when given, else by handle", async () => {
+      const { rest, tools } = toolsWithFullRest();
+      await tools.executeToolCall("band_respond_contact_request", { request_id: "r-1", action: "approve" });
+      expect(rest.respondContactRequest).toHaveBeenCalledWith(
+        { action: "approve", target: "requestId", requestId: "r-1" },
+        expect.anything(),
+      );
+
+      await tools.executeToolCall("band_respond_contact_request", { handle: "bob", action: "reject" });
+      expect(rest.respondContactRequest).toHaveBeenLastCalledWith(
+        { action: "reject", target: "handle", handle: "bob" },
+        expect.anything(),
+      );
+    });
+
+    it("dispatches band_list_memories, band_store_memory, band_get_memory, band_supersede_memory, band_archive_memory", async () => {
+      const { rest, tools } = toolsWithFullRest();
+      await tools.executeToolCall("band_list_memories", {});
+      expect(rest.listMemories).toHaveBeenCalled();
+
+      await tools.executeToolCall("band_store_memory", { content: "x", system: "s", type: "note", segment: "seg" });
+      expect(rest.storeMemory).toHaveBeenCalled();
+
+      await tools.executeToolCall("band_get_memory", { memory_id: "m-1" });
+      expect(rest.getMemory).toHaveBeenCalledWith("m-1", expect.anything());
+
+      await tools.executeToolCall("band_supersede_memory", { memory_id: "m-1" });
+      expect(rest.supersedeMemory).toHaveBeenCalledWith("m-1", expect.anything());
+
+      await tools.executeToolCall("band_archive_memory", { memory_id: "m-1" });
+      expect(rest.archiveMemory).toHaveBeenCalledWith("m-1", expect.anything());
+    });
+
+    it("throws UnsupportedFeatureError for an unrecognized tool name", async () => {
+      const { tools } = toolsWithFullRest();
+      await expect(tools.executeToolCall("band_unknown_tool", {})).rejects.toThrow(UnsupportedFeatureError);
+    });
+  });
+});


### PR DESCRIPTION
**Dependent on #150** (base branch `feature/thenvoi-band-rename-c5-package-symbols`) — merge order: #150 first, then this.

## Why
The REST model already exposes an optional handle on chat participants (`ChatParticipant.handle?: string | null` in `packages/sdk/src/client/rest/types.ts`), but `band_get_participants`'s response mapping dropped it. An agent had no way to discover a participant's `@mention` handle from the tool result alone when one exists.

## What changed
- `packages/openclaw/src/tools.ts`: `getParticipantsTool` now returns `handle: p.handle ?? null` alongside `id`/`name`/`type`; count unchanged.
- Tool description and the `README.md` tools table now say available participant handles are returned for `@mention` discovery (a participant may not have one).
- Strengthened the existing `band_get_participants` unit test (previously asserted only `count`) to assert the exact response shape for a participant with a handle and one without (`null`).

## Testing
- `pnpm build` / `pnpm typecheck` / `pnpm lint`: pass.
- `pnpm test`: 182/182 (OpenClaw).
- `git diff --check`: clean.

## CI
This PR's base is a feature branch, not `main`/`dev`; `.github/workflows/ci.yml` triggers `pull_request` only for `branches: [main, dev]`, so the repository `CI` workflow and CodeQL are not expected to run until this is retargeted (post-#150-merge). Only `Validate PR Title` runs on a feature-branch-based PR, and it passes. The `pnpm` commands above are the current evidence for this change.

## Scope
This is the implementation candidate for the OpenClaw nonbreaking-preflight proof tracked separately (self-contained, not linked here since that tracker is local and untracked). Deliberately excluded from this PR: manual package-version/changelog edits, publish, and the recovery-drill rehearsal. The live nonbreaking-publish/install/provenance proof for `@band-ai/openclaw-channel-band` remains a separate, deferred step — this PR is the implementation only.
