### PR TITLE
chore: remove stale .release-hold from the Thenvoi-to-Band rename

### DIFF
--- a/.release-hold
+++ b/.release-hold
@@ -1,1 +1,0 @@
-thenvoi-to-band rename in progress


### PR DESCRIPTION
## Summary
- \`.release-hold\` was added in #150 during the Thenvoi-to-Band rename and never cleared, silently blocking all releases (\`assert-release-ready.mjs\` / \`release.yml\` both reject any release while it's present).
- Confirmed with Natan it was left over, not an intentional ongoing block.

## Test plan
- [ ] CI passes
- [ ] Next release run is not blocked

Refs INT-1209