### PR TITLE
chore(docs): wire changelog-generator for cloud sessions

### DIFF
--- a/.band/changelog.yml
+++ b/.band/changelog.yml
@@ -1,0 +1,18 @@
+fern_repo: thenvoi/fern
+fern_changelog_path: fern/changelog/sdks
+product:
+  name: Band TypeScript SDK
+  label: TypeScript SDK
+  tag: typescript
+linear:
+  team_key: INT
+announce:
+  slack:
+    enabled: true
+    channel: integrations
+    mode: live
+  discord:
+    # channel is a label only — the webhook fixes the real target, which in
+    # draft mode is the private review channel a human forwards from.
+    enabled: true
+    mode: draft

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "extraKnownMarketplaces": {
+    "private-agent-skills": {
+      "source": { "source": "github", "repo": "band-ai/private-agent-skills" },
+      "autoUpdate": true
+    }
+  },
+  "enabledPlugins": {
+    "changelog-generator@private-agent-skills": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@ coverage
 .tmp-bin
 .tmp-harness-reports
 .desloppify
-.claude
+.claude/*
+!.claude/settings.json
 .agents
 .idea
 scorecard.png


### PR DESCRIPTION
## Summary
Makes `/changelog-generator:generate` runnable in this repo, including from Claude cloud sessions and routines. This repo had no `.claude/` config at all and no `.band/changelog.yml`.

- `.claude/settings.json` registers the private `private-agent-skills` marketplace and enables the plugin. Cloud sessions install plugins from the repo's committed settings — this file is the only auto-install hook.
- `.gitignore` ignored `.claude` wholesale, which would have kept that file untracked. Narrowed to `.claude/*` + `!.claude/settings.json`, so personal scratch and worktrees stay ignored.
- `.band/changelog.yml` supplies `generate`'s required config.

## Config values, and where they come from
| Key | Value | Source |
| --- | --- | --- |
| `fern_repo` | `thenvoi/fern` | `band-ai/fern` no longer resolves; `thenvoi/fern` is the live docs source |
| `fern_changelog_path` | `fern/changelog/sdks` | surface dir holding SDK entries |
| `product.label` / `product.tag` | `TypeScript SDK` / `typescript` | label matches the existing TypeScript entries in that surface |
| `linear.team_key` | `INT` | INT-#### identifiers in this repo's history |
| Slack | live → `integrations` | confirmed target channel |
| Discord | draft | webhook points at the private review channel; the config `channel` is a label only, so it is omitted |

## Still needed outside this PR
The cloud environment itself (network allowlist for `api.linear.app`, `LINEAR_API_KEY` and webhook vars, and a setup script installing `gh` + `fern-api`) is configured at claude.ai/code, not in the repo.